### PR TITLE
[SO-016][FEAT] Implement Jobs CLI commands for SolidQueue management

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -28,12 +28,16 @@ detectors:
       - SolidObserver::CLI::Base#table
       - SolidObserver::CLI::Base#confirm
       - SolidObserver::CLI::Status#print_queue_depths
+      - SolidObserver::CLI::Jobs#retry_job
+      - SolidObserver::CLI::Jobs#discard
 
   LongParameterList:
     exclude:
       - SolidObserver::BaseMetric#self.increment
       - SolidObserver::BaseMetric#self.record
       - SolidObserver::Services::RecordEvent#self.call
+      - SolidObserver::CLI::Jobs#list
+      - SolidObserver::CLI::Jobs#fetch_job
 
   UtilityFunction:
     enabled: false
@@ -50,6 +54,10 @@ detectors:
       - SolidObserver::CLI::Base#confirm
       - SolidObserver::CLI::Status#print_queue_stats
       - SolidObserver::CLI::Status#print_queue_table
+      - SolidObserver::CLI::Jobs#format_job_row
+      - SolidObserver::CLI::Jobs#build_job_details
+      - SolidObserver::CLI::Jobs#add_scheduled_details
+      - SolidObserver::CLI::Jobs#fetch_jobs
 
   DuplicateMethodCall:
     exclude:
@@ -63,6 +71,8 @@ detectors:
       - SolidObserver::CLI::Status#print_queue_stats
       - SolidObserver::CLI::Status#print_queue_table
       - SolidObserver::CLI::Status#print_queue_depths
+      - SolidObserver::CLI::Jobs#add_error_details
+      - SolidObserver::CLI::Jobs#scope_for_status
 
   MissingSafeMethod:
     exclude:
@@ -72,6 +82,7 @@ detectors:
   RepeatedConditional:
     exclude:
       - SolidObserver::CorrelationIdResolver#resolve
+      - SolidObserver::CLI::Jobs
 
   UncommunicativeVariableName:
     accept:
@@ -81,8 +92,16 @@ detectors:
 
   BooleanParameter:
     exclude:
-      - SolidObserver::CLI::Base#confirm # Natural for default parameter
+      - SolidObserver::CLI::Base#confirm
 
   NilCheck:
     exclude:
-      - SolidObserver::CLI::Base#confirm # Necessary for stdin handling
+      - SolidObserver::CLI::Base#confirm
+
+  ControlParameter:
+    exclude:
+      - SolidObserver::CLI::Jobs#scope_for_status
+
+  TooManyMethods:
+    exclude:
+      - SolidObserver::CLI::Jobs

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -12,6 +12,7 @@ require_relative "solid_observer/queue_event_buffer" if defined?(ActiveRecord)
 require_relative "solid_observer/subscriber" if defined?(ActiveSupport)
 require_relative "solid_observer/cli/base"
 require_relative "solid_observer/cli/status"
+require_relative "solid_observer/cli/jobs"
 require_relative "solid_observer/queue_stats"
 require_relative "solid_observer/engine" if defined?(Rails::Engine)
 

--- a/lib/solid_observer/cli/jobs.rb
+++ b/lib/solid_observer/cli/jobs.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module CLI
+    class Jobs < Base
+      def list(status: nil, queue: nil, job_class: nil, limit: 20)
+        return error("SolidQueue is not available") unless solid_queue_available?
+
+        jobs = fetch_jobs(status: status, queue: queue, job_class: job_class, limit: limit)
+
+        return warning("No jobs found matching the criteria") if jobs.empty?
+
+        print_jobs_table(jobs)
+      end
+
+      def show(job_id)
+        return error("SolidQueue is not available") unless solid_queue_available?
+
+        job = find_job(job_id)
+        return unless job
+
+        print_job_details(job)
+      end
+
+      def retry_job(job_id)
+        return error("SolidQueue is not available") unless solid_queue_available?
+
+        job = find_failed_job(job_id)
+        return unless job
+
+        return info("Retry cancelled") unless confirm("Retry job #{job_id}?")
+
+        job.retry
+        success("✓ Job #{job_id} has been queued for retry")
+      end
+
+      def discard(job_id)
+        return error("SolidQueue is not available") unless solid_queue_available?
+
+        job = find_failed_job(job_id)
+        return unless job
+
+        return info("Discard cancelled") unless confirm("Discard job #{job_id}? This cannot be undone.", default: false)
+
+        job.discard
+        success("✓ Job #{job_id} has been discarded")
+      end
+
+      private
+
+      def solid_queue_available?
+        SolidObserver::QueueStats.solid_queue_available?
+      end
+
+      def fetch_jobs(status:, queue:, job_class:, limit:)
+        scope = scope_for_status(status)
+        scope = scope.where(queue_name: queue) if queue
+        scope = scope.where("job_class = ?", job_class) if job_class
+        scope.order(created_at: :desc).limit(limit.to_i).to_a
+      end
+
+      def scope_for_status(status)
+        case status&.to_s&.downcase
+        when "ready" then SolidQueue::ReadyExecution.all
+        when "scheduled" then SolidQueue::ScheduledExecution.all
+        when "claimed" then SolidQueue::ClaimedExecution.all
+        when "failed" then SolidQueue::FailedExecution.all
+        else SolidQueue::ReadyExecution.all
+        end
+      end
+
+      def find_job(job_id)
+        job = find_in_execution_tables(job_id)
+        return job if job
+
+        error("Job #{job_id} not found")
+        nil
+      end
+
+      def find_failed_job(job_id)
+        job = SolidQueue::FailedExecution.find_by(id: job_id)
+        return job if job
+
+        error("Failed job #{job_id} not found")
+        nil
+      end
+
+      def find_in_execution_tables(job_id)
+        SolidQueue::ReadyExecution.find_by(id: job_id) ||
+          SolidQueue::ScheduledExecution.find_by(id: job_id) ||
+          SolidQueue::ClaimedExecution.find_by(id: job_id) ||
+          SolidQueue::FailedExecution.find_by(id: job_id)
+      end
+
+      def print_jobs_table(jobs)
+        print_section_header("📋 Jobs")
+        table(
+          headers: ["ID", "Queue", "Class", "Status", "Created At"],
+          rows: jobs.map { |job| format_job_row(job) }
+        )
+        output("")
+      end
+
+      def format_job_row(job)
+        [
+          job.id.to_s,
+          job.queue_name,
+          job.job_class,
+          job_status(job),
+          format_time(job.created_at)
+        ]
+      end
+
+      def job_status(job)
+        return "Ready" if job.is_a?(SolidQueue::ReadyExecution)
+        return "Scheduled" if job.is_a?(SolidQueue::ScheduledExecution)
+        return "Claimed" if job.is_a?(SolidQueue::ClaimedExecution)
+        return "Failed" if job.is_a?(SolidQueue::FailedExecution)
+
+        "Unknown"
+      end
+
+      def format_time(time)
+        time.strftime("%Y-%m-%d %H:%M:%S")
+      end
+
+      def print_job_details(job)
+        print_section_header("📄 Job Details")
+
+        details = build_job_details(job)
+
+        table(
+          headers: ["Attribute", "Value"],
+          rows: details
+        )
+        output("")
+      end
+
+      def build_job_details(job)
+        details = [
+          ["ID", job.id],
+          ["Queue", job.queue_name],
+          ["Class", job.job_class],
+          ["Status", job_status(job)],
+          ["Created At", format_time(job.created_at)],
+          ["Priority", job.priority]
+        ]
+
+        add_scheduled_details(details, job)
+        add_error_details(details, job)
+
+        details
+      end
+
+      def add_scheduled_details(details, job)
+        return unless job.is_a?(SolidQueue::ScheduledExecution)
+
+        details << ["Scheduled At", format_time(job.scheduled_at)]
+      end
+
+      def add_error_details(details, job)
+        return unless job.is_a?(SolidQueue::FailedExecution)
+        return unless job.error
+
+        details << ["Error", job.error.exception_class]
+        details << ["Error Message", job.error.message]
+      end
+
+      def print_section_header(title)
+        output("\n#{title}", color: :cyan)
+        output("=" * 80, color: :cyan)
+        output("")
+      end
+    end
+  end
+end

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -5,4 +5,46 @@ namespace :solid_observer do
   task status: :environment do
     SolidObserver::CLI::Status.call
   end
+
+  desc "List jobs with optional filters (status, queue, class, limit)"
+  task :jobs, [:status, :queue, :job_class, :limit] => :environment do |_t, args|
+    SolidObserver::CLI::Jobs.new.list(
+      status: args[:status],
+      queue: args[:queue],
+      job_class: args[:job_class],
+      limit: args[:limit] || 20
+    )
+  end
+
+  namespace :jobs do
+    desc "Show details for a specific job by ID"
+    task :show, [:job_id] => :environment do |_t, args|
+      if args[:job_id].nil?
+        puts "Error: Job ID required. Usage: rails solid_observer:jobs:show[JOB_ID]"
+        exit 1
+      end
+
+      SolidObserver::CLI::Jobs.new.show(args[:job_id])
+    end
+
+    desc "Retry a failed job by ID"
+    task :retry, [:job_id] => :environment do |_t, args|
+      if args[:job_id].nil?
+        puts "Error: Job ID required. Usage: rails solid_observer:jobs:retry[JOB_ID]"
+        exit 1
+      end
+
+      SolidObserver::CLI::Jobs.new.retry_job(args[:job_id])
+    end
+
+    desc "Discard a failed job by ID"
+    task :discard, [:job_id] => :environment do |_t, args|
+      if args[:job_id].nil?
+        puts "Error: Job ID required. Usage: rails solid_observer:jobs:discard[JOB_ID]"
+        exit 1
+      end
+
+      SolidObserver::CLI::Jobs.new.discard(args[:job_id])
+    end
+  end
 end

--- a/spec/solid_observer/cli/jobs_spec.rb
+++ b/spec/solid_observer/cli/jobs_spec.rb
@@ -1,0 +1,441 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CLI::Jobs do
+  let(:jobs_cli) { described_class.new }
+
+  before do
+    stub_const("SolidQueue", Module.new)
+    stub_const("SolidQueue::Job", Class.new)
+    stub_const("SolidQueue::ReadyExecution", Class.new(ActiveRecord::Base))
+    stub_const("SolidQueue::ScheduledExecution", Class.new(ActiveRecord::Base))
+    stub_const("SolidQueue::ClaimedExecution", Class.new(ActiveRecord::Base))
+    stub_const("SolidQueue::FailedExecution", Class.new(ActiveRecord::Base))
+
+    allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(true)
+  end
+
+  describe "#list" do
+    context "when SolidQueue is not available" do
+      before do
+        allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(false)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.list }
+
+        expect(output).to include("SolidQueue is not available")
+      end
+    end
+
+    context "when SolidQueue is available" do
+      let(:job1) do
+        double("Job",
+          id: 1,
+          queue_name: "default",
+          job_class: "TestJob",
+          created_at: Time.new(2026, 1, 21, 10, 0, 0),
+          priority: 0)
+      end
+
+      let(:job2) do
+        double("Job",
+          id: 2,
+          queue_name: "mailers",
+          job_class: "MailerJob",
+          created_at: Time.new(2026, 1, 21, 11, 0, 0),
+          priority: 5)
+      end
+
+      context "with no filters" do
+        before do
+          scope = double("scope")
+          allow(SolidQueue::ReadyExecution).to receive(:all).and_return(scope)
+          allow(scope).to receive(:order).and_return(scope)
+          allow(scope).to receive(:limit).and_return(scope)
+          allow(scope).to receive(:to_a).and_return([job1, job2])
+          allow(job1).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(true)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+          allow(job2).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(true)
+          allow(job2).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+          allow(job2).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+          allow(job2).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+        end
+
+        it "displays jobs table" do
+          output = capture_stdout { jobs_cli.list }
+
+          expect(output).to include("📋 Jobs")
+          expect(output).to include("ID")
+          expect(output).to include("Queue")
+          expect(output).to include("Class")
+          expect(output).to include("Status")
+          expect(output).to include("default")
+          expect(output).to include("TestJob")
+          expect(output).to include("Ready")
+        end
+      end
+
+      context "with status filter" do
+        before do
+          scope = double("scope")
+          allow(SolidQueue::FailedExecution).to receive(:all).and_return(scope)
+          allow(scope).to receive(:order).and_return(scope)
+          allow(scope).to receive(:limit).and_return(scope)
+          allow(scope).to receive(:to_a).and_return([job1])
+          allow(job1).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(true)
+        end
+
+        it "fetches jobs with specified status" do
+          output = capture_stdout { jobs_cli.list(status: "failed") }
+
+          expect(output).to include("Failed")
+        end
+      end
+
+      context "with queue filter" do
+        before do
+          scope = double("scope")
+          filtered_scope = double("filtered_scope")
+          allow(SolidQueue::ReadyExecution).to receive(:all).and_return(scope)
+          allow(scope).to receive(:where).with(queue_name: "mailers").and_return(filtered_scope)
+          allow(filtered_scope).to receive(:order).and_return(filtered_scope)
+          allow(filtered_scope).to receive(:limit).and_return(filtered_scope)
+          allow(filtered_scope).to receive(:to_a).and_return([job2])
+          allow(job2).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(true)
+          allow(job2).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+          allow(job2).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+          allow(job2).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+        end
+
+        it "fetches jobs from specified queue" do
+          output = capture_stdout { jobs_cli.list(queue: "mailers") }
+
+          expect(output).to include("mailers")
+          expect(output).to include("MailerJob")
+        end
+      end
+
+      context "with job_class filter" do
+        before do
+          scope = double("scope")
+          filtered_scope = double("filtered_scope")
+          allow(SolidQueue::ReadyExecution).to receive(:all).and_return(scope)
+          allow(scope).to receive(:where).with("job_class = ?", "TestJob").and_return(filtered_scope)
+          allow(filtered_scope).to receive(:order).and_return(filtered_scope)
+          allow(filtered_scope).to receive(:limit).and_return(filtered_scope)
+          allow(filtered_scope).to receive(:to_a).and_return([job1])
+          allow(job1).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(true)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+        end
+
+        it "fetches jobs of specified class" do
+          output = capture_stdout { jobs_cli.list(job_class: "TestJob") }
+
+          expect(output).to include("TestJob")
+        end
+      end
+
+      context "with limit" do
+        before do
+          scope = double("scope")
+          limited_scope = double("limited_scope")
+          allow(SolidQueue::ReadyExecution).to receive(:all).and_return(scope)
+          allow(scope).to receive(:order).and_return(scope)
+          allow(scope).to receive(:limit).with(5).and_return(limited_scope)
+          allow(limited_scope).to receive(:to_a).and_return([job1])
+          allow(job1).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(true)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+          allow(job1).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+        end
+
+        it "limits number of jobs returned" do
+          output = capture_stdout { jobs_cli.list(limit: 5) }
+
+          expect(output).to include("TestJob")
+        end
+      end
+
+      context "when no jobs found" do
+        before do
+          scope = double("scope")
+          allow(SolidQueue::ReadyExecution).to receive(:all).and_return(scope)
+          allow(scope).to receive(:order).and_return(scope)
+          allow(scope).to receive(:limit).and_return(scope)
+          allow(scope).to receive(:to_a).and_return([])
+        end
+
+        it "displays warning message" do
+          output = capture_stdout { jobs_cli.list }
+
+          expect(output).to include("No jobs found matching the criteria")
+        end
+      end
+    end
+  end
+
+  describe "#show" do
+    context "when SolidQueue is not available" do
+      before do
+        allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(false)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.show(1) }
+
+        expect(output).to include("SolidQueue is not available")
+      end
+    end
+
+    context "when job exists" do
+      let(:job) do
+        double("Job",
+          id: 1,
+          queue_name: "default",
+          job_class: "TestJob",
+          created_at: Time.new(2026, 1, 21, 10, 0, 0),
+          priority: 0)
+      end
+
+      before do
+        allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(job).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(true)
+        allow(job).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+      end
+
+      it "displays job details" do
+        output = capture_stdout { jobs_cli.show(1) }
+
+        expect(output).to include("📄 Job Details")
+        expect(output).to include("ID")
+        expect(output).to include("1")
+        expect(output).to include("Queue")
+        expect(output).to include("default")
+        expect(output).to include("Class")
+        expect(output).to include("TestJob")
+        expect(output).to include("Status")
+        expect(output).to include("Ready")
+      end
+    end
+
+    context "when job is scheduled" do
+      let(:job) do
+        double("Job",
+          id: 1,
+          queue_name: "default",
+          job_class: "TestJob",
+          created_at: Time.new(2026, 1, 21, 10, 0, 0),
+          priority: 0,
+          scheduled_at: Time.new(2026, 1, 21, 12, 0, 0))
+      end
+
+      before do
+        allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: 1).and_return(nil)
+        allow(SolidQueue::ScheduledExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(SolidQueue::ClaimedExecution).to receive(:find_by).with(id: 1).and_return(nil)
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 1).and_return(nil)
+        allow(job).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(true)
+        allow(job).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(false)
+      end
+
+      it "displays scheduled_at field" do
+        output = capture_stdout { jobs_cli.show(1) }
+
+        expect(output).to include("Scheduled At")
+        expect(output).to include("2026-01-21 12:00:00")
+      end
+    end
+
+    context "when job is failed" do
+      let(:error) { double("Error", exception_class: "StandardError", message: "Test error") }
+      let(:job) do
+        double("Job",
+          id: 1,
+          queue_name: "default",
+          job_class: "TestJob",
+          created_at: Time.new(2026, 1, 21, 10, 0, 0),
+          priority: 0,
+          error: error)
+      end
+
+      before do
+        allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: 1).and_return(nil)
+        allow(SolidQueue::ScheduledExecution).to receive(:find_by).with(id: 1).and_return(nil)
+        allow(SolidQueue::ClaimedExecution).to receive(:find_by).with(id: 1).and_return(nil)
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(job).to receive(:is_a?).with(SolidQueue::ReadyExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::ScheduledExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::ClaimedExecution).and_return(false)
+        allow(job).to receive(:is_a?).with(SolidQueue::FailedExecution).and_return(true)
+      end
+
+      it "displays error information" do
+        output = capture_stdout { jobs_cli.show(1) }
+
+        expect(output).to include("Error")
+        expect(output).to include("StandardError")
+        expect(output).to include("Error Message")
+        expect(output).to include("Test error")
+      end
+    end
+
+    context "when job does not exist" do
+      before do
+        allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: 999).and_return(nil)
+        allow(SolidQueue::ScheduledExecution).to receive(:find_by).with(id: 999).and_return(nil)
+        allow(SolidQueue::ClaimedExecution).to receive(:find_by).with(id: 999).and_return(nil)
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 999).and_return(nil)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.show(999) }
+
+        expect(output).to include("Job 999 not found")
+      end
+    end
+  end
+
+  describe "#retry_job" do
+    context "when SolidQueue is not available" do
+      before do
+        allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(false)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.retry_job(1) }
+
+        expect(output).to include("SolidQueue is not available")
+      end
+    end
+
+    context "when failed job exists" do
+      let(:job) { double("FailedJob", id: 1, retry: true) }
+
+      before do
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(jobs_cli).to receive(:confirm).and_return(true)
+      end
+
+      it "retries the job" do
+        expect(job).to receive(:retry)
+
+        output = capture_stdout { jobs_cli.retry_job(1) }
+
+        expect(output).to include("✓ Job 1 has been queued for retry")
+      end
+    end
+
+    context "when user cancels" do
+      let(:job) { double("FailedJob", id: 1, retry: true) }
+
+      before do
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(jobs_cli).to receive(:confirm).and_return(false)
+      end
+
+      it "does not retry the job" do
+        expect(job).not_to receive(:retry)
+
+        output = capture_stdout { jobs_cli.retry_job(1) }
+
+        expect(output).to include("Retry cancelled")
+      end
+    end
+
+    context "when failed job does not exist" do
+      before do
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 999).and_return(nil)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.retry_job(999) }
+
+        expect(output).to include("Failed job 999 not found")
+      end
+    end
+  end
+
+  describe "#discard" do
+    context "when SolidQueue is not available" do
+      before do
+        allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(false)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.discard(1) }
+
+        expect(output).to include("SolidQueue is not available")
+      end
+    end
+
+    context "when failed job exists" do
+      let(:job) { double("FailedJob", id: 1, discard: true) }
+
+      before do
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(jobs_cli).to receive(:confirm).and_return(true)
+      end
+
+      it "discards the job" do
+        expect(job).to receive(:discard)
+
+        output = capture_stdout { jobs_cli.discard(1) }
+
+        expect(output).to include("✓ Job 1 has been discarded")
+      end
+    end
+
+    context "when user cancels" do
+      let(:job) { double("FailedJob", id: 1, discard: true) }
+
+      before do
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 1).and_return(job)
+        allow(jobs_cli).to receive(:confirm).and_return(false)
+      end
+
+      it "does not discard the job" do
+        expect(job).not_to receive(:discard)
+
+        output = capture_stdout { jobs_cli.discard(1) }
+
+        expect(output).to include("Discard cancelled")
+      end
+    end
+
+    context "when failed job does not exist" do
+      before do
+        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: 999).and_return(nil)
+      end
+
+      it "displays error message" do
+        output = capture_stdout { jobs_cli.discard(999) }
+
+        expect(output).to include("Failed job 999 not found")
+      end
+    end
+  end
+
+  private
+
+  def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
Add comprehensive job management CLI with list, show, retry, and discard commands. Includes flexible filtering, detailed job information display, and safe confirmation prompts for destructive operations.

Features:
- List jobs with filters (status, queue, class, limit)
- Show detailed job information with status-specific fields
- Retry failed jobs with confirmation prompt
- Discard failed jobs with strict confirmation
- Support for all `SolidQueue` execution states (Ready, Scheduled, Claimed, Failed)
- Graceful error handling when `SolidQueue` is unavailable
- Formatted table output with timestamps and priorities

Implementation:
- Created `SolidObserver::CLI::Jobs` class
- 4 public commands with 14 private helper methods
- Guard clauses with early returns for clean control flow
- Extracted methods for scope building, job lookup, and detail formatting
- Added 4 rake tasks: `jobs`, `jobs:show`,` jobs:retry`, `jobs:discard`