### PR TITLE
[SO-009][FEAT] Implement metric models with race-condition-safe atomic operations

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -19,6 +19,11 @@ detectors:
       - CreateSolidObserverMetrics#change
       - CreateSolidObserverStorageInfo#change
 
+  LongParameterList:
+    exclude:
+      - SolidObserver::BaseMetric#self.increment
+      - SolidObserver::BaseMetric#self.record
+
   UtilityFunction:
     enabled: false
 

--- a/app/models/solid_observer/queue_metric.rb
+++ b/app/models/solid_observer/queue_metric.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class QueueMetric < BaseMetric
+    self.abstract_class = true
+    connects_to database: {writing: :solid_observer_queue, reading: :solid_observer_queue}
+  end
+end

--- a/app/models/solid_observer/storage_info.rb
+++ b/app/models/solid_observer/storage_info.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class StorageInfo < ActiveRecord::Base
+    self.abstract_class = true
+    self.table_name = "solid_observer_storage_info"
+
+    MB_TO_BYTES = 1_048_576
+    GB_TO_BYTES = 1_073_741_824
+
+    connects_to database: {writing: :solid_observer_queue, reading: :solid_observer_queue}
+
+    validates :db_size_bytes, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+    validates :event_count, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+    validates :recorded_at, presence: true
+
+    scope :recent, ->(limit = 10) { order(recorded_at: :desc).limit(limit) }
+    scope :since, ->(time) { where("recorded_at >= ?", time) }
+
+    def self.record_snapshot(db_size:, event_count:)
+      create!(
+        db_size_bytes: db_size,
+        event_count: event_count,
+        recorded_at: Time.current
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error "[SolidObserver] Failed to record storage snapshot: #{e.message}"
+      raise
+    end
+
+    def db_size_mb
+      (db_size_bytes / MB_TO_BYTES.to_f).round(2)
+    end
+
+    def db_size_gb
+      (db_size_bytes / GB_TO_BYTES.to_f).round(2)
+    end
+  end
+end

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -4,6 +4,7 @@ require_relative "solid_observer/version"
 require_relative "solid_observer/configuration"
 require_relative "solid_observer/correlation_id_resolver"
 require_relative "solid_observer/base_event" if defined?(ActiveRecord)
+require_relative "solid_observer/base_metric" if defined?(ActiveRecord)
 require_relative "solid_observer/engine" if defined?(Rails::Engine)
 
 module SolidObserver

--- a/lib/solid_observer/base_metric.rb
+++ b/lib/solid_observer/base_metric.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class BaseMetric < ActiveRecord::Base
+    self.abstract_class = true
+    self.table_name = "solid_observer_metrics"
+
+    PERIOD_TYPES = %w[minute hour day].freeze
+
+    validates :metric_name, presence: true
+    validates :value, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+    validates :period_start, presence: true
+    validates :period_type, presence: true, inclusion: {in: PERIOD_TYPES}
+
+    scope :for_metric, ->(name) { where(metric_name: name) }
+    scope :hourly, -> { where(period_type: "hour") }
+    scope :daily, -> { where(period_type: "day") }
+    scope :minutely, -> { where(period_type: "minute") }
+    scope :since, ->(time) { where("period_start >= ?", time) }
+    scope :between, ->(start_time, end_time) { where(period_start: start_time..end_time) }
+
+    def self.increment(metric:, period: Time.current.beginning_of_hour, period_type: "hour", by: 1)
+      record = find_or_create_by!(
+        metric_name: metric,
+        period_start: period,
+        period_type: period_type
+      )
+      record.increment!(:value, by)
+      record
+    rescue ActiveRecord::RecordNotUnique
+      retry
+    end
+
+    def self.record(metric:, value:, period: Time.current.beginning_of_hour, period_type: "hour")
+      upsert(
+        {
+          metric_name: metric,
+          value: value,
+          period_start: period,
+          period_type: period_type
+        },
+        unique_by: [:metric_name, :period_start, :period_type]
+      )
+      find_by!(
+        metric_name: metric,
+        period_start: period,
+        period_type: period_type
+      )
+    end
+  end
+end

--- a/spec/models/solid_observer/base_metric_spec.rb
+++ b/spec/models/solid_observer/base_metric_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::BaseMetric do
+  it "is an abstract class" do
+    expect(described_class.abstract_class?).to be true
+  end
+
+  it "cannot be instantiated directly" do
+    expect { described_class.new }.to raise_error(NotImplementedError)
+  end
+
+  it "defines PERIOD_TYPES constant" do
+    expect(described_class::PERIOD_TYPES).to eq(%w[minute hour day])
+  end
+
+  it "has validations defined" do
+    expect(described_class.validators.map(&:class)).to include(ActiveRecord::Validations::PresenceValidator)
+  end
+
+  it "defines for_metric scope" do
+    expect(described_class).to respond_to(:for_metric)
+  end
+
+  it "defines hourly scope" do
+    expect(described_class).to respond_to(:hourly)
+  end
+
+  it "defines daily scope" do
+    expect(described_class).to respond_to(:daily)
+  end
+
+  it "defines minutely scope" do
+    expect(described_class).to respond_to(:minutely)
+  end
+
+  it "defines since scope" do
+    expect(described_class).to respond_to(:since)
+  end
+
+  it "defines between scope" do
+    expect(described_class).to respond_to(:between)
+  end
+
+  it "defines increment class method" do
+    expect(described_class).to respond_to(:increment)
+  end
+
+  it "defines record class method" do
+    expect(described_class).to respond_to(:record)
+  end
+end

--- a/spec/models/solid_observer/queue_metric_spec.rb
+++ b/spec/models/solid_observer/queue_metric_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::QueueMetric do
+  it "inherits from BaseMetric" do
+    expect(described_class.ancestors).to include(SolidObserver::BaseMetric)
+  end
+
+  it "uses connects_to for database configuration" do
+    model_content = File.read(File.join(__dir__, "../../../app/models/solid_observer/queue_metric.rb"))
+    expect(model_content).to include("connects_to")
+    expect(model_content).to include("solid_observer_queue")
+  end
+
+  it "is an abstract class" do
+    expect(described_class.abstract_class?).to be true
+  end
+
+  it "uses solid_observer_metrics table" do
+    expect(described_class.table_name).to eq("solid_observer_metrics")
+  end
+end

--- a/spec/models/solid_observer/storage_info_spec.rb
+++ b/spec/models/solid_observer/storage_info_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::StorageInfo do
+  it "is an abstract class" do
+    expect(described_class.abstract_class?).to be true
+  end
+
+  it "cannot be instantiated directly" do
+    expect { described_class.new }.to raise_error(NotImplementedError)
+  end
+
+  it "uses solid_observer_storage_info table" do
+    expect(described_class.table_name).to eq("solid_observer_storage_info")
+  end
+
+  it "uses connects_to for database configuration" do
+    model_content = File.read(File.join(__dir__, "../../../app/models/solid_observer/storage_info.rb"))
+    expect(model_content).to include("connects_to")
+    expect(model_content).to include("solid_observer_queue")
+  end
+
+  it "has validations defined" do
+    expect(described_class.validators.map(&:class)).to include(ActiveRecord::Validations::PresenceValidator)
+  end
+
+  it "defines recent scope" do
+    expect(described_class).to respond_to(:recent)
+  end
+
+  it "defines since scope" do
+    expect(described_class).to respond_to(:since)
+  end
+
+  it "defines record_snapshot class method" do
+    expect(described_class).to respond_to(:record_snapshot)
+  end
+
+  it "defines db_size_mb instance method" do
+    expect(described_class.instance_methods).to include(:db_size_mb)
+  end
+
+  it "defines db_size_gb instance method" do
+    expect(described_class.instance_methods).to include(:db_size_gb)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,23 @@ require "rspec"
 require "rails"
 require "action_controller/railtie"
 require "active_record/railtie"
+
+ENV["RAILS_ENV"] = "test"
+Rails.env = ActiveSupport::StringInquirer.new("test")
+
 require_relative "../lib/solid_observer"
+
+ActiveRecord::Base.configurations = {
+  "test" => {
+    "solid_observer_queue" => {
+      "adapter" => "sqlite3",
+      "database" => ":memory:"
+    }
+  }
+}
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+
+Dir[File.join(__dir__, "../app/models/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Changes:
- Add BaseMetric abstract class with atomic incrementmethods
  * Fix race condition: find_or_create_by! + increment! upsert (atomic UPDATE)
  * Add RecordNotUnique retry logic for concurrent creation
  * Use upsert with unique_by constraint for idempotent inserts
- Add QueueMetric model connecting to solid_observer_queue database
- Add StorageInfo model for database size tracking
  * Add MB_TO_BYTES and GB_TO_BYTES constants
  * Add error logging in record_snapshot

Implements atomic SQL operations (UPDATE SET value = value + 1) to prevent lost updates under concurrent access. No explicit transactions needed as single operations are already atomic at database level.