### PR TITLE
[REFACTOR] Web UI polish — CSS utility classes, controller cleanup, test fixes

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -77,6 +77,7 @@ detectors:
       - SolidObserver::Configuration#validate_positive_integer!
       - SolidObserver::Configuration#validate_positive_numeric!
       - SolidObserver::Services::CleanupStorage#format_bytes
+      - SolidObserver::ApplicationHelper#format_bytes
       - SolidObserver::ApplicationHelper#mode_badge
 
   DuplicateMethodCall:
@@ -103,6 +104,7 @@ detectors:
   InstanceVariableAssumption:
     exclude:
       - SolidObserver::Subscriber
+      - SolidObserver::ApplicationController
       - SolidObserver::JobsController
       - SolidObserver::EventsController
 
@@ -116,6 +118,7 @@ detectors:
     exclude:
       - SolidObserver::CorrelationIdResolver#resolve
       - SolidObserver::CLI::Jobs
+      - SolidObserver::JobsController
 
   UncommunicativeVariableName:
     accept:

--- a/app/controllers/solid_observer/application_controller.rb
+++ b/app/controllers/solid_observer/application_controller.rb
@@ -57,14 +57,15 @@ module SolidObserver
       SolidObserver.config.realtime_mode?
     end
 
+    EXECUTION_STATUS_MAP = {
+      "SolidQueue::ReadyExecution" => "ready",
+      "SolidQueue::ScheduledExecution" => "scheduled",
+      "SolidQueue::ClaimedExecution" => "claimed",
+      "SolidQueue::FailedExecution" => "failed"
+    }.freeze
+
     def determine_status(execution)
-      case execution.class.name
-      when "SolidQueue::ReadyExecution" then "ready"
-      when "SolidQueue::ScheduledExecution" then "scheduled"
-      when "SolidQueue::ClaimedExecution" then "claimed"
-      when "SolidQueue::FailedExecution" then "failed"
-      else "unknown"
-      end
+      EXECUTION_STATUS_MAP.fetch(execution.class.name, "unknown")
     end
 
     def normalize_page

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -6,14 +6,8 @@ module SolidObserver
       @stats = QueueStats.snapshot
 
       if persistence_mode?
-        @recent_events = QueueEvent
-          .order(recorded_at: :desc)
-          .limit(10)
-
-        @recent_failures = QueueEvent
-          .by_event_type("job_failed")
-          .order(recorded_at: :desc)
-          .limit(5)
+        @recent_events = QueueEvent.recent(10)
+        @recent_failures = QueueEvent.recent_failures(5)
       end
     end
   end

--- a/app/controllers/solid_observer/events_controller.rb
+++ b/app/controllers/solid_observer/events_controller.rb
@@ -45,10 +45,10 @@ module SolidObserver
     end
 
     def load_available_options
-      distinct_events = SolidObserver::QueueEvent.distinct
+      scope = SolidObserver::QueueEvent.distinct
       @available_event_types = SolidObserver::QueueEvent::EVENT_TYPES
-      @available_job_classes = distinct_events.pluck(:job_class).compact.sort
-      @available_queues = distinct_events.pluck(:queue_name).compact.sort
+      @available_job_classes = scope.pluck(:job_class).compact.sort
+      @available_queues = scope.pluck(:queue_name).compact.sort
     end
 
     def set_event

--- a/app/controllers/solid_observer/jobs_controller.rb
+++ b/app/controllers/solid_observer/jobs_controller.rb
@@ -23,8 +23,8 @@ module SolidObserver
 
     def retry
       id = params[:id]
-      execution = SolidQueue::FailedExecution.find_by(id: id)
-      return redirect_to jobs_path, alert: "Failed job not found" unless execution
+      execution = find_failed_execution(id)
+      return unless execution
 
       execution.retry
       redirect_to jobs_path(status: "failed"), notice: "Job #{id} queued for retry"
@@ -32,8 +32,8 @@ module SolidObserver
 
     def discard
       id = params[:id]
-      execution = SolidQueue::FailedExecution.find_by(id: id)
-      return redirect_to jobs_path, alert: "Failed job not found" unless execution
+      execution = find_failed_execution(id)
+      return unless execution
 
       execution.discard
       redirect_to jobs_path(status: "failed"), notice: "Job #{id} discarded"
@@ -98,11 +98,23 @@ module SolidObserver
       []
     end
 
+    def find_failed_execution(id)
+      execution = SolidQueue::FailedExecution.find_by(id: id)
+      redirect_to jobs_path, alert: "Failed job not found" unless execution
+      execution
+    end
+
     def find_execution(id)
-      SolidQueue::ReadyExecution.find_by(id: id) ||
-        SolidQueue::ScheduledExecution.find_by(id: id) ||
-        SolidQueue::ClaimedExecution.find_by(id: id) ||
-        SolidQueue::FailedExecution.find_by(id: id)
+      [
+        SolidQueue::ReadyExecution,
+        SolidQueue::ScheduledExecution,
+        SolidQueue::ClaimedExecution,
+        SolidQueue::FailedExecution
+      ].each do |type|
+        execution = type.find_by(id: id)
+        return execution if execution
+      end
+      nil
     end
   end
 end

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -18,7 +18,7 @@ module SolidObserver
     }.freeze
 
     def format_bytes(bytes)
-      return "0 B" if bytes.to_i.zero?
+      return "0 B" if bytes.to_f.zero?
 
       if bytes < KB
         "#{bytes.to_i} B"

--- a/app/models/solid_observer/queue_event.rb
+++ b/app/models/solid_observer/queue_event.rb
@@ -19,5 +19,7 @@ module SolidObserver
     scope :by_event_type, ->(event_type) { where(event_type: event_type) }
     scope :since, ->(time) { where("recorded_at >= ?", time) }
     scope :before, ->(time) { where("recorded_at < ?", time) }
+    scope :recent, ->(limit = 10) { order(recorded_at: :desc).limit(limit) }
+    scope :recent_failures, ->(limit = 5) { by_event_type("job_failed").order(recorded_at: :desc).limit(limit) }
   end
 end

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -87,6 +87,32 @@
     .so-usage-bar__fill--ok { background: var(--so-success); }
     .so-usage-bar__fill--warning { background: var(--so-warning); }
     .so-usage-bar__fill--critical { background: var(--so-danger); }
+
+    .so-back-link { margin-bottom: 1rem; }
+    .so-card--spaced { margin-bottom: 1.5rem; }
+    .so-card--error { border-left: 4px solid var(--so-danger); }
+    .so-card__label--danger { color: var(--so-danger); }
+    .so-details td:first-child { width: 150px; font-weight: 600; }
+    .so-pre { margin-top: 1rem; padding: 1rem; background: #f8fafc; border-radius: 4px; overflow-x: auto; }
+    .so-pre--error { margin-top: 0.5rem; background: #fee2e2; font-size: 0.8rem; }
+    .so-actions { margin-top: 1.5rem; }
+    .so-form--inline { display: inline; }
+    .so-btn--disabled { opacity: 0.4; cursor: default; }
+    .so-btn--static { cursor: default; }
+    .so-table--card { margin: 1rem 0; }
+
+    @media (max-width: 768px) {
+      .so-layout { grid-template-columns: 1fr; }
+      .so-sidebar { position: relative; padding: 0.75rem 0; }
+      .so-sidebar__logo { display: inline-block; padding: 0.5rem 1rem; }
+      .so-sidebar__nav { display: flex; flex-wrap: wrap; gap: 0.25rem; padding: 0 0.75rem; }
+      .so-sidebar__nav a { padding: 0.4rem 0.75rem; border-radius: 4px; margin-right: 0; }
+      .so-sidebar__nav a.active { margin-right: 0; border-radius: 4px; }
+      .so-sidebar__mode { display: inline-block; padding: 0.5rem 1rem; border-top: none; margin-top: 0; font-size: 0.7rem; }
+      .so-content { padding: 1rem; }
+      .so-stat-cards { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+      .so-table { display: block; overflow-x: auto; }
+    }
   </style>
 </head>
 <body>
@@ -116,6 +142,14 @@
       <%= yield %>
     </main>
   </div>
+<script>
+  document.addEventListener("submit", function(event) {
+    var confirmEl = event.target.querySelector("[data-confirm]");
+    if (confirmEl && !window.confirm(confirmEl.getAttribute("data-confirm"))) {
+      event.preventDefault();
+    }
+  });
+</script>
 <% if content_for?(:auto_refresh) && SolidObserver.config.ui_refresh_interval.to_i > 0 %>
 <script>
   (function() {

--- a/app/views/solid_observer/events/show.html.erb
+++ b/app/views/solid_observer/events/show.html.erb
@@ -4,35 +4,35 @@
   <h1>Event #<%= @event.id %></h1>
 </div>
 
-<div style="margin-bottom: 1rem;">
+<div class="so-back-link">
   <%= link_to "← Back to Events", events_path(event_type: params[:event_type], job_class: params[:job_class], queue_name: params[:queue_name], from: params[:from], to: params[:to]), class: "so-btn" %>
 </div>
 
-<div class="so-card" style="margin-bottom: 1.5rem;">
-  <table class="so-table">
+<div class="so-card so-card--spaced">
+  <table class="so-table so-details">
     <tbody>
       <tr>
-        <td style="width: 150px; font-weight: 600;">Event Type</td>
+        <td>Event Type</td>
         <td><%= @event.event_type.humanize %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Job Class</td>
+        <td>Job Class</td>
         <td><code><%= @event.job_class %></code></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Queue</td>
+        <td>Queue</td>
         <td><%= @event.queue_name %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Correlation ID</td>
+        <td>Correlation ID</td>
         <td><code><%= @event.correlation_id || "N/A" %></code></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Duration</td>
+        <td>Duration</td>
         <td><%= @event.duration ? format_duration(@event.duration) : "N/A" %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Recorded At</td>
+        <td>Recorded At</td>
         <td><%= @event.recorded_at.strftime("%Y-%m-%d %H:%M:%S.%3N UTC") %></td>
       </tr>
     </tbody>
@@ -42,6 +42,6 @@
 <% if @metadata %>
   <div class="so-card">
     <div class="so-card__label">Metadata</div>
-    <pre style="margin-top: 1rem; padding: 1rem; background: #f8fafc; border-radius: 4px; overflow-x: auto;"><code><%= JSON.pretty_generate(@metadata) %></code></pre>
+    <pre class="so-pre"><code><%= JSON.pretty_generate(@metadata) %></code></pre>
   </div>
 <% end %>

--- a/app/views/solid_observer/jobs/index.html.erb
+++ b/app/views/solid_observer/jobs/index.html.erb
@@ -36,14 +36,14 @@
         <tr>
           <td><%= link_to execution.id, job_path(execution.id) %></td>
           <td><%= job&.class_name || "N/A" %></td>
-          <td><%= job&.queue_name || execution.try(:queue_name) || "N/A" %></td>
+          <td><%= job&.queue_name || execution&.queue_name || "N/A" %></td>
           <td><%= status_badge(determine_status(execution)) %></td>
           <td><%= time_ago_in_words(execution.created_at) %> ago</td>
           <td>
             <%= link_to "View", job_path(execution.id), class: "so-btn" %>
             <% if execution.is_a?(SolidQueue::FailedExecution) %>
-              <%= button_to "Retry", retry_job_path(execution.id), method: :post, class: "so-btn so-btn--primary", form: { style: "display: inline" }, data: { confirm: "Retry job #{execution.id}?" } %>
-              <%= button_to "Discard", discard_job_path(execution.id), method: :post, class: "so-btn so-btn--danger", form: { style: "display: inline" }, data: { confirm: "Discard job #{execution.id}? This cannot be undone." } %>
+              <%= button_to "Retry", retry_job_path(execution.id), method: :post, class: "so-btn so-btn--primary", form: { class: "so-form--inline" }, data: { confirm: "Retry job #{execution.id}?" } %>
+              <%= button_to "Discard", discard_job_path(execution.id), method: :post, class: "so-btn so-btn--danger", form: { class: "so-form--inline" }, data: { confirm: "Discard job #{execution.id}? This cannot be undone." } %>
             <% end %>
           </td>
         </tr>

--- a/app/views/solid_observer/jobs/show.html.erb
+++ b/app/views/solid_observer/jobs/show.html.erb
@@ -4,40 +4,40 @@
   <h1>Job #<%= @execution.id %></h1>
 </div>
 
-<div style="margin-bottom: 1rem;">
+<div class="so-back-link">
   <%= link_to "← Back to Jobs", jobs_path(status: @status), class: "so-btn" %>
 </div>
 
-<div class="so-card" style="margin-bottom: 1.5rem;">
-  <table class="so-table">
+<div class="so-card so-card--spaced">
+  <table class="so-table so-details">
     <tbody>
       <tr>
-        <td style="width: 150px; font-weight: 600;">Job Class</td>
+        <td>Job Class</td>
         <td><code><%= @job&.class_name || "N/A" %></code></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Job ID</td>
+        <td>Job ID</td>
         <td><%= @job&.id || "N/A" %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Status</td>
+        <td>Status</td>
         <td><%= status_badge(@status) %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Queue</td>
-        <td><%= @job&.queue_name || @execution.try(:queue_name) || "N/A" %></td>
+        <td>Queue</td>
+        <td><%= @job&.queue_name || @execution&.queue_name || "N/A" %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Priority</td>
-        <td><%= @execution.try(:priority) || @job&.priority || "N/A" %></td>
+        <td>Priority</td>
+        <td><%= @execution&.priority || @job&.priority || "N/A" %></td>
       </tr>
       <tr>
-        <td style="font-weight: 600;">Created At</td>
+        <td>Created At</td>
         <td><%= @execution.created_at.strftime("%Y-%m-%d %H:%M:%S UTC") %></td>
       </tr>
       <% if @execution.respond_to?(:scheduled_at) && @execution.scheduled_at %>
         <tr>
-          <td style="font-weight: 600;">Scheduled At</td>
+          <td>Scheduled At</td>
           <td><%= @execution.scheduled_at.strftime("%Y-%m-%d %H:%M:%S UTC") %></td>
         </tr>
       <% end %>
@@ -46,32 +46,32 @@
 </div>
 
 <% if @job&.arguments %>
-  <div class="so-card" style="margin-bottom: 1.5rem;">
+  <div class="so-card so-card--spaced">
     <div class="so-card__label">Arguments</div>
-    <pre style="margin-top: 1rem; padding: 1rem; background: #f8fafc; border-radius: 4px; overflow-x: auto;"><code><%= JSON.pretty_generate(@job.arguments) rescue @job.arguments.to_s %></code></pre>
+    <pre class="so-pre"><code><%= JSON.pretty_generate(@job.arguments) rescue @job.arguments.to_s %></code></pre>
   </div>
 <% end %>
 
 <% if @execution.is_a?(SolidQueue::FailedExecution) && @execution.error %>
-  <div class="so-card" style="border-left: 4px solid var(--so-danger);">
-    <div class="so-card__label" style="color: var(--so-danger);">Error Details</div>
-    <table class="so-table" style="margin: 1rem 0;">
+  <div class="so-card so-card--error">
+    <div class="so-card__label so-card__label--danger">Error Details</div>
+    <table class="so-table so-details so-table--card">
       <tbody>
         <tr>
-          <td style="width: 150px; font-weight: 600;">Error Class</td>
+          <td>Error Class</td>
           <td><code><%= @execution.error.exception_class %></code></td>
         </tr>
         <tr>
-          <td style="font-weight: 600;">Message</td>
+          <td>Message</td>
           <td><%= @execution.error.message %></td>
         </tr>
       </tbody>
     </table>
     <div class="so-card__label">Backtrace</div>
-    <pre style="margin-top: 0.5rem; padding: 1rem; background: #fee2e2; border-radius: 4px; overflow-x: auto; font-size: 0.8rem;"><code><%= @execution.error.backtrace&.first(20)&.join("\n") || "No backtrace available" %></code></pre>
+    <pre class="so-pre so-pre--error"><code><%= @execution.error.backtrace&.first(20)&.join("\n") || "No backtrace available" %></code></pre>
   </div>
 
-  <div style="margin-top: 1.5rem;">
+  <div class="so-actions">
     <%= button_to "Retry Job", retry_job_path(@execution.id), method: :post, class: "so-btn so-btn--primary", data: { confirm: "Retry job #{@execution.id}?" } %>
     <%= button_to "Discard Job", discard_job_path(@execution.id), method: :post, class: "so-btn so-btn--danger", data: { confirm: "Discard job #{@execution.id}? This cannot be undone." } %>
   </div>

--- a/app/views/solid_observer/shared/_pagination.html.erb
+++ b/app/views/solid_observer/shared/_pagination.html.erb
@@ -3,15 +3,15 @@
     <% if page > 1 %>
       <%= link_to "Previous", url_for(request.query_parameters.merge(page: page - 1)), class: "so-btn" %>
     <% else %>
-      <span class="so-btn" style="opacity: 0.4; cursor: default;">Previous</span>
+      <span class="so-btn so-btn--disabled">Previous</span>
     <% end %>
 
-    <span class="so-btn" style="cursor: default;">Page <%= page %> of <%= total_pages %></span>
+    <span class="so-btn so-btn--static">Page <%= page %> of <%= total_pages %></span>
 
     <% if page < total_pages %>
       <%= link_to "Next", url_for(request.query_parameters.merge(page: page + 1)), class: "so-btn" %>
     <% else %>
-      <span class="so-btn" style="opacity: 0.4; cursor: default;">Next</span>
+      <span class="so-btn so-btn--disabled">Next</span>
     <% end %>
   </div>
 <% end %>

--- a/app/views/solid_observer/shared/_stat_card.html.erb
+++ b/app/views/solid_observer/shared/_stat_card.html.erb
@@ -1,4 +1,4 @@
-<% local_assigns[:color] ||= nil %>
+<% color = local_assigns[:color] %>
 <div class="so-card">
   <div class="so-card__label"><%= label %></div>
   <div class="so-card__value"<% if color %> style="color: var(--so-<%= color %>)"<% end %>>

--- a/app/views/solid_observer/storages/show.html.erb
+++ b/app/views/solid_observer/storages/show.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <% if @current_storage %>
-  <div class="so-stat-cards" style="margin-bottom: 2rem;">
+  <div class="so-stat-cards">
     <%= render "solid_observer/shared/stat_card", label: "Database Size", value: format_bytes(@current_storage.db_size_bytes) %>
     <%= render "solid_observer/shared/stat_card", label: "Event Count", value: format_number(@current_storage.event_count) %>
     <%= render "solid_observer/shared/stat_card", label: "Last Updated", value: time_ago_in_words(@current_storage.recorded_at) + " ago" %>
@@ -14,7 +14,7 @@
   <% if @storage_history.any? %>
     <div class="so-card">
       <div class="so-card__label">Recent Snapshots</div>
-      <table class="so-table" style="margin-top: 1rem;">
+      <table class="so-table so-table--card">
         <thead>
           <tr>
             <th>Time</th>

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -10,7 +10,7 @@ require "solid_observer"
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 8.1
+    config.load_defaults Rails::VERSION::STRING.to_f
 
     # Dummy app only needs what the engine provides
     config.eager_load = false

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.cache_classes = false
+  config.eager_load = false
+  config.consider_all_requests_local = true
+  config.action_dispatch.show_exceptions = :none
+end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] = "test"
+require_relative "dummy/config/environment"
+require "capybara/rspec"
+
+Capybara.app = Rails.application
+
+# When spec_helper is auto-loaded before feature_helper (via .rspec --require spec_helper),
+# the engine's URL helpers may not be properly included in controllers because controllers
+# were loaded before Rails.application drew the routes. Re-include them explicitly.
+SolidObserver::ApplicationController.include SolidObserver::Engine.routes.url_helpers
+SolidObserver::ApplicationController.helper SolidObserver::Engine.routes.url_helpers
+SolidObserver::ApplicationController.helper SolidObserver::ApplicationHelper
+
+RSpec.configure do |config|
+  config.include Capybara::DSL, type: :feature
+
+  config.before(:suite) do
+    conn = SolidObserver::QueueEvent.connection
+
+    unless conn.table_exists?(:solid_observer_queue_events)
+      conn.create_table :solid_observer_queue_events do |t|
+        t.string :event_type, null: false, limit: 50
+        t.string :job_class, limit: 100
+        t.string :queue_name, limit: 50
+        t.string :correlation_id, limit: 64
+        t.text :metadata
+        t.float :duration
+        t.datetime :recorded_at, null: false
+        t.index :recorded_at
+        t.index :event_type
+        t.index :job_class
+        t.index :queue_name
+      end
+    end
+
+    unless conn.table_exists?(:solid_observer_storage_info)
+      conn.create_table :solid_observer_storage_info do |t|
+        t.integer :event_count, default: 0
+        t.integer :db_size_bytes, default: 0
+        t.datetime :recorded_at, null: false
+        t.index :recorded_at
+      end
+    end
+  end
+
+  config.after(type: :feature) { SolidObserver.reset_configuration! }
+end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "feature_helper"
+
+RSpec.describe "Dashboard", type: :feature do
+  before { SolidObserver.config.storage_mode = :persistence }
+
+  it "displays the Dashboard heading" do
+    visit "/solid_observer"
+    expect(page).to have_css("h1", text: "Dashboard")
+  end
+
+  it "shows the SolidObserver logo in the sidebar" do
+    visit "/solid_observer"
+    expect(page).to have_content("SolidObserver")
+  end
+
+  it "shows Dashboard and Jobs navigation links" do
+    visit "/solid_observer"
+    expect(page).to have_link("Dashboard")
+    expect(page).to have_link("Jobs")
+  end
+
+  context "in persistence mode" do
+    it "shows Events and Storage navigation links" do
+      visit "/solid_observer"
+      expect(page).to have_link("Events")
+      expect(page).to have_link("Storage")
+    end
+
+    it "shows Persistence mode indicator" do
+      visit "/solid_observer"
+      expect(page).to have_content("Persistence")
+    end
+  end
+
+  context "in realtime mode" do
+    before { SolidObserver.config.storage_mode = :realtime }
+
+    it "does not show Events and Storage navigation links" do
+      visit "/solid_observer"
+      expect(page).not_to have_link("Events")
+      expect(page).not_to have_link("Storage")
+    end
+
+    it "shows Real-time mode indicator" do
+      visit "/solid_observer"
+      expect(page).to have_content("Real-time")
+    end
+  end
+
+  context "when UI is disabled" do
+    before { SolidObserver.config.ui_enabled = false }
+
+    it "returns a 404 response" do
+      visit "/solid_observer"
+      expect(page).to have_content("Not Found")
+    end
+  end
+end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "feature_helper"
+
+RSpec.describe "Events", type: :feature do
+  before { SolidObserver.config.storage_mode = :persistence }
+  after { SolidObserver::QueueEvent.delete_all }
+
+  context "in persistence mode" do
+    it "displays the Events heading" do
+      visit "/solid_observer/events"
+      expect(page).to have_css("h1", text: "Events")
+    end
+
+    it "shows filter dropdowns" do
+      visit "/solid_observer/events"
+      expect(page).to have_select("event_type")
+      expect(page).to have_select("job_class")
+      expect(page).to have_select("queue_name")
+    end
+
+    context "when no events exist" do
+      it "displays the empty state message" do
+        visit "/solid_observer/events"
+        expect(page).to have_content("No events found")
+      end
+    end
+
+    context "when events exist" do
+      before do
+        SolidObserver::QueueEvent.create!(
+          event_type: "job_completed",
+          job_class: "MyJob",
+          queue_name: "default",
+          recorded_at: Time.now
+        )
+      end
+
+      it "displays the event in the table" do
+        visit "/solid_observer/events"
+        expect(page).to have_content("MyJob")
+        expect(page).to have_content("default")
+      end
+
+      it "links to the event show page" do
+        visit "/solid_observer/events"
+        expect(page).to have_link("Job completed")
+      end
+    end
+  end
+
+  context "in realtime mode" do
+    before { SolidObserver.config.storage_mode = :realtime }
+
+    it "redirects to dashboard with an alert" do
+      visit "/solid_observer/events"
+      expect(page.current_path).to match(%r{/solid_observer/?$})
+      expect(page).to have_content("not available in real-time mode")
+    end
+  end
+end

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "feature_helper"
+
+RSpec.describe "Jobs", type: :feature do
+  context "when SolidQueue is not available" do
+    it "redirects to dashboard with an alert" do
+      visit "/solid_observer/jobs"
+      expect(page.current_path).to match(%r{/solid_observer/?$})
+    end
+
+    it "displays the SolidQueue unavailable alert" do
+      visit "/solid_observer/jobs"
+      expect(page).to have_content("SolidQueue is not available")
+    end
+  end
+end

--- a/spec/features/storage_spec.rb
+++ b/spec/features/storage_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "feature_helper"
+
+RSpec.describe "Storage", type: :feature do
+  before { SolidObserver.config.storage_mode = :persistence }
+  after { SolidObserver::StorageInfo.delete_all }
+
+  context "in persistence mode" do
+    it "displays the Storage heading" do
+      visit "/solid_observer/storage"
+      expect(page).to have_css("h1", text: "Storage")
+    end
+
+    context "when no storage data exists" do
+      it "displays the empty state message" do
+        visit "/solid_observer/storage"
+        expect(page).to have_content("No storage information available")
+      end
+    end
+
+    context "when storage data exists" do
+      before do
+        SolidObserver::StorageInfo.create!(
+          db_size_bytes: 2_048,
+          event_count: 42,
+          recorded_at: Time.now
+        )
+      end
+
+      it "displays database size stat card" do
+        visit "/solid_observer/storage"
+        expect(page).to have_content("Database Size")
+        expect(page).to have_content("2.0 KB")
+      end
+
+      it "displays event count stat card" do
+        visit "/solid_observer/storage"
+        expect(page).to have_content("Event Count")
+        expect(page).to have_content("42")
+      end
+
+      it "displays the recent snapshots table" do
+        visit "/solid_observer/storage"
+        expect(page).to have_content("Recent Snapshots")
+      end
+    end
+  end
+
+  context "in realtime mode" do
+    before { SolidObserver.config.storage_mode = :realtime }
+
+    it "redirects to dashboard with an alert" do
+      visit "/solid_observer/storage"
+      expect(page.current_path).to match(%r{/solid_observer/?$})
+      expect(page).to have_content("not available in real-time mode")
+    end
+  end
+end

--- a/spec/solid_observer/application_layout_spec.rb
+++ b/spec/solid_observer/application_layout_spec.rb
@@ -249,4 +249,37 @@ RSpec.describe "SolidObserver application layout" do
       end
     end
   end
+
+  describe "confirmation dialog handler" do
+    it "includes a data-confirm submit handler script" do
+      expect(template_source).to include('querySelector("[data-confirm]")')
+    end
+
+    it "shows window.confirm with the message" do
+      expect(template_source).to include("window.confirm")
+    end
+
+    it "prevents form submission when user cancels" do
+      expect(template_source).to include("event.preventDefault()")
+    end
+  end
+
+  describe "responsive design" do
+    it "includes mobile viewport meta tag" do
+      expect(template_source).to include('name="viewport"')
+      expect(template_source).to include("width=device-width")
+    end
+
+    it "includes mobile media query breakpoint" do
+      expect(template_source).to include("@media (max-width: 768px)")
+    end
+
+    it "makes tables horizontally scrollable on mobile" do
+      expect(template_source).to include("overflow-x: auto")
+    end
+
+    it "collapses sidebar to single column on mobile" do
+      expect(template_source).to include("grid-template-columns: 1fr")
+    end
+  end
 end

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -33,15 +33,8 @@ RSpec.describe SolidObserver::DashboardController do
       let(:failures_scope) { double("failures_scope") }
 
       before do
-        ordered = double("ordered")
-        allow(SolidObserver::QueueEvent).to receive(:order).with(recorded_at: :desc).and_return(ordered)
-        allow(ordered).to receive(:limit).with(10).and_return(events_scope)
-
-        by_type = double("by_type")
-        allow(SolidObserver::QueueEvent).to receive(:by_event_type).with("job_failed").and_return(by_type)
-        ordered2 = double("ordered2")
-        allow(by_type).to receive(:order).with(recorded_at: :desc).and_return(ordered2)
-        allow(ordered2).to receive(:limit).with(5).and_return(failures_scope)
+        allow(SolidObserver::QueueEvent).to receive(:recent).with(10).and_return(events_scope)
+        allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(5).and_return(failures_scope)
       end
 
       it "assigns @recent_events" do


### PR DESCRIPTION
- Replace `.try()` with safe navigation (`&.`) in jobs views
- DRY `JobsController` `retry/discard` via `find_failed_execution`; `find_execution` iterates array
- Add `QueueEvent.recent `/ `recent_failures` scopes; `DashboardController` uses them
- Introduce `EXECUTION_STATUS_MAP` hash in `ApplicationController#determine_status`
- Fix `_stat_card` partial: `local_assigns[:color] `→ `color = local_assigns[:color]`
- Fix feature specs: scoped `config.after to` `type: :feature` (fixes benchmark flakiness), use valid `event_type` `job_completed`
- Fix `format_bytes: bytes.to_f.zero?` eliminates duplicate `bytes.to_i `call