### PR TITLE
Updating readme after some changes in Roadmap and add some missing configuration attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ SolidObserver is a production-grade observability solution for Rails 8's Solid S
 
 --- coming soon ---
 
+## Roadmap
+
+If you're interested what features are comming next, please visit: [GitHub Milestones](https://github.com/bart-oz/solid_observer/milestones) - note that as it's my side project the release plan is more or less indicative.
+
+If you're interesting in contribution, please check out issues labeled
+[good first issue](https://github.com/bart-oz/solid_observer/labels/good%20first%20issue) or [help wanted](https://github.com/bart-oz/solid_observer/labels/help%20wanted).
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
@@ -26,3 +33,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the SolidObserver project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/solid_observer/blob/main/CODE_OF_CONDUCT.md).
+

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/numeric/bytes"
 
 module SolidObserver
   class Configuration
@@ -14,6 +15,8 @@ module SolidObserver
       :observe_cable,
       :event_retention,
       :metrics_retention,
+      :max_db_size,
+      :warning_threshold,
       :sampling_rate,
       :cache_sampling_rate,
       :buffer_size,
@@ -30,6 +33,8 @@ module SolidObserver
       @observe_cable = true
       @event_retention = 30.days
       @metrics_retention = 90.days
+      @max_db_size = 1.gigabyte
+      @warning_threshold = 0.8
       @sampling_rate = 1.0
       @cache_sampling_rate = 0.1
       @buffer_size = 1000

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe SolidObserver::Configuration do
     expect(config.sampling_rate).to eq(1.0)
     expect(config.buffer_size).to eq(1000)
     expect(config.observe_queue).to be true
+    expect(config.max_db_size).to eq(1.gigabyte)
+    expect(config.warning_threshold).to eq(0.8)
   end
 
   it "disables UI in production" do


### PR DESCRIPTION
What needed to be updated:
* README.md since I prepared updates on the gem Roadmap and it needed to align with what I had in Github Issues / Milestones
*  Extend configuration for: 
```ruby
:max_db_size, # Limit the database size, default: 1GB
:warning_threshold, # Alerting when database size will reach 80% of the limit, default threshold: 0.8
```