### PR TITLE
[SO-006][FEAT] Create events migration for Queue database

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -15,12 +15,17 @@ detectors:
       - SolidObserver::Generators::InstallGenerator#show_instructions
       - SolidObserver::CorrelationIdResolver#resolve
       - SolidObserver::CorrelationIdResolver#call_custom_generator
+      - CreateSolidObserverQueueEvents#change
 
   UtilityFunction:
     enabled: false
 
   IrresponsibleModule:
     enabled: false
+
+  FeatureEnvy:
+    exclude:
+      - CreateSolidObserverQueueEvents#change
 
   DuplicateMethodCall:
     exclude:
@@ -34,4 +39,5 @@ detectors:
 
   UncommunicativeVariableName:
     accept:
-      - e # Standard exception variable in rescue blocks
+      - e # Commonly used for exceptions
+      - t # Commonly used for time variables

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ group :test do
   gem "selenium-webdriver", "~> 4.39.0"
   gem "rspec", "~> 3.13.2"
   gem "simplecov", "~> 0.22.0", require: false
+  gem "sqlite3", "~> 2.5"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    sqlite3 (2.9.0-x86_64-darwin)
+    sqlite3 (2.9.0-x86_64-linux-gnu)
     standard (1.52.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -393,6 +395,7 @@ DEPENDENCIES
   selenium-webdriver (~> 4.39.0)
   simplecov (~> 0.22.0)
   solid_observer!
+  sqlite3 (~> 2.5)
   standard (~> 1.52.0)
   standard-performance (~> 1.9.0)
 

--- a/db/solid_observer_migrate/20260115000001_create_solid_observer_queue_events.rb
+++ b/db/solid_observer_migrate/20260115000001_create_solid_observer_queue_events.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateSolidObserverQueueEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_observer_queue_events do |t|
+      t.string :event_type, null: false, limit: 50
+      t.string :correlation_id, limit: 64
+      t.text :metadata
+      t.float :duration
+      t.datetime :recorded_at, null: false
+
+      t.index :recorded_at
+      t.index :correlation_id, where: "correlation_id IS NOT NULL"
+      t.index :event_type
+    end
+  end
+end

--- a/solid_observer.gemspec
+++ b/solid_observer.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description = "SolidObserver is a production-grade observability solution for Rails 8's Solid Stack (Solid Queue, Solid Cache, Solid Cable). It provides unified monitoring, health metrics, and debugging tools across all three Solid technologies."
   spec.homepage = "https://solid.observer"
   spec.license = "MIT"
-  spec.files = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", "bin/*"]
+  spec.files = Dir["lib/**/*", "app/**/*", "db/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", "bin/*"]
   spec.require_paths = ["lib"]
   spec.bindir = "bin"
 

--- a/spec/db/migrate/create_solid_observer_queue_events_spec.rb
+++ b/spec/db/migrate/create_solid_observer_queue_events_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_record"
+
+RSpec.describe "CreateSolidObserverQueueEvents migration" do
+  let(:migration_file) do
+    File.join(__dir__, "../../../db/solid_observer_migrate/20260115000001_create_solid_observer_queue_events.rb")
+  end
+
+  let(:migration_class) { CreateSolidObserverQueueEvents }
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(
+      adapter: "sqlite3",
+      database: ":memory:"
+    )
+  end
+
+  before do
+    load migration_file
+  end
+
+  after do
+    migration_class.migrate(:down) if ActiveRecord::Base.connection.table_exists?(:solid_observer_queue_events)
+  end
+
+  describe "up migration" do
+    it "creates solid_observer_queue_events table" do
+      migration_class.migrate(:up)
+
+      expect(ActiveRecord::Base.connection.table_exists?(:solid_observer_queue_events)).to be true
+    end
+
+    it "creates required columns with correct types" do
+      migration_class.migrate(:up)
+
+      columns = ActiveRecord::Base.connection.columns(:solid_observer_queue_events)
+      column_info = columns.each_with_object({}) do |col, hash|
+        hash[col.name] = {type: col.type, null: col.null, limit: col.limit}
+      end
+
+      expect(column_info["event_type"]).to include(type: :string, null: false, limit: 50)
+      expect(column_info["correlation_id"]).to include(type: :string, limit: 64)
+      expect(column_info["metadata"]).to include(type: :text)
+      expect(column_info["duration"]).to include(type: :float)
+      expect(column_info["recorded_at"]).to include(type: :datetime, null: false)
+    end
+
+    it "creates indexes on recorded_at, correlation_id, and event_type" do
+      migration_class.migrate(:up)
+
+      indexes = ActiveRecord::Base.connection.indexes(:solid_observer_queue_events)
+      index_columns = indexes.map(&:columns).flatten
+
+      expect(index_columns).to include("recorded_at")
+      expect(index_columns).to include("correlation_id")
+      expect(index_columns).to include("event_type")
+    end
+
+    it "creates partial index on correlation_id" do
+      migration_class.migrate(:up)
+
+      indexes = ActiveRecord::Base.connection.indexes(:solid_observer_queue_events)
+      correlation_id_index = indexes.find { |idx| idx.columns == ["correlation_id"] }
+
+      expect(correlation_id_index).not_to be_nil
+      expect(correlation_id_index.where).to eq("correlation_id IS NOT NULL")
+    end
+  end
+
+  describe "down migration" do
+    it "removes solid_observer_queue_events table" do
+      migration_class.migrate(:up)
+      expect(ActiveRecord::Base.connection.table_exists?(:solid_observer_queue_events)).to be true
+
+      migration_class.migrate(:down)
+      expect(ActiveRecord::Base.connection.table_exists?(:solid_observer_queue_events)).to be false
+    end
+  end
+end


### PR DESCRIPTION
Implements the `solid_observer_queue_events` table to store Queue observability events. Migration follows Rails 8 conventions with efficient indexing for query performance.

Schema:
- `event_type` (string, 50 chars, NOT NULL) - `job_enqueued`, `job_completed`, etc.
- `correlation_id` (string, 64 chars, nullable) - for distributed tracing
- `metadata` (text) - JSON serialized event details
- `duration` (float) - milliseconds from `ActiveSupport::Notifications`
- `recorded_at` (datetime, NOT NULL) - event timestamp