### PR TITLE
[SO-021][TECH-DEBT] Fix architecture inconsistencies before v0.1.0 launch

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -22,6 +22,7 @@ detectors:
       - SolidObserver::QueueEventBuffer#push
       - SolidObserver::QueueEventBuffer#schedule_flush
       - SolidObserver::Services::FlushEventBuffer#call
+      - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
       - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::CleanupStorage#call
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
@@ -33,6 +34,8 @@ detectors:
       - SolidObserver::CLI::Storage#call
       - SolidObserver::CLI::Storage#calculate_database_size
       - SolidObserver::CLI::Storage#print_configuration
+      - SolidObserver::Engine#activate_subscribers
+      - SolidObserver::Subscriber#subscribe!
 
   LongParameterList:
     exclude:
@@ -71,6 +74,7 @@ detectors:
       - SolidObserver::QueueEventBuffer#flush!
       - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::RecordEvent#handle_error
+      - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
       - SolidObserver::CLI::Status#print_queue_stats
       - SolidObserver::CLI::Status#print_queue_table
       - SolidObserver::CLI::Status#print_queue_depths
@@ -80,6 +84,10 @@ detectors:
       - SolidObserver::CLI::Storage#print_configuration
       - SolidObserver::CLI::Storage#print_section_header
       - SolidObserver::CLI::Storage#print_storage_table
+
+  InstanceVariableAssumption:
+    exclude:
+      - SolidObserver::Subscriber
 
   MissingSafeMethod:
     exclude:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.0-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-94.87%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-94.73%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---
@@ -246,14 +246,19 @@ bin/rails solid_observer:storage:purge
 
 ## Database Setup
 
-SolidObserver uses a separate SQLite database to avoid impacting your main application:
+**SolidObserver works with any main application database** — PostgreSQL, MySQL, or SQLite.
+
+For its own monitoring data, SolidObserver uses a **separate SQLite database**. This keeps monitoring isolated from your main app and provides simple file-based storage that requires no additional infrastructure.
 
 ```yaml
 # config/database.yml
 solid_observer_queue:
   <<: *default
+  adapter: sqlite3  # Always SQLite for SolidObserver storage
   database: storage/<%= Rails.env %>_solid_observer_queue.sqlite3
 ```
+
+> **Note:** Your main app's `primary` database can be PostgreSQL, MySQL, or any Rails-supported adapter. Only the `solid_observer_queue` database needs to be SQLite.
 
 ## Roadmap
 
@@ -309,19 +314,21 @@ config.solid_queue.connects_to = { database: { writing: :queue } }
 
 ### Multi-database setup
 
-SolidObserver works with Rails multi-database configurations. Ensure your `database.yml` has proper structure:
+SolidObserver works with Rails multi-database configurations. Here's an example with PostgreSQL as your primary database:
 
 ```yaml
 development:
   primary:
-    <<: *default
-    database: storage/development.sqlite3
+    adapter: postgresql
+    database: myapp_development
+    # ... PostgreSQL settings
   queue:
     <<: *default
+    adapter: sqlite3
     database: storage/development_queue.sqlite3
     migrations_paths: db/queue_migrate
   solid_observer_queue:
-    <<: *default
+    adapter: sqlite3
     database: storage/development_solid_observer_queue.sqlite3
 ```
 

--- a/app/models/solid_observer/queue_metric.rb
+++ b/app/models/solid_observer/queue_metric.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 module SolidObserver
+  # QueueMetric provides time-series metrics storage for queue statistics.
+  #
+  # NOTE: Metrics functionality is planned for v0.2.0. This class currently
+  # serves as a placeholder and inherits base functionality from BaseMetric.
+  # The database connection will be configured by the Engine when metrics
+  # are fully implemented.
+  #
+  # @see BaseMetric for available methods (increment, record)
   class QueueMetric < BaseMetric
-    self.abstract_class = true
-    connects_to database: {writing: :solid_observer_queue, reading: :solid_observer_queue}
   end
 end

--- a/lib/solid_observer/base_metric.rb
+++ b/lib/solid_observer/base_metric.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module SolidObserver
+  # BaseMetric provides the foundation for time-series metrics storage.
+  #
+  # NOTE: Metrics functionality is planned for v0.2.0. The database connection
+  # will be configured by the Engine (similar to BaseEvent) when metrics are
+  # fully implemented.
+  #
   class BaseMetric < ActiveRecord::Base
     self.abstract_class = true
     self.table_name = "solid_observer_metrics"

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -4,42 +4,77 @@ require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/numeric/bytes"
 
 module SolidObserver
+  # Configuration options for SolidObserver.
+  #
+  # @example Basic configuration
+  #   SolidObserver.configure do |config|
+  #     config.event_retention = 14.days
+  #     config.sampling_rate = 0.5
+  #   end
   class Configuration
+    # UI Settings
     attr_accessor :ui_enabled,
       :ui_base_controller,
       :http_basic_auth_enabled,
       :http_basic_auth_user,
-      :http_basic_auth_password,
-      :observe_queue,
-      :observe_cache,
+      :http_basic_auth_password
+
+    # Observer Settings
+    attr_accessor :observe_queue
+
+    # Observer Settings (planned for v0.2.0)
+    # @note Cache and Cable observers are not yet implemented
+    attr_accessor :observe_cache,
       :observe_cable,
-      :event_retention,
-      :metrics_retention,
-      :max_db_size,
-      :warning_threshold,
-      :sampling_rate,
-      :cache_sampling_rate,
+      :cache_sampling_rate
+
+    # Retention Settings
+    attr_accessor :event_retention
+
+    # Retention Settings (planned for v0.2.0)
+    # @note Metrics cleanup is not yet implemented
+    attr_accessor :metrics_retention
+
+    # Storage Settings
+    attr_accessor :max_db_size,
+      :warning_threshold
+
+    # Performance Settings
+    attr_accessor :sampling_rate,
       :buffer_size,
-      :flush_interval,
-      :correlation_id_generator
+      :flush_interval
+
+    # Correlation Settings
+    attr_accessor :correlation_id_generator
 
     def initialize
+      # UI defaults
       @ui_enabled = !production?
       @ui_base_controller = "::ApplicationController"
       @http_basic_auth_enabled = false
       @http_basic_auth_user = nil
       @http_basic_auth_password = nil
+
+      # Observer defaults
       @observe_queue = true
-      @observe_cache = true
-      @observe_cable = true
+      @observe_cache = false  # v0.2.0
+      @observe_cable = false  # v0.2.0
+
+      # Retention defaults
       @event_retention = 30.days
-      @metrics_retention = 90.days
+      @metrics_retention = 90.days  # v0.2.0
+
+      # Storage defaults
       @max_db_size = 1.gigabyte
       @warning_threshold = 0.8
+
+      # Performance defaults
       @sampling_rate = 1.0
-      @cache_sampling_rate = 0.1
+      @cache_sampling_rate = 0.1  # v0.2.0
       @buffer_size = 1000
       @flush_interval = 10.seconds
+
+      # Correlation defaults
       @correlation_id_generator = nil
     end
 

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -19,22 +19,32 @@ module SolidObserver
 
         return unless db_config
 
-        SolidObserver::BaseEvent.connects_to database: {
-          writing: :solid_observer_queue,
-          reading: :solid_observer_queue
+        connection_config = {
+          database: {writing: :solid_observer_queue, reading: :solid_observer_queue}
         }
+
+        SolidObserver::BaseEvent.connects_to(**connection_config)
+        SolidObserver::BaseMetric.connects_to(**connection_config)
       end
 
-      def check_and_activate_subscribers
+      def activate_subscribers
         logger = Rails.logger
 
-        if ActiveRecord::Base.connection.table_exists?("solid_observer_queue_events")
-          logger.info "[SolidObserver] Tables detected, activating event subscribers"
-        else
-          logger.info "[SolidObserver] Tables not found. Run migrations: rails solid_observer:install:migrations && rails db:migrate"
+        unless table_exists?("solid_observer_queue_events")
+          logger.info "[SolidObserver] Tables not found. Run: rails solid_observer:install:migrations && rails db:migrate"
+          return
         end
+
+        logger.info "[SolidObserver] Activating event subscribers"
+        Subscriber.subscribe!
       rescue ActiveRecord::NoDatabaseError
         logger.info "[SolidObserver] Database not ready yet. Skipping subscriber activation."
+      end
+
+      private
+
+      def table_exists?(table_name)
+        ActiveRecord::Base.connection.table_exists?(table_name)
       end
     end
 
@@ -44,7 +54,7 @@ module SolidObserver
 
     config.after_initialize do
       Engine.configure_database_connection
-      Engine.check_and_activate_subscribers
+      Engine.activate_subscribers
     end
   end
 end

--- a/lib/solid_observer/services/flush_event_buffer.rb
+++ b/lib/solid_observer/services/flush_event_buffer.rb
@@ -3,35 +3,53 @@
 module SolidObserver
   module Services
     class FlushEventBuffer
+      BATCH_SIZE = 100
+
       def self.call(events)
         new(events).call
       end
 
       def initialize(events)
         @events = events
+        @failed_count = 0
       end
 
       def call
-        return if @events.empty?
+        return 0 if @events.empty?
 
         QueueEvent.transaction do
           QueueEvent.insert_all!(@events)
         end
-      rescue ActiveRecord::RecordInvalid
+
+        @events.size
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => e
+        log_error("Bulk insert failed, retrying in batches: #{e.message}")
         retry_with_smaller_batches
-      rescue => e
-        Rails.logger.error "[SolidObserver] Event buffer flush failed: #{e.message}" if defined?(Rails)
-        raise
       end
 
       private
 
       def retry_with_smaller_batches
-        @events.each_slice(100) do |batch|
+        inserted = 0
+
+        @events.each_slice(BATCH_SIZE) do |batch|
           QueueEvent.insert_all(batch, returning: false)
-        rescue => e
-          Rails.logger.warn "[SolidObserver] Failed to insert batch: #{e.message}" if defined?(Rails)
+          inserted += batch.size
+        rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordInvalid => e
+          @failed_count += batch.size
+          log_warning("Failed to insert batch of #{batch.size} events: #{e.message}")
         end
+
+        log_warning("#{@failed_count} events could not be saved") if @failed_count.positive?
+        inserted
+      end
+
+      def log_error(message)
+        Rails.logger.error("[SolidObserver] #{message}") if defined?(Rails)
+      end
+
+      def log_warning(message)
+        Rails.logger.warn("[SolidObserver] #{message}") if defined?(Rails)
       end
     end
   end

--- a/lib/solid_observer/subscriber.rb
+++ b/lib/solid_observer/subscriber.rb
@@ -2,14 +2,36 @@
 
 module SolidObserver
   class Subscriber
+    EVENTS = %w[
+      enqueue.active_job
+      perform.active_job
+      retry_stopped.active_job
+      discard.active_job
+    ].freeze
+
     class << self
       def subscribe!
         return unless SolidObserver.config.observe_queue
 
-        subscribe_to_enqueue
-        subscribe_to_perform
-        subscribe_to_retry_stopped
-        subscribe_to_discard
+        @subscriptions = []
+        @subscriptions << subscribe_to_enqueue
+        @subscriptions << subscribe_to_perform
+        @subscriptions << subscribe_to_retry_stopped
+        @subscriptions << subscribe_to_discard
+        @subscriptions.compact!
+      end
+
+      def unsubscribe!
+        return unless @subscriptions
+
+        @subscriptions.each do |subscription|
+          ActiveSupport::Notifications.unsubscribe(subscription)
+        end
+        @subscriptions = []
+      end
+
+      def subscribed?
+        @subscriptions&.any?
       end
 
       private

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -75,10 +75,19 @@ namespace :solid_observer do
 
         SolidObserver::QueueEvent.delete_all
         SolidObserver::StorageInfo.delete_all
-        SolidObserver::QueueEvent.connection.execute("VACUUM")
+
+        connection = SolidObserver::QueueEvent.connection
+        case connection.adapter_name.downcase
+        when "sqlite"
+          connection.execute("VACUUM")
+          puts "✓ Database vacuumed to reclaim disk space"
+        when "postgresql"
+          connection.execute("ANALYZE solid_observer_queue_events")
+          connection.execute("ANALYZE solid_observer_storage_info")
+          puts "✓ Database tables analyzed"
+        end
 
         puts "✓ Purged #{event_count} events and #{snapshot_count} storage snapshots"
-        puts "✓ Database vacuumed to reclaim disk space"
       else
         puts "Aborted"
       end

--- a/spec/models/solid_observer/queue_metric_spec.rb
+++ b/spec/models/solid_observer/queue_metric_spec.rb
@@ -7,14 +7,13 @@ RSpec.describe SolidObserver::QueueMetric do
     expect(described_class.ancestors).to include(SolidObserver::BaseMetric)
   end
 
-  it "uses connects_to for database configuration" do
+  it "is documented as planned for v0.2.0" do
     model_content = File.read(File.join(__dir__, "../../../app/models/solid_observer/queue_metric.rb"))
-    expect(model_content).to include("connects_to")
-    expect(model_content).to include("solid_observer_queue")
+    expect(model_content).to include("v0.2.0")
   end
 
-  it "is an abstract class" do
-    expect(described_class.abstract_class?).to be true
+  it "is not an abstract class" do
+    expect(described_class.abstract_class?).to be false
   end
 
   it "uses solid_observer_metrics table" do

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -35,27 +35,30 @@ RSpec.describe SolidObserver::Engine do
     end
   end
 
-  describe ".check_and_activate_subscribers" do
+  describe ".activate_subscribers" do
     let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
 
     before do
       allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+      allow(SolidObserver::Subscriber).to receive(:subscribe!)
     end
 
-    it "logs activation message when tables exist" do
+    it "activates subscribers when tables exist" do
       allow(connection).to receive(:table_exists?).with("solid_observer_queue_events").and_return(true)
 
-      expect(logger).to receive(:info).with(/Tables detected/)
+      expect(logger).to receive(:info).with(/Activating event subscribers/)
+      expect(SolidObserver::Subscriber).to receive(:subscribe!)
 
-      described_class.check_and_activate_subscribers
+      described_class.activate_subscribers
     end
 
     it "logs migration instruction when tables do not exist" do
       allow(connection).to receive(:table_exists?).with("solid_observer_queue_events").and_return(false)
 
       expect(logger).to receive(:info).with(/Tables not found/)
+      expect(SolidObserver::Subscriber).not_to receive(:subscribe!)
 
-      described_class.check_and_activate_subscribers
+      described_class.activate_subscribers
     end
 
     it "rescues gracefully when database is not ready" do
@@ -63,7 +66,7 @@ RSpec.describe SolidObserver::Engine do
 
       expect(logger).to receive(:info).with(/Database not ready/)
 
-      described_class.check_and_activate_subscribers
+      described_class.activate_subscribers
     end
   end
 
@@ -74,8 +77,8 @@ RSpec.describe SolidObserver::Engine do
   end
 
   describe "configuration" do
-    it "checks tables after initialization" do
-      expect(described_class).to respond_to(:check_and_activate_subscribers)
+    it "activates subscribers after initialization" do
+      expect(described_class).to respond_to(:activate_subscribers)
     end
   end
 end

--- a/spec/solid_observer/services/flush_event_buffer_spec.rb
+++ b/spec/solid_observer/services/flush_event_buffer_spec.rb
@@ -53,9 +53,10 @@ RSpec.describe SolidObserver::Services::FlushEventBuffer do
       end
 
       it "does not attempt insert" do
-        service.call
+        result = service.call
 
         expect(SolidObserver::QueueEvent).not_to have_received(:insert_all!)
+        expect(result).to eq(0)
       end
     end
 
@@ -64,7 +65,7 @@ RSpec.describe SolidObserver::Services::FlushEventBuffer do
         allow(SolidObserver::QueueEvent).to receive(:transaction).and_yield
         allow(SolidObserver::QueueEvent).to receive(:insert_all!).and_raise(ActiveRecord::RecordInvalid)
         allow(SolidObserver::QueueEvent).to receive(:insert_all).and_return(true)
-        allow(Rails).to receive(:logger).and_return(double(warn: nil))
+        allow(Rails).to receive(:logger).and_return(double(warn: nil, error: nil))
       end
 
       it "retries with smaller batches" do
@@ -91,12 +92,12 @@ RSpec.describe SolidObserver::Services::FlushEventBuffer do
       before do
         allow(SolidObserver::QueueEvent).to receive(:transaction).and_yield
         allow(SolidObserver::QueueEvent).to receive(:insert_all!).and_raise(ActiveRecord::RecordInvalid)
-        allow(Rails).to receive(:logger).and_return(double(warn: nil))
+        allow(Rails).to receive(:logger).and_return(double(warn: nil, error: nil))
 
         call_count = 0
         allow(SolidObserver::QueueEvent).to receive(:insert_all) do
           call_count += 1
-          raise StandardError, "DB error" if call_count == 2
+          raise ActiveRecord::StatementInvalid, "DB error" if call_count == 2
           true
         end
       end
@@ -105,7 +106,7 @@ RSpec.describe SolidObserver::Services::FlushEventBuffer do
         service.call
 
         expect(Rails.logger).to have_received(:warn).with(
-          "[SolidObserver] Failed to insert batch: DB error"
+          /Failed to insert batch of \d+ events/
         )
       end
 
@@ -114,22 +115,17 @@ RSpec.describe SolidObserver::Services::FlushEventBuffer do
       end
     end
 
-    context "when transaction fails" do
+    context "when transaction fails with unexpected error" do
       before do
-        allow(SolidObserver::QueueEvent).to receive(:transaction).and_raise(StandardError, "Transaction error")
-        allow(Rails).to receive(:logger).and_return(double(error: nil))
+        allow(SolidObserver::QueueEvent).to receive(:transaction).and_raise(ActiveRecord::StatementInvalid, "Connection error")
+        allow(SolidObserver::QueueEvent).to receive(:insert_all).and_return(true)
+        allow(Rails).to receive(:logger).and_return(double(error: nil, warn: nil))
       end
 
-      it "logs the error" do
-        expect { service.call }.to raise_error(StandardError, "Transaction error")
+      it "falls back to batch retry" do
+        service.call
 
-        expect(Rails.logger).to have_received(:error).with(
-          "[SolidObserver] Event buffer flush failed: Transaction error"
-        )
-      end
-
-      it "re-raises the error" do
-        expect { service.call }.to raise_error(StandardError, "Transaction error")
+        expect(SolidObserver::QueueEvent).to have_received(:insert_all).at_least(:once)
       end
     end
   end
@@ -158,14 +154,15 @@ RSpec.describe SolidObserver::Services::FlushEventBuffer do
       end
     end
 
-    context "when other errors occur" do
+    context "when StatementInvalid occurs" do
       before do
-        allow(SolidObserver::QueueEvent).to receive(:insert_all!).and_raise(StandardError, "DB connection lost")
+        allow(SolidObserver::QueueEvent).to receive(:insert_all!).and_raise(ActiveRecord::StatementInvalid, "DB connection lost")
+        allow(SolidObserver::QueueEvent).to receive(:insert_all).and_return(true)
       end
 
-      it "logs and re-raises the error" do
-        expect { service.call }.to raise_error(StandardError, "DB connection lost")
-        expect(Rails.logger).to have_received(:error).with("[SolidObserver] Event buffer flush failed: DB connection lost")
+      it "falls back to batch retry" do
+        service.call
+        expect(SolidObserver::QueueEvent).to have_received(:insert_all).at_least(:once)
       end
     end
   end

--- a/spec/solid_observer/subscriber_spec.rb
+++ b/spec/solid_observer/subscriber_spec.rb
@@ -128,4 +128,50 @@ RSpec.describe SolidObserver::Subscriber do
       )
     end
   end
+
+  describe ".unsubscribe!" do
+    before do
+      allow(SolidObserver.config).to receive(:observe_queue).and_return(true)
+    end
+
+    it "removes all subscriptions" do
+      described_class.subscribe!
+      expect(described_class.subscribed?).to be true
+
+      described_class.unsubscribe!
+      expect(described_class.subscribed?).to be false
+    end
+
+    it "does nothing when not subscribed" do
+      described_class.instance_variable_set(:@subscriptions, nil)
+      expect { described_class.unsubscribe! }.not_to raise_error
+    end
+  end
+
+  describe ".subscribed?" do
+    before do
+      allow(SolidObserver.config).to receive(:observe_queue).and_return(true)
+    end
+
+    it "returns true when subscribed" do
+      described_class.subscribe!
+      expect(described_class.subscribed?).to be true
+    end
+
+    it "returns false when not subscribed" do
+      described_class.unsubscribe!
+      expect(described_class.subscribed?).to be false
+    end
+  end
+
+  describe "EVENTS constant" do
+    it "lists all subscribed event names" do
+      expect(described_class::EVENTS).to contain_exactly(
+        "enqueue.active_job",
+        "perform.active_job",
+        "retry_stopped.active_job",
+        "discard.active_job"
+      )
+    end
+  end
 end

--- a/spec/tasks/solid_observer_rake_spec.rb
+++ b/spec/tasks/solid_observer_rake_spec.rb
@@ -277,6 +277,7 @@ RSpec.describe "solid_observer rake tasks" do
         connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter)
         allow(SolidObserver::QueueEvent).to receive(:connection).and_return(connection)
         allow(connection).to receive(:execute)
+        allow(connection).to receive(:adapter_name).and_return("SQLite")
       end
 
       it "purges data when user confirms with y" do
@@ -284,7 +285,7 @@ RSpec.describe "solid_observer rake tasks" do
 
         expect {
           Rake::Task["solid_observer:storage:purge"].invoke
-        }.to output(/Purged 100 events and 10 storage snapshots.*Database vacuumed/m).to_stdout
+        }.to output(/Purged 100 events and 10 storage snapshots/m).to_stdout
 
         expect(SolidObserver::QueueEvent).to have_received(:delete_all)
         expect(SolidObserver::StorageInfo).to have_received(:delete_all)


### PR DESCRIPTION
Critical fixes:
- Remove `abstract_class` and direct `connects_to` from `QueueMetric`
- Engine now calls `Subscriber.subscribe!` (was only logging)
- Add `BaseMetric` `connects_to` configuration in Engine

Improvements:
- Add `Subscriber.unsubscribesubscribed?`, and EVENTS constant
- `FlushEventBuffer`: specific exceptions, batch size constant, return count
- Database-agnostic VACUUM (SQLite/PostgreSQL support)
- Group config options with v0.2.0 annotations for future features
- Set `observe_cache/observe_cable` defaults to false (not yet implemented)

Documentation:
- Clarify README: main app supports any DB, SolidObserver uses SQLite
- Add PostgreSQL example in multi-database setup section