### PR TITLE
[SO-045][REFACTORING] Remove allow_any_instance_of and dead private-method specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-93.06%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-94.54%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -74,12 +74,14 @@ RSpec.describe SolidObserver::Configuration do
   end
 
   it "disables UI in production" do
-    allow_any_instance_of(described_class).to receive(:production?).and_return(true)
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+
     expect(described_class.new.ui_enabled).to be false
   end
 
   it "enables UI outside production" do
-    allow_any_instance_of(described_class).to receive(:production?).and_return(false)
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
+
     expect(described_class.new.ui_enabled).to be true
   end
 

--- a/spec/solid_observer/queue_stats_spec.rb
+++ b/spec/solid_observer/queue_stats_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe SolidObserver::QueueStats do
   end
 
   describe ".snapshot" do
-    it "creates an instance and calls #snapshot" do
-      allow_any_instance_of(described_class).to receive(:snapshot).and_return({ready: 0})
+    it "delegates to a new instance" do
+      instance = instance_double(described_class, snapshot: {ready: 0})
+      allow(described_class).to receive(:new).and_return(instance)
+
       expect(described_class.snapshot).to eq({ready: 0})
     end
   end
@@ -156,81 +158,6 @@ RSpec.describe SolidObserver::QueueStats do
           available: false,
           error: "Database connection failed"
         )
-      end
-    end
-  end
-
-  describe "private methods" do
-    let(:queue_stats) { described_class.new }
-
-    describe "#ready_count" do
-      it "queries ReadyExecution count" do
-        ready_execution = double("ReadyExecution", count: 15)
-        stub_const("SolidQueue::ReadyExecution", ready_execution)
-
-        expect(queue_stats.send(:ready_count)).to eq(15)
-      end
-    end
-
-    describe "#scheduled_count" do
-      it "queries ScheduledExecution count" do
-        scheduled_execution = double("ScheduledExecution", count: 20)
-        stub_const("SolidQueue::ScheduledExecution", scheduled_execution)
-
-        expect(queue_stats.send(:scheduled_count)).to eq(20)
-      end
-    end
-
-    describe "#claimed_count" do
-      it "queries ClaimedExecution count" do
-        claimed_execution = double("ClaimedExecution", count: 7)
-        stub_const("SolidQueue::ClaimedExecution", claimed_execution)
-
-        expect(queue_stats.send(:claimed_count)).to eq(7)
-      end
-    end
-
-    describe "#failed_count" do
-      it "queries FailedExecution count" do
-        failed_execution = double("FailedExecution", count: 4)
-        stub_const("SolidQueue::FailedExecution", failed_execution)
-
-        expect(queue_stats.send(:failed_count)).to eq(4)
-      end
-    end
-
-    describe "#active_workers_count" do
-      it "queries Process count for Workers" do
-        process_model = double("Process")
-        stub_const("SolidQueue::Process", process_model)
-        allow(process_model).to receive(:where).with(kind: "Worker").and_return(double(count: 6))
-
-        expect(queue_stats.send(:active_workers_count)).to eq(6)
-      end
-
-      it "returns 0 when Process model is not defined" do
-        hide_const("SolidQueue::Process")
-
-        expect(queue_stats.send(:active_workers_count)).to eq(0)
-      end
-    end
-
-    describe "#queue_depths" do
-      it "groups ReadyExecution by queue_name and counts" do
-        ready_execution = double("ReadyExecution")
-        stub_const("SolidQueue::ReadyExecution", ready_execution)
-
-        group_double = double
-        allow(ready_execution).to receive(:group).with(:queue_name).and_return(group_double)
-        allow(group_double).to receive(:count).and_return({"default" => 10, "mailers" => 5, "urgent" => 2})
-
-        expect(queue_stats.send(:queue_depths)).to eq({"default" => 10, "mailers" => 5, "urgent" => 2})
-      end
-
-      it "returns empty hash when ReadyExecution is not defined" do
-        hide_const("SolidQueue::ReadyExecution")
-
-        expect(queue_stats.send(:queue_depths)).to eq({})
       end
     end
   end

--- a/spec/solid_observer/services/record_event_spec.rb
+++ b/spec/solid_observer/services/record_event_spec.rb
@@ -72,11 +72,13 @@ RSpec.describe SolidObserver::Services::RecordEvent do
         ))
       end
 
-      it "includes metadata as JSON" do
+      it "includes metadata as JSON with job fields" do
         service.call
 
         expect(buffer).to have_received(:push).with(hash_including(
-          metadata: be_a(String)
+          job_class: "TestJob",
+          queue_name: "default",
+          metadata: satisfy { |m| JSON.parse(m).slice("job_id", "arguments", "executions", "priority") == {"job_id" => "test-job-123", "arguments" => [1, 2, 3], "executions" => 1, "priority" => 10} }
         ))
       end
 
@@ -90,6 +92,48 @@ RSpec.describe SolidObserver::Services::RecordEvent do
           metric: "jobs_completed",
           period: current_time.beginning_of_hour
         )
+      end
+    end
+
+    context "with exception data in payload" do
+      let(:event_payload) do
+        {
+          job: {job_id: "test-job-123", class_name: "TestJob", queue_name: "default"},
+          exception_object: StandardError.new("Something went wrong")
+        }
+      end
+
+      before do
+        allow(service).to receive(:rand).and_return(0.5)
+        allow(SolidObserver.config).to receive(:sampling_rate).and_return(1.0)
+      end
+
+      it "includes exception class and message in metadata" do
+        service.call
+
+        expect(buffer).to have_received(:push).with(hash_including(
+          metadata: satisfy { |m|
+            parsed = JSON.parse(m)
+            parsed["exception_class"] == "StandardError" && parsed["exception_message"] == "Something went wrong"
+          }
+        ))
+      end
+    end
+
+    context "with minimal empty payload" do
+      let(:event_payload) { {} }
+
+      before do
+        allow(service).to receive(:rand).and_return(0.5)
+        allow(SolidObserver.config).to receive(:sampling_rate).and_return(1.0)
+      end
+
+      it "handles missing job data gracefully" do
+        service.call
+
+        expect(buffer).to have_received(:push).with(hash_including(
+          metadata: satisfy { |m| JSON.parse(m) == {} }
+        ))
       end
     end
 
@@ -173,61 +217,6 @@ RSpec.describe SolidObserver::Services::RecordEvent do
         expect(Rails.logger).to have_received(:warn).with(
           "[SolidObserver] Metric increment failed: Metric error"
         )
-      end
-    end
-  end
-
-  describe "#build_event_data" do
-    subject(:service) { described_class.new(event, event_type, buffer, metric_name) }
-
-    it "includes correlation_id from resolver" do
-      event_data = service.send(:build_event_data)
-
-      expect(event_data[:correlation_id]).to eq("correlation-123")
-      expect(SolidObserver::CorrelationIdResolver).to have_received(:resolve).with(event)
-    end
-
-    it "extracts job metadata correctly" do
-      event_data = service.send(:build_event_data)
-      metadata = JSON.parse(event_data[:metadata])
-
-      # Top-level columns for efficient querying
-      expect(event_data[:job_class]).to eq("TestJob")
-      expect(event_data[:queue_name]).to eq("default")
-
-      # Remaining metadata in JSON
-      expect(metadata["job_id"]).to eq("test-job-123")
-      expect(metadata["arguments"]).to eq([1, 2, 3])
-      expect(metadata["executions"]).to eq(1)
-      expect(metadata["priority"]).to eq(10)
-    end
-
-    context "with exception data" do
-      let(:exception_obj) { StandardError.new("Something went wrong") }
-      let(:event_payload) do
-        {
-          job: {job_id: "test-job-123", class_name: "TestJob", queue_name: "default"},
-          exception_object: exception_obj
-        }
-      end
-
-      it "includes exception information" do
-        event_data = service.send(:build_event_data)
-        metadata = JSON.parse(event_data[:metadata])
-
-        expect(metadata["exception_class"]).to eq("StandardError")
-        expect(metadata["exception_message"]).to eq("Something went wrong")
-      end
-    end
-
-    context "with minimal payload" do
-      let(:event_payload) { {} }
-
-      it "handles missing job data gracefully" do
-        event_data = service.send(:build_event_data)
-        metadata = JSON.parse(event_data[:metadata])
-
-        expect(metadata).to eq({})
       end
     end
   end


### PR DESCRIPTION
Changes:
- Replace 3x `allow_any_instance_of` with` instance_double` + `Rails.env` stubs
- Delete describe private methods block in `queue_stats_spec` (covered by #snapshot)
- Delete describe `build_event_data` block in `record_event_spec` (covered by #call)
- Add missing #call coverage: job field extraction, exception data, minimal payload