### PR TITLE
[SO-003][FEAT] Set up Rails Engine with initialization hooks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+SolidObserver::Engine.routes.draw do
+  # Only mount UI routes if enabled in configuration
+  if SolidObserver.config.ui_enabled
+    # TODO: Add UI routes in SO-013
+    # root "dashboard#index"
+    # resources :queue_events, only: [:index, :show]
+    # resources :metrics, only: [:index]
+  end
+end

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -2,6 +2,7 @@
 
 require_relative "solid_observer/version"
 require_relative "solid_observer/configuration"
+require_relative "solid_observer/engine" if defined?(Rails::Engine)
 
 module SolidObserver
   class Error < StandardError; end

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class Engine < ::Rails::Engine
+    isolate_namespace SolidObserver
+
+    class << self
+      def check_solid_queue_availability
+        return if defined?(SolidQueue)
+
+        Rails.logger.warn "[SolidObserver] SolidQueue not detected. Queue observability features will be limited."
+      end
+
+      def check_and_activate_subscribers
+        logger = Rails.logger
+
+        if ActiveRecord::Base.connection.table_exists?("solid_observer_queue_events")
+          logger.info "[SolidObserver] Tables detected, activating event subscribers"
+          # TODO: Activate event subscribers in SO-010
+        else
+          logger.info "[SolidObserver] Tables not found. Run migrations: rails solid_observer:install:migrations && rails db:migrate"
+        end
+      rescue ActiveRecord::NoDatabaseError
+        logger.info "[SolidObserver] Database not ready yet. Skipping subscriber activation."
+      end
+    end
+
+    config.before_initialize do
+      Engine.check_solid_queue_availability
+    end
+
+    initializer "solid_observer.check_tables" do
+      ActiveSupport.on_load(:active_record) do
+        config.after_initialize do
+          Engine.check_and_activate_subscribers
+        end
+      end
+    end
+  end
+end

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Engine do
+  let(:logger) { instance_double(Logger, warn: nil, info: nil) }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(logger)
+  end
+
+  it "is a Rails::Engine" do
+    expect(described_class.ancestors).to include(Rails::Engine)
+  end
+
+  it "isolates namespace to SolidObserver" do
+    expect(described_class.isolated?).to be true
+  end
+
+  describe ".check_solid_queue_availability" do
+    it "warns when SolidQueue is not defined" do
+      hide_const("SolidQueue")
+
+      expect(logger).to receive(:warn).with(/SolidQueue not detected/)
+
+      described_class.check_solid_queue_availability
+    end
+
+    it "does not warn when SolidQueue is defined" do
+      stub_const("SolidQueue", Class.new)
+
+      expect(logger).not_to receive(:warn)
+
+      described_class.check_solid_queue_availability
+    end
+  end
+
+  describe ".check_and_activate_subscribers" do
+    let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+
+    before do
+      allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+    end
+
+    it "logs activation message when tables exist" do
+      allow(connection).to receive(:table_exists?).with("solid_observer_queue_events").and_return(true)
+
+      expect(logger).to receive(:info).with(/Tables detected/)
+
+      described_class.check_and_activate_subscribers
+    end
+
+    it "logs migration instruction when tables do not exist" do
+      allow(connection).to receive(:table_exists?).with("solid_observer_queue_events").and_return(false)
+
+      expect(logger).to receive(:info).with(/Tables not found/)
+
+      described_class.check_and_activate_subscribers
+    end
+
+    it "rescues gracefully when database is not ready" do
+      allow(connection).to receive(:table_exists?).and_raise(ActiveRecord::NoDatabaseError)
+
+      expect(logger).to receive(:info).with(/Database not ready/)
+
+      described_class.check_and_activate_subscribers
+    end
+  end
+
+  describe "routes" do
+    it "has a route set" do
+      expect(described_class.routes).to be_a(ActionDispatch::Routing::RouteSet)
+    end
+  end
+
+  describe "initializers" do
+    it "defines solid_observer.check_tables initializer" do
+      initializer_names = described_class.initializers.map(&:name)
+      expect(initializer_names).to include("solid_observer.check_tables")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,9 @@ end
 
 require "bundler/setup"
 require "rspec"
-
-# Load solid_observer
+require "rails"
+require "action_controller/railtie"
+require "active_record/railtie"
 require_relative "../lib/solid_observer"
 
 RSpec.configure do |config|


### PR DESCRIPTION
SolidObserver into Rails applications with safety checks and route mounting.

Key changes:
- Created Engine class with isolated namespace
- Added check_solid_queue_availability class method to warn if SolidQueue missing
- Added check_and_activate_subscribers method with table existence checks
- Implemented conditional route mounting based on ui_enabled config
- Added Rails initializers with deferred activation until after initialization
- Graceful error handling for ActiveRecord::NoDatabaseError