### PR TITLE
[SO-015][FEAT] Implement status CLI command

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -27,6 +27,7 @@ detectors:
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
       - SolidObserver::CLI::Base#table
       - SolidObserver::CLI::Base#confirm
+      - SolidObserver::CLI::Status#print_queue_depths
 
   LongParameterList:
     exclude:
@@ -47,6 +48,8 @@ detectors:
       - CreateSolidObserverStorageInfo#change
       - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::CLI::Base#confirm
+      - SolidObserver::CLI::Status#print_queue_stats
+      - SolidObserver::CLI::Status#print_queue_table
 
   DuplicateMethodCall:
     exclude:
@@ -57,6 +60,9 @@ detectors:
       - SolidObserver::QueueEventBuffer#flush!
       - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::RecordEvent#handle_error
+      - SolidObserver::CLI::Status#print_queue_stats
+      - SolidObserver::CLI::Status#print_queue_table
+      - SolidObserver::CLI::Status#print_queue_depths
 
   MissingSafeMethod:
     exclude:

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -11,6 +11,7 @@ require_relative "solid_observer/services/cleanup_storage" if defined?(ActiveRec
 require_relative "solid_observer/queue_event_buffer" if defined?(ActiveRecord)
 require_relative "solid_observer/subscriber" if defined?(ActiveSupport)
 require_relative "solid_observer/cli/base"
+require_relative "solid_observer/cli/status"
 require_relative "solid_observer/queue_stats"
 require_relative "solid_observer/engine" if defined?(Rails::Engine)
 

--- a/lib/solid_observer/cli/status.rb
+++ b/lib/solid_observer/cli/status.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module CLI
+    class Status < Base
+      def call
+        print_header
+        print_queue_stats
+      end
+
+      private
+
+      def print_header
+        output("\n📊 SolidObserver Status", color: :cyan)
+        output("=" * 50, color: :cyan)
+        output("")
+      end
+
+      def print_queue_stats
+        stats = SolidObserver::QueueStats.snapshot
+
+        if stats[:available]
+          print_queue_table(stats)
+          print_queue_depths(stats[:queues]) if stats[:queues].any?
+        else
+          warning("⚠️  SolidQueue not available: #{stats[:error]}")
+        end
+      end
+
+      def print_queue_table(stats)
+        output("🚀 Solid Queue", color: :green)
+        output("")
+
+        table(
+          headers: ["Metric", "Value"],
+          rows: [
+            ["Ready", stats[:ready]],
+            ["Scheduled", stats[:scheduled]],
+            ["Claimed", stats[:claimed]],
+            ["Failed", stats[:failed]],
+            ["Workers", stats[:workers]]
+          ]
+        )
+        output("")
+      end
+
+      def print_queue_depths(queues)
+        output("📋 Queue Depths", color: :green)
+        output("")
+
+        table(
+          headers: ["Queue", "Jobs"],
+          rows: queues.sort_by { |name, _count| name }.map { |name, count| [name, count] }
+        )
+        output("")
+      end
+    end
+  end
+end

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :solid_observer do
+  desc "Display SolidObserver status with queue statistics"
+  task status: :environment do
+    SolidObserver::CLI::Status.call
+  end
+end

--- a/spec/solid_observer/cli/status_spec.rb
+++ b/spec/solid_observer/cli/status_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CLI::Status do
+  let(:status) { described_class.new }
+
+  describe "#call" do
+    context "when SolidQueue is available" do
+      let(:stats) do
+        {
+          ready: 10,
+          scheduled: 5,
+          claimed: 3,
+          failed: 2,
+          workers: 4,
+          queues: {"default" => 8, "mailers" => 2},
+          available: true
+        }
+      end
+
+      before do
+        allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
+      end
+
+      it "displays header" do
+        expect { status.call }.to output(/📊 SolidObserver Status/).to_stdout
+      end
+
+      it "displays queue statistics table" do
+        output = capture_stdout { status.call }
+
+        expect(output).to include("🚀 Solid Queue")
+        expect(output).to include("Metric")
+        expect(output).to include("Value")
+        expect(output).to include("Ready")
+        expect(output).to include("10")
+        expect(output).to include("Scheduled")
+        expect(output).to include("5")
+        expect(output).to include("Claimed")
+        expect(output).to include("3")
+        expect(output).to include("Failed")
+        expect(output).to include("2")
+        expect(output).to include("Workers")
+        expect(output).to include("4")
+      end
+
+      it "displays queue depths table" do
+        output = capture_stdout { status.call }
+
+        expect(output).to include("📋 Queue Depths")
+        expect(output).to include("Queue")
+        expect(output).to include("Jobs")
+        expect(output).to include("default")
+        expect(output).to include("8")
+        expect(output).to include("mailers")
+        expect(output).to include("2")
+      end
+
+      it "sorts queues alphabetically" do
+        stats[:queues] = {"zebra" => 1, "alpha" => 2, "beta" => 3}
+        allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
+
+        output = capture_stdout { status.call }
+
+        alpha_index = output.index("alpha")
+        beta_index = output.index("beta")
+        zebra_index = output.index("zebra")
+
+        expect(alpha_index).to be < beta_index
+        expect(beta_index).to be < zebra_index
+      end
+
+      context "when no queues have jobs" do
+        before do
+          stats[:queues] = {}
+          allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
+        end
+
+        it "does not display queue depths section" do
+          output = capture_stdout { status.call }
+
+          expect(output).not_to include("📋 Queue Depths")
+        end
+      end
+    end
+
+    context "when SolidQueue is not available" do
+      let(:stats) do
+        {
+          ready: 0,
+          scheduled: 0,
+          claimed: 0,
+          failed: 0,
+          workers: 0,
+          queues: {},
+          available: false,
+          error: "SolidQueue not available"
+        }
+      end
+
+      before do
+        allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
+      end
+
+      it "displays header" do
+        expect { status.call }.to output(/📊 SolidObserver Status/).to_stdout
+      end
+
+      it "displays warning message" do
+        output = capture_stdout { status.call }
+
+        expect(output).to include("⚠️  SolidQueue not available")
+        expect(output).to include("SolidQueue not available")
+      end
+
+      it "does not display queue statistics table" do
+        output = capture_stdout { status.call }
+
+        expect(output).not_to include("🚀 Solid Queue")
+        expect(output).not_to include("Metric")
+      end
+
+      it "does not display queue depths table" do
+        output = capture_stdout { status.call }
+
+        expect(output).not_to include("📋 Queue Depths")
+      end
+    end
+
+    context "when database error occurs" do
+      let(:stats) do
+        {
+          ready: 0,
+          scheduled: 0,
+          claimed: 0,
+          failed: 0,
+          workers: 0,
+          queues: {},
+          available: false,
+          error: "Database connection failed"
+        }
+      end
+
+      before do
+        allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { status.call }
+
+        expect(output).to include("⚠️  SolidQueue not available")
+        expect(output).to include("Database connection failed")
+      end
+    end
+  end
+
+  private
+
+  def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
Add status command to display real-time SolidQueue statistics with formatted ASCII table output via rake task.

New features:
- `CLI::Status` class with colored, formatted output
- Queue statistics table (ready, scheduled, claimed, failed, workers)
- Queue depths table sorted alphabetically by queue name
- Graceful degradation when `SolidQueue` unavailable
- Rake task: `rails solid_observer:status`

Display sections:
- 📊 Status header with visual separator
- 🚀 Solid Queue metrics table
- 📋 Queue depths table (only when queues have jobs)
- ⚠️ Warning messages for unavailable services

Implementation:
- Uses `QueueStats.snapshot `for real-time data
- Leverages `CLI::Base#table` for ASCII formatting
- Supports colored output when TTY available
- Handles database errors with user-friendly messages