### PR TITLE
[SO-013][FEAT] add CLI base infrastructure with output helpers

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -25,6 +25,8 @@ detectors:
       - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::CleanupStorage#call
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
+      - SolidObserver::CLI::Base#table
+      - SolidObserver::CLI::Base#confirm
 
   LongParameterList:
     exclude:
@@ -44,6 +46,7 @@ detectors:
       - CreateSolidObserverMetrics#change
       - CreateSolidObserverStorageInfo#change
       - SolidObserver::Services::RecordEvent#extract_metadata
+      - SolidObserver::CLI::Base#confirm
 
   DuplicateMethodCall:
     exclude:
@@ -67,4 +70,13 @@ detectors:
   UncommunicativeVariableName:
     accept:
       - e # Commonly used for exceptions
+      - i # Standard index variable
+
+  BooleanParameter:
+    exclude:
+      - SolidObserver::CLI::Base#confirm # Natural for default parameter
+
+  NilCheck:
+    exclude:
+      - SolidObserver::CLI::Base#confirm # Necessary for stdin handling
       - t # Commonly used for time variables

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -10,6 +10,7 @@ require_relative "solid_observer/services/flush_event_buffer" if defined?(Active
 require_relative "solid_observer/services/cleanup_storage" if defined?(ActiveRecord)
 require_relative "solid_observer/queue_event_buffer" if defined?(ActiveRecord)
 require_relative "solid_observer/subscriber" if defined?(ActiveSupport)
+require_relative "solid_observer/cli/base"
 require_relative "solid_observer/engine" if defined?(Rails::Engine)
 
 module SolidObserver

--- a/lib/solid_observer/cli/base.rb
+++ b/lib/solid_observer/cli/base.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module CLI
+    class Base
+      class << self
+        def call(*args, **kwargs)
+          new.call(*args, **kwargs)
+        end
+      end
+
+      def call
+        raise NotImplementedError, "#{self.class} must implement #call"
+      end
+
+      private
+
+      def output(text, color: nil)
+        text = colorize(text, color) if color && color_enabled?
+        puts text
+      end
+
+      def error(text)
+        output(text, color: :red)
+      end
+
+      def success(text)
+        output(text, color: :green)
+      end
+
+      def warning(text)
+        output(text, color: :yellow)
+      end
+
+      def info(text)
+        output(text, color: :blue)
+      end
+
+      def table(headers:, rows:)
+        return if rows.empty?
+
+        widths = calculate_column_widths(headers, rows)
+
+        output(format_table_row(headers, widths), color: :cyan)
+        output(separator_line(widths), color: :cyan)
+
+        rows.each do |row|
+          output(format_table_row(row, widths))
+        end
+      end
+
+      def confirm(question, default: true)
+        prompt = default ? "(Y/n)" : "(y/N)"
+        output("#{question} #{prompt} ", color: :yellow)
+        print "> "
+
+        response = $stdin.gets&.strip&.downcase
+
+        return default if response.nil? || response.empty?
+
+        response.start_with?("y")
+      end
+
+      def color_enabled?
+        $stdout.tty?
+      end
+
+      def colorize(text, color)
+        return text unless color
+
+        color_code = COLORS[color]
+        return text unless color_code
+
+        "\e[#{color_code}m#{text}\e[0m"
+      end
+
+      def calculate_column_widths(headers, rows)
+        all_rows = [headers] + rows
+        all_rows.transpose.map { |column| column.map(&:to_s).map(&:length).max }
+      end
+
+      def format_table_row(row, widths)
+        row.map.with_index { |cell, i| cell.to_s.ljust(widths[i]) }.join("  ")
+      end
+
+      def separator_line(widths)
+        widths.map { |width| "-" * width }.join("  ")
+      end
+
+      COLORS = {
+        red: 31,
+        green: 32,
+        yellow: 33,
+        blue: 34,
+        magenta: 35,
+        cyan: 36
+      }.freeze
+    end
+  end
+end

--- a/spec/solid_observer/cli/base_spec.rb
+++ b/spec/solid_observer/cli/base_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CLI::Base do
+  let(:test_cli_class) do
+    Class.new(described_class) do
+      def call
+        "executed"
+      end
+    end
+  end
+
+  let(:cli) { test_cli_class.new }
+
+  describe ".call" do
+    it "creates an instance and calls #call" do
+      expect_any_instance_of(test_cli_class).to receive(:call)
+      test_cli_class.call
+    end
+  end
+
+  describe "#call" do
+    it "raises NotImplementedError in base class" do
+      base_cli = described_class.new
+      expect { base_cli.call }.to raise_error(NotImplementedError, /must implement #call/)
+    end
+  end
+
+  describe "#output" do
+    it "outputs plain text without color" do
+      expect { cli.send(:output, "Hello") }.to output("Hello\n").to_stdout
+    end
+
+    it "outputs colored text when color is enabled" do
+      allow(cli).to receive(:color_enabled?).and_return(true)
+      expect { cli.send(:output, "Hello", color: :red) }.to output("\e[31mHello\e[0m\n").to_stdout
+    end
+
+    it "skips color when color is disabled" do
+      allow(cli).to receive(:color_enabled?).and_return(false)
+      expect { cli.send(:output, "Hello", color: :red) }.to output("Hello\n").to_stdout
+    end
+  end
+
+  describe "#error" do
+    it "outputs text in red" do
+      allow(cli).to receive(:color_enabled?).and_return(true)
+      expect { cli.send(:error, "Error message") }.to output("\e[31mError message\e[0m\n").to_stdout
+    end
+  end
+
+  describe "#success" do
+    it "outputs text in green" do
+      allow(cli).to receive(:color_enabled?).and_return(true)
+      expect { cli.send(:success, "Success message") }.to output("\e[32mSuccess message\e[0m\n").to_stdout
+    end
+  end
+
+  describe "#warning" do
+    it "outputs text in yellow" do
+      allow(cli).to receive(:color_enabled?).and_return(true)
+      expect { cli.send(:warning, "Warning message") }.to output("\e[33mWarning message\e[0m\n").to_stdout
+    end
+  end
+
+  describe "#info" do
+    it "outputs text in blue" do
+      allow(cli).to receive(:color_enabled?).and_return(true)
+      expect { cli.send(:info, "Info message") }.to output("\e[34mInfo message\e[0m\n").to_stdout
+    end
+  end
+
+  describe "#table" do
+    let(:headers) { ["Name", "Age", "City"] }
+    let(:rows) do
+      [
+        ["Alice", "30", "New York"],
+        ["Bob", "25", "San Francisco"],
+        ["Charlie", "35", "Los Angeles"]
+      ]
+    end
+
+    it "outputs formatted table with headers and rows" do
+      expect do
+        cli.send(:table, headers: headers, rows: rows)
+      end.to output(a_string_matching(/Name\s+Age\s+City/) && a_string_matching(/Alice\s+30\s+New York/)).to_stdout
+    end
+
+    it "does not output anything for empty rows" do
+      expect { cli.send(:table, headers: headers, rows: []) }.not_to output.to_stdout
+    end
+
+    it "handles numeric values" do
+      numeric_headers = ["ID", "Score"]
+      numeric_rows = [[1, 100], [2, 95], [3, 88]]
+
+      expect do
+        cli.send(:table, headers: numeric_headers, rows: numeric_rows)
+      end.to output(a_string_matching(/ID\s+Score/) && a_string_matching(/1\s+100/) && a_string_matching(/2\s+95/)).to_stdout
+    end
+  end
+
+  describe "#confirm" do
+    it "returns true for 'y' input" do
+      allow($stdin).to receive(:gets).and_return("y\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?")).to be true
+    end
+
+    it "returns true for 'yes' input" do
+      allow($stdin).to receive(:gets).and_return("yes\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?")).to be true
+    end
+
+    it "returns false for 'n' input" do
+      allow($stdin).to receive(:gets).and_return("n\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?")).to be false
+    end
+
+    it "returns false for 'no' input" do
+      allow($stdin).to receive(:gets).and_return("no\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?")).to be false
+    end
+
+    it "returns default value for empty input (default: true)" do
+      allow($stdin).to receive(:gets).and_return("\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?", default: true)).to be true
+    end
+
+    it "returns default value for empty input (default: false)" do
+      allow($stdin).to receive(:gets).and_return("\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?", default: false)).to be false
+    end
+
+    it "returns default value when stdin returns nil" do
+      allow($stdin).to receive(:gets).and_return(nil)
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?", default: true)).to be true
+    end
+
+    it "is case insensitive" do
+      allow($stdin).to receive(:gets).and_return("Y\n")
+      allow(cli).to receive(:print)
+      expect(cli.send(:confirm, "Continue?")).to be true
+    end
+  end
+
+  describe "#color_enabled?" do
+    it "returns true when stdout is a TTY" do
+      allow($stdout).to receive(:tty?).and_return(true)
+      expect(cli.send(:color_enabled?)).to be true
+    end
+
+    it "returns false when stdout is not a TTY" do
+      allow($stdout).to receive(:tty?).and_return(false)
+      expect(cli.send(:color_enabled?)).to be false
+    end
+  end
+
+  describe "#colorize" do
+    it "adds ANSI color codes" do
+      expect(cli.send(:colorize, "text", :red)).to eq("\e[31mtext\e[0m")
+    end
+
+    it "returns original text for unknown color" do
+      expect(cli.send(:colorize, "text", :unknown)).to eq("text")
+    end
+
+    it "returns original text when color is nil" do
+      expect(cli.send(:colorize, "text", nil)).to eq("text")
+    end
+  end
+
+  describe "#calculate_column_widths" do
+    it "calculates correct widths for each column" do
+      headers = ["Name", "Age"]
+      rows = [["Alice", "30"], ["Bob", "5"]]
+
+      widths = cli.send(:calculate_column_widths, headers, rows)
+      expect(widths).to eq([5, 3])
+    end
+  end
+
+  describe "#format_table_row" do
+    it "formats row with proper padding" do
+      row = ["Alice", "30"]
+      widths = [10, 5]
+
+      result = cli.send(:format_table_row, row, widths)
+      expect(result).to eq("Alice       30   ")
+    end
+  end
+
+  describe "#separator_line" do
+    it "generates separator line with correct lengths" do
+      widths = [5, 3, 10]
+      result = cli.send(:separator_line, widths)
+      expect(result).to eq("-----  ---  ----------")
+    end
+  end
+
+  describe "COLORS" do
+    it "defines expected color codes" do
+      expect(described_class::COLORS).to include(
+        red: 31,
+        green: 32,
+        yellow: 33,
+        blue: 34,
+        magenta: 35,
+        cyan: 36
+      )
+    end
+
+    it "is frozen" do
+      expect(described_class::COLORS).to be_frozen
+    end
+  end
+end


### PR DESCRIPTION
Implement foundation for CLI commands with colorized output, table formatting, and user prompts. This base class will be used by queue stats and status commands.

Features:
- Base class with template pattern (`.call` class method)
- Colorized output helpers (error, success, warning, info)
- ASCII table formatting with automatic column width calculation
- Confirmation prompts with customizable defaults (Y/n or y/N)
- TTY detection for smart color handling
- ANSI escape codes (no external dependencies)

Implementation Details:
- `SolidObserver::CLI::Base` with abstract `#call method`
- Output helpers: output, error, success, warning, info
- Table rendering: `calculate_column_widths`, `format_table_row`
- User interaction: confirm method with default parameter
- Color support: colorize with COLORS constant (red, green, yellow, blue, magenta, cyan)
- Graceful fallback when not running in TTY