### PR TITLE
[SO-008][FEAT] Add storage info migration

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -17,6 +17,7 @@ detectors:
       - SolidObserver::CorrelationIdResolver#call_custom_generator
       - CreateSolidObserverQueueEvents#change
       - CreateSolidObserverMetrics#change
+      - CreateSolidObserverStorageInfo#change
 
   UtilityFunction:
     enabled: false
@@ -28,6 +29,7 @@ detectors:
     exclude:
       - CreateSolidObserverQueueEvents#change
       - CreateSolidObserverMetrics#change
+      - CreateSolidObserverStorageInfo#change
 
   DuplicateMethodCall:
     exclude:

--- a/db/solid_observer_migrate/20260115000003_create_solid_observer_storage_info.rb
+++ b/db/solid_observer_migrate/20260115000003_create_solid_observer_storage_info.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateSolidObserverStorageInfo < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_observer_storage_info do |t|
+      t.bigint :db_size_bytes, null: false
+      t.bigint :event_count, null: false
+      t.datetime :recorded_at, null: false
+
+      t.index :recorded_at
+    end
+  end
+end

--- a/spec/db/migrate/create_solid_observer_storage_info_spec.rb
+++ b/spec/db/migrate/create_solid_observer_storage_info_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_record"
+
+RSpec.describe "CreateSolidObserverStorageInfo migration" do
+  let(:migration_file) do
+    File.join(__dir__, "../../../db/solid_observer_migrate/20260115000003_create_solid_observer_storage_info.rb")
+  end
+
+  let(:migration_class) { CreateSolidObserverStorageInfo }
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(
+      adapter: "sqlite3",
+      database: ":memory:"
+    )
+  end
+
+  before do
+    load migration_file
+  end
+
+  after do
+    migration_class.migrate(:down) if ActiveRecord::Base.connection.table_exists?(:solid_observer_storage_info)
+  end
+
+  describe "up migration" do
+    it "creates solid_observer_storage_info table" do
+      migration_class.migrate(:up)
+
+      expect(ActiveRecord::Base.connection.table_exists?(:solid_observer_storage_info)).to be true
+    end
+
+    it "creates required columns with correct types" do
+      migration_class.migrate(:up)
+
+      columns = ActiveRecord::Base.connection.columns(:solid_observer_storage_info)
+      column_info = columns.each_with_object({}) do |col, hash|
+        hash[col.name] = {type: col.type, null: col.null}
+      end
+
+      expect(column_info["db_size_bytes"]).to include(type: :integer, null: false)
+      expect(column_info["event_count"]).to include(type: :integer, null: false)
+      expect(column_info["recorded_at"]).to include(type: :datetime, null: false)
+    end
+
+    it "creates index on recorded_at" do
+      migration_class.migrate(:up)
+
+      indexes = ActiveRecord::Base.connection.indexes(:solid_observer_storage_info)
+      index_columns = indexes.map(&:columns).flatten
+
+      expect(index_columns).to include("recorded_at")
+    end
+
+    it "allows inserting storage snapshots" do
+      migration_class.migrate(:up)
+
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO solid_observer_storage_info (db_size_bytes, event_count, recorded_at) " \
+        "VALUES (1048576, 1000, '2026-01-16 10:00:00')"
+      )
+
+      result = ActiveRecord::Base.connection.execute(
+        "SELECT * FROM solid_observer_storage_info"
+      ).first
+
+      expect(result["db_size_bytes"]).to eq(1048576)
+      expect(result["event_count"]).to eq(1000)
+    end
+  end
+
+  describe "down migration" do
+    it "removes solid_observer_storage_info table" do
+      migration_class.migrate(:up)
+      expect(ActiveRecord::Base.connection.table_exists?(:solid_observer_storage_info)).to be true
+
+      migration_class.migrate(:down)
+      expect(ActiveRecord::Base.connection.table_exists?(:solid_observer_storage_info)).to be false
+    end
+  end
+end


### PR DESCRIPTION
Changes:
- Create `solid_observer_storage_info` table
- Tracks `db_size_bytes`, `event_count`, and `recorded_at`
- Index on `recorded_at` for time-series queries
- Used by `CleanupJob` to monitor storage growth