### PR TITLE
[FEAT][SO-023] Add storage_mode configuration for real-time operations

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -37,6 +37,8 @@ detectors:
       - SolidObserver::CLI::Storage#print_configuration
       - SolidObserver::Engine#activate_subscribers
       - SolidObserver::Engine#self.activate_subscribers
+      - SolidObserver::Engine#configure_database_connection
+      - SolidObserver::Engine#self.configure_database_connection
       - SolidObserver::Subscriber#subscribe!
       - SolidObserver::Subscriber#self.subscribe!
 
@@ -70,6 +72,7 @@ detectors:
       - SolidObserver::Configuration#validate_rate!
       - SolidObserver::Configuration#validate_positive_integer!
       - SolidObserver::Configuration#validate_positive_numeric!
+      - SolidObserver::Services::CleanupStorage#format_bytes
 
   DuplicateMethodCall:
     exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.1.1] - 2026-02-10
+
+### Added
+- **Real-time mode** (`storage_mode: :realtime`) — run SolidObserver without database migrations
+  - Queue status and job management CLI commands work without any SolidObserver database
+  - `storage_mode` configuration option (`:persistence` default, `:realtime` for no-DB operation)
+  - `persistence_mode?` and `realtime_mode?` configuration predicates
+  - Graceful `CLI::Storage` message when in real-time mode
+  - Event buffering, metric incrementing, and cleanup automatically disabled in real-time mode
+
 ## [0.1.0] - 2026-02-02
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_observer (0.1.0)
+    solid_observer (0.1.1)
       rails (>= 8.0)
 
 GEM
@@ -230,7 +230,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.8.0)
+    prism (1.9.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.0-blue.svg" alt="Version"></a>
+  <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-93.23%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-93.06%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---
 
 SolidObserver is a production-grade observability solution for Rails 8's Solid Stack. Starting with **Solid Queue** monitoring in v0.1.0, it provides unified visibility into your background job processing with CLI tools, metrics collection, and distributed tracing support.
 
-## Features (v0.1.0)
+## Features (v0.1.1)
 
 - 📊 **Real-time Queue Status** — Monitor jobs across all states (ready, scheduled, claimed, failed)
 - 🔍 **Job Management CLI** — List, inspect, retry, and discard failed jobs
@@ -29,6 +29,7 @@ SolidObserver is a production-grade observability solution for Rails 8's Solid S
 - 🔗 **Distributed Tracing** — Correlate jobs with APM tools (Datadog, Sentry, OpenTelemetry)
 - ⚡ **High Performance** — Buffered writes, configurable sampling, minimal overhead
 - 🛡️ **Production Ready** — Automatic cleanup, size limits, retention policies
+- 🚀 **Two Operating Modes** — Real-time (no migrations) or persistence (full event history)
 
 ## Requirements
 
@@ -46,20 +47,37 @@ Add to your Gemfile:
 gem "solid_observer"
 ```
 
-Run the installer:
-
 ```bash
 bundle install
 rails generate solid_observer:install
 ```
 
-Install and run migrations:
+SolidObserver supports two operating modes. Choose the one that fits your needs:
+
+### Real-time Mode (no migrations needed)
+
+Get queue monitoring and job management instantly — no database setup required. SolidObserver queries Solid Queue directly.
+
+```ruby
+# config/initializers/solid_observer.rb
+SolidObserver.configure do |config|
+  config.storage_mode = :realtime
+end
+```
+
+That's it. You now have access to queue status, job listing, retry, and discard commands.
+
+### Persistence Mode (default)
+
+Store event history, metrics, and storage snapshots in a dedicated SQLite database. This gives you everything in real-time mode plus long-term event tracking, buffered writes, and retention-based cleanup.
 
 ```bash
 bin/rails solid_observer:install:migrations
 bin/rails db:create
 bin/rails db:migrate
 ```
+
+No additional configuration needed — persistence is the default `storage_mode`.
 
 ## Quick Start
 
@@ -116,7 +134,7 @@ bin/rails "solid_observer:jobs:retry[JOB_ID]"
 bin/rails "solid_observer:jobs:discard[JOB_ID]"
 ```
 
-### Check Storage
+### Check Storage (Persistence Mode)
 
 ```bash
 bin/rails solid_observer:storage
@@ -142,18 +160,23 @@ After installation, configure SolidObserver in `config/initializers/solid_observ
 
 ```ruby
 SolidObserver.configure do |config|
+  # Storage Mode (:persistence or :realtime)
+  # :persistence — stores events, metrics, snapshots (requires migrations)
+  # :realtime    — live monitoring only, no database needed
+  config.storage_mode = :persistence  # default
+
   # Enable queue monitoring (default: true)
   config.observe_queue = true
 
-  # Data Retention
+  # Data Retention (persistence mode only)
   config.event_retention = 30.days    # Keep events for 30 days
   config.metrics_retention = 90.days  # Keep metrics for 90 days
 
-  # Database Limits
+  # Database Limits (persistence mode only)
   config.max_db_size = 1.gigabyte     # Maximum database size
   config.warning_threshold = 0.8      # Warn at 80% capacity
 
-  # Performance Tuning
+  # Performance Tuning (persistence mode only)
   config.buffer_size = 1000           # Buffer before flushing to DB
   config.flush_interval = 10.seconds  # Flush interval
   config.sampling_rate = 1.0          # 1.0 = capture all events
@@ -192,6 +215,8 @@ When configured, all job events will include your correlation ID, allowing you t
 
 ## CLI Reference
 
+**Available in both modes (real-time and persistence):**
+
 | Command | Description |
 |---------|-------------|
 | `solid_observer:status` | Show queue status overview |
@@ -199,13 +224,18 @@ When configured, all job events will include your correlation ID, allowing you t
 | `solid_observer:jobs:show[ID]` | Show job details |
 | `solid_observer:jobs:retry[ID]` | Retry a failed job |
 | `solid_observer:jobs:discard[ID]` | Discard a failed job |
+
+**Persistence mode only:**
+
+| Command | Description |
+|---------|-------------|
 | `solid_observer:storage` | Show storage statistics |
 | `solid_observer:buffer:flush` | Force flush event buffer to database |
 | `solid_observer:buffer:clear` | Clear buffer without saving |
 | `solid_observer:storage:cleanup` | Run retention-based cleanup |
 | `solid_observer:storage:purge` | Delete ALL SolidObserver data |
 
-> **Note:** These commands manage **SolidObserver's storage** (event logs, metrics, snapshots) - not Solid Queue's jobs. To manage jobs, use `jobs:discard` or `jobs:retry`.
+> **Note:** Storage commands manage **SolidObserver's storage** (event logs, metrics, snapshots) — not Solid Queue's jobs. To manage jobs, use `jobs:discard` or `jobs:retry`.
 
 ### Jobs List Arguments
 
@@ -226,7 +256,7 @@ bin/rails "solid_observer:jobs:list[ready,mailers]"          # Ready jobs in mai
 bin/rails "solid_observer:jobs:list[failed,,,50]"            # 50 failed jobs (skip queue/class)
 ```
 
-### Buffer & Storage Management
+### Buffer & Storage Management (Persistence Mode)
 
 ```bash
 # Flush in-memory buffer to database
@@ -244,7 +274,9 @@ bin/rails solid_observer:storage:purge
 
 > **Important:** `storage:purge` deletes SolidObserver's monitoring data, NOT your Solid Queue jobs. Your queued jobs remain safe.
 
-## Database Setup
+## Database Setup (Persistence Mode)
+
+> **Tip:** If you're using real-time mode (`storage_mode: :realtime`), you can skip this section entirely — no database setup is needed.
 
 **SolidObserver works with any main application database** — PostgreSQL, MySQL, or SQLite.
 
@@ -266,12 +298,13 @@ SolidObserver is actively developed. Here's what's coming:
 
 | Version | Focus | Status |
 |---------|-------|--------|
-| v0.1.0 | Solid Queue monitoring, CLI tools | ✅ Current |
-| v0.2.0 | Solid Cache monitoring | 🔜 Planned |
-| v0.3.0 | Solid Cable monitoring | 🔜 Planned |
-| v0.4.0 | Cross-component correlation, health scores | 🔜 Planned |
-| v0.5.0 | Alerting & notifications | 🔜 Planned |
-| v0.6.0 | Web UI dashboard | 🔜 Planned |
+| v0.1.0 | Solid Queue monitoring, CLI tools | ✅ Released |
+| v0.1.1 | Real-time mode (no migrations needed) | ✅ Current |
+| v0.2.0 | Web UI dashboard (vanilla HTML/CSS) | 🔜 Planned |
+| v0.3.0 | Solid Cache monitoring | 🔜 Planned |
+| v0.4.0 | Solid Cable monitoring | 🔜 Planned |
+| v0.5.0 | Cross-component correlation, health scores | 🔜 Planned |
+| v0.6.0 | Alerting & notifications | 🔜 Planned |
 | v1.0.0 | Production stable release | 🎯 Goal |
 
 See [GitHub Milestones](https://github.com/bart-oz/solid_observer/milestones) for detailed plans.

--- a/lib/solid_observer/cli/storage.rb
+++ b/lib/solid_observer/cli/storage.rb
@@ -4,6 +4,14 @@ module SolidObserver
   module CLI
     class Storage < Base
       def call
+        if SolidObserver.config.realtime_mode?
+          print_section_header("💾 Storage Status")
+          info("Storage monitoring is not available in real-time mode.")
+          info("Switch to persistence mode for event history and storage tracking.")
+          output("")
+          return
+        end
+
         print_section_header("💾 Storage Status")
 
         current_stats = gather_storage_stats

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -38,6 +38,9 @@ module SolidObserver
     # Storage Settings
     attr_accessor :max_db_size
 
+    # Storage Mode
+    attr_reader :storage_mode
+
     # Performance Settings (with validation)
     attr_reader :sampling_rate,
       :warning_threshold,
@@ -54,6 +57,9 @@ module SolidObserver
       @http_basic_auth_enabled = false
       @http_basic_auth_user = nil
       @http_basic_auth_password = nil
+
+      # Storage mode
+      @storage_mode = :persistence
 
       # Observer defaults
       @observe_queue = true
@@ -76,6 +82,23 @@ module SolidObserver
 
       # Correlation defaults
       @correlation_id_generator = nil
+    end
+
+    STORAGE_MODES = %i[persistence realtime].freeze
+
+    def storage_mode=(value)
+      value = value.to_sym
+      raise ArgumentError, "storage_mode must be :persistence or :realtime" unless STORAGE_MODES.include?(value)
+
+      @storage_mode = value
+    end
+
+    def persistence_mode?
+      @storage_mode == :persistence
+    end
+
+    def realtime_mode?
+      @storage_mode == :realtime
     end
 
     def sampling_rate=(value)

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -12,6 +12,8 @@ module SolidObserver
       end
 
       def configure_database_connection
+        return if SolidObserver.config.realtime_mode?
+
         db_config = ActiveRecord::Base.configurations.configs_for(
           env_name: Rails.env,
           name: "solid_observer_queue"
@@ -30,12 +32,15 @@ module SolidObserver
       def activate_subscribers
         logger = Rails.logger
 
-        unless table_exists?("solid_observer_queue_events")
+        if SolidObserver.config.realtime_mode?
+          logger.info "[SolidObserver] Starting in real-time mode (no persistence)"
+        elsif !table_exists?("solid_observer_queue_events")
           logger.info "[SolidObserver] Tables not found. Run: rails solid_observer:install:migrations && rails db:migrate"
           return
+        else
+          logger.info "[SolidObserver] Activating event subscribers"
         end
 
-        logger.info "[SolidObserver] Activating event subscribers"
         Subscriber.subscribe!
       rescue ActiveRecord::NoDatabaseError
         logger.info "[SolidObserver] Database not ready yet. Skipping subscriber activation."

--- a/lib/solid_observer/queue_event_buffer.rb
+++ b/lib/solid_observer/queue_event_buffer.rb
@@ -25,12 +25,15 @@ module SolidObserver
     # @param event_data [Hash] Event data to buffer
     # @return [void]
     def push(event_data)
+      config = SolidObserver.config
+      return unless config.persistence_mode?
+
       should_flush = false
 
       @mutex.synchronize do
         @buffer << event_data
         schedule_flush unless @flush_scheduled
-        should_flush = @buffer.size >= SolidObserver.config.buffer_size
+        should_flush = @buffer.size >= config.buffer_size
       end
 
       flush! if should_flush

--- a/lib/solid_observer/services/cleanup_storage.rb
+++ b/lib/solid_observer/services/cleanup_storage.rb
@@ -8,6 +8,8 @@ module SolidObserver
       end
 
       def call
+        return 0 if SolidObserver.config.realtime_mode?
+
         deleted_count = 0
 
         QueueEvent.transaction do

--- a/lib/solid_observer/services/record_event.rb
+++ b/lib/solid_observer/services/record_event.rb
@@ -81,6 +81,8 @@ module SolidObserver
       end
 
       def increment_metric
+        return unless SolidObserver.config.persistence_mode?
+
         period = Time.current.beginning_of_hour
         QueueMetric.increment(metric: @metric_name, period: period)
       rescue => e

--- a/lib/solid_observer/version.rb
+++ b/lib/solid_observer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidObserver
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
   RUBY_MINIMUM_VERSION = "3.2.0"
   RAILS_MINIMUM_VERSION = "8.0"
 end

--- a/spec/solid_observer/cli/storage_spec.rb
+++ b/spec/solid_observer/cli/storage_spec.rb
@@ -15,7 +15,29 @@ RSpec.describe SolidObserver::CLI::Storage do
     allow(SolidObserver::QueueEvent).to receive(:connection_db_config).and_return(db_config)
   end
 
+  after { SolidObserver.reset_configuration! }
+
   describe "#call" do
+    context "when in realtime mode" do
+      before do
+        SolidObserver.config.storage_mode = :realtime
+      end
+
+      it "displays informative message" do
+        output = capture_stdout { storage_cli.call }
+
+        expect(output).to include("💾 Storage Status")
+        expect(output).to include("not available in real-time mode")
+        expect(output).to include("persistence mode")
+      end
+
+      it "does not query the database" do
+        expect(SolidObserver::QueueEvent).not_to receive(:count)
+
+        capture_stdout { storage_cli.call }
+      end
+    end
+
     context "when database file exists" do
       before do
         FileUtils.mkdir_p(File.dirname(temp_db_path))

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -13,6 +13,64 @@ RSpec.describe SolidObserver::Configuration do
     expect(config.observe_queue).to be true
     expect(config.max_db_size).to eq(1.gigabyte)
     expect(config.warning_threshold).to eq(0.8)
+    expect(config.storage_mode).to eq(:persistence)
+  end
+
+  describe "#storage_mode" do
+    it "defaults to :persistence" do
+      expect(described_class.new.storage_mode).to eq(:persistence)
+    end
+
+    it "accepts :realtime" do
+      config = described_class.new
+      config.storage_mode = :realtime
+      expect(config.storage_mode).to eq(:realtime)
+    end
+
+    it "accepts :persistence" do
+      config = described_class.new
+      config.storage_mode = :persistence
+      expect(config.storage_mode).to eq(:persistence)
+    end
+
+    it "accepts string values" do
+      config = described_class.new
+      config.storage_mode = "realtime"
+      expect(config.storage_mode).to eq(:realtime)
+    end
+
+    it "raises ArgumentError for invalid values" do
+      config = described_class.new
+      expect { config.storage_mode = :invalid }.to raise_error(
+        ArgumentError, "storage_mode must be :persistence or :realtime"
+      )
+    end
+  end
+
+  describe "#persistence_mode?" do
+    it "returns true when storage_mode is :persistence" do
+      config = described_class.new
+      expect(config.persistence_mode?).to be true
+    end
+
+    it "returns false when storage_mode is :realtime" do
+      config = described_class.new
+      config.storage_mode = :realtime
+      expect(config.persistence_mode?).to be false
+    end
+  end
+
+  describe "#realtime_mode?" do
+    it "returns true when storage_mode is :realtime" do
+      config = described_class.new
+      config.storage_mode = :realtime
+      expect(config.realtime_mode?).to be true
+    end
+
+    it "returns false when storage_mode is :persistence" do
+      config = described_class.new
+      expect(config.realtime_mode?).to be false
+    end
   end
 
   it "disables UI in production" do

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe SolidObserver::Engine do
       allow(SolidObserver::Subscriber).to receive(:subscribe!)
     end
 
+    after { SolidObserver.reset_configuration! }
+
     it "activates subscribers when tables exist" do
       allow(connection).to receive(:table_exists?).with("solid_observer_queue_events").and_return(true)
 
@@ -67,6 +69,20 @@ RSpec.describe SolidObserver::Engine do
       expect(logger).to receive(:info).with(/Database not ready/)
 
       described_class.activate_subscribers
+    end
+
+    context "when in realtime mode" do
+      before do
+        SolidObserver.config.storage_mode = :realtime
+      end
+
+      it "subscribes without checking tables" do
+        expect(logger).to receive(:info).with(/real-time mode/)
+        expect(SolidObserver::Subscriber).to receive(:subscribe!)
+        expect(connection).not_to receive(:table_exists?)
+
+        described_class.activate_subscribers
+      end
     end
   end
 

--- a/spec/solid_observer/queue_event_buffer_spec.rb
+++ b/spec/solid_observer/queue_event_buffer_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe SolidObserver::QueueEventBuffer do
         expect(buffer.size).to eq(0)
       end
     end
+
+    context "when in realtime mode" do
+      before do
+        allow(SolidObserver.config).to receive(:persistence_mode?).and_return(false)
+      end
+
+      it "does not add event to buffer" do
+        buffer.push(event_data)
+        expect(buffer.size).to eq(0)
+      end
+    end
   end
 
   describe "#flush!" do

--- a/spec/solid_observer/realtime_mode_spec.rb
+++ b/spec/solid_observer/realtime_mode_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Real-time mode" do
+  after { SolidObserver.reset_configuration! }
+
+  before do
+    SolidObserver.config.storage_mode = :realtime
+  end
+
+  describe "configuration" do
+    it "reports realtime mode" do
+      expect(SolidObserver.config.realtime_mode?).to be true
+      expect(SolidObserver.config.persistence_mode?).to be false
+    end
+  end
+
+  describe "QueueEventBuffer" do
+    subject(:buffer) { SolidObserver::QueueEventBuffer.instance }
+
+    after { buffer.clear }
+
+    it "does not buffer events" do
+      buffer.push({event_type: "job_enqueued", recorded_at: Time.current})
+
+      expect(buffer.size).to eq(0)
+    end
+  end
+
+  describe "RecordEvent" do
+    let(:event) do
+      double(duration: 100.0, payload: {job: {job_id: "123", class_name: "TestJob", queue_name: "default"}})
+    end
+    let(:buffer) { instance_double(SolidObserver::QueueEventBuffer) }
+
+    before do
+      allow(buffer).to receive(:push)
+      allow(SolidObserver::CorrelationIdResolver).to receive(:resolve).and_return("test-id")
+    end
+
+    it "does not increment metrics" do
+      expect(SolidObserver::QueueMetric).not_to receive(:increment)
+
+      SolidObserver::Services::RecordEvent.call(
+        event: event,
+        event_type: "job_completed",
+        buffer: buffer,
+        metric_name: "jobs_completed"
+      )
+    end
+  end
+
+  describe "CleanupStorage" do
+    it "returns 0 without performing any operations" do
+      expect(SolidObserver::QueueEvent).not_to receive(:transaction)
+
+      result = SolidObserver::Services::CleanupStorage.call
+
+      expect(result).to eq(0)
+    end
+  end
+
+  describe "CLI::Storage" do
+    it "shows real-time mode message" do
+      output = capture_stdout { SolidObserver::CLI::Storage.new.call }
+
+      expect(output).to include("not available in real-time mode")
+    end
+  end
+
+  describe "QueueStats" do
+    it "still works (queries SolidQueue directly)" do
+      allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(false)
+
+      stats = SolidObserver::QueueStats.snapshot
+
+      expect(stats).to include(available: false)
+    end
+  end
+
+  private
+
+  def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end

--- a/spec/solid_observer/services/cleanup_storage_spec.rb
+++ b/spec/solid_observer/services/cleanup_storage_spec.rb
@@ -29,7 +29,22 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
     allow(File).to receive(:size).and_return(500.kilobytes)
   end
 
+  after { SolidObserver.reset_configuration! }
+
   describe ".call" do
+    context "when in realtime mode" do
+      before do
+        SolidObserver.config.storage_mode = :realtime
+      end
+
+      it "returns 0 without performing cleanup" do
+        result = described_class.call
+
+        expect(result).to eq(0)
+        expect(SolidObserver::QueueEvent).not_to have_received(:transaction)
+      end
+    end
+
     it "deletes events older than retention period" do
       expect(relation).to receive(:delete_all)
 

--- a/spec/solid_observer/services/record_event_spec.rb
+++ b/spec/solid_observer/services/record_event_spec.rb
@@ -133,6 +133,26 @@ RSpec.describe SolidObserver::Services::RecordEvent do
       end
     end
 
+    context "when in realtime mode" do
+      before do
+        allow(service).to receive(:rand).and_return(0.5)
+        allow(SolidObserver.config).to receive(:sampling_rate).and_return(1.0)
+        allow(SolidObserver.config).to receive(:persistence_mode?).and_return(false)
+      end
+
+      it "does not increment metric" do
+        service.call
+
+        expect(SolidObserver::QueueMetric).not_to have_received(:increment)
+      end
+
+      it "still pushes event to buffer" do
+        service.call
+
+        expect(buffer).to have_received(:push)
+      end
+    end
+
     context "when metric increment fails" do
       before do
         allow(service).to receive(:rand).and_return(0.5)


### PR DESCRIPTION
Enable SolidObserver to operate without its own database via storage_mode: :realtime. Defaults to :persistence for backward compatibility.

- Add storage_mode (:persistence, :realtime) to Configuration
- Guard database connection and subscriber activation in Engine
- Guard RecordEvent, CleanupStorage, and QueueEventBuffer
- Add graceful CLI::Storage message in real-time mode
- Update README with dual-mode installation and roadmap rearrangement