### PR TITLE
[SO-041][FIX] QueueEventBuffer memory leak + unbounded thread spawning

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -10,6 +10,7 @@ detectors:
       - SolidObserver::Configuration
       - SolidObserver::JobsController
       - SolidObserver::EventsController
+      - SolidObserver::QueueEventBuffer
 
   TooManyStatements:
     exclude:
@@ -22,7 +23,9 @@ detectors:
       - CreateSolidObserverStorageInfo#change
       - SolidObserver::QueueEventBuffer#flush!
       - SolidObserver::QueueEventBuffer#push
-      - SolidObserver::QueueEventBuffer#schedule_flush
+      - SolidObserver::QueueEventBuffer#replace_timer_if_stopped
+      - SolidObserver::QueueEventBuffer#requeue_failed_events
+      - SolidObserver::QueueEventBuffer#trim_events_for_capacity
       - SolidObserver::Services::FlushEventBuffer#call
       - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
       - SolidObserver::Services::RecordEvent#extract_metadata
@@ -88,6 +91,8 @@ detectors:
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
       - SolidObserver::Services::CleanupStorage#vacuum_database
       - SolidObserver::QueueEventBuffer#flush!
+      - SolidObserver::QueueEventBuffer#replace_timer_if_stopped
+      - SolidObserver::QueueEventBuffer#record_flush_failure
       - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::RecordEvent#handle_error
       - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
@@ -150,6 +155,7 @@ detectors:
     exclude:
       - SolidObserver::CLI::Jobs
       - SolidObserver::ApplicationController
+      - SolidObserver::QueueEventBuffer
 
 exclude_paths:
   - spec/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
 - Engine boot no longer requires a live database connection (Docker/CI/K8s safe)
 - Table presence check now uses `BaseEvent.connection_pool` instead of `ActiveRecord::Base` (multi-DB safe)
 - Rescue clause in `activate_subscribers` extended to cover `ConnectionNotEstablished`, `StatementInvalid`, and adapter-specific connection errors (`PG::ConnectionBad`, `Mysql2::Error::ConnectionError`, `SQLite3::CantOpenException`)
+- QueueEventBuffer hard-caps at `max_buffer_size` (default 10_000) with configurable overflow strategy; prevents OOM during prolonged DB outages
+- QueueEventBuffer uses a single persistent `Concurrent::TimerTask` for scheduled flushes instead of spawning a new thread every cycle
+
+### Added
+- `SolidObserver::QueueEventBuffer#metrics` — exposes flush latency, failure count, drops count, and last-error for observability
+- `SolidObserver::QueueEventBuffer#shutdown` — graceful drain and timer stop for app-exit hooks
+- `Configuration#max_buffer_size` (default 10_000) and `Configuration#buffer_overflow_strategy` (`:drop_old` default, `:drop_new` alternative)
 
 ### Changed
 - Removed `allow_any_instance_of` anti-pattern from specs; replaced with `instance_double` stubs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     solid_observer (0.1.1)
+      concurrent-ruby (>= 1.3.1)
       rails (>= 8.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-94.62%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-94.84%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "action_text-trix", ">= 2.1.18"
 gem "rails", "~> 8.0.0"
 
 group :development do
@@ -10,15 +11,19 @@ group :development do
   gem "standard", "~> 1.52.0"
   gem "standard-performance", "~> 1.9.0"
   gem "guard-rspec", "~> 4.7.3"
+  gem "benchmark", "~> 0.5.0"
+  gem "puma"
 end
 
 group :test do
+  gem "bundler-audit", "~> 0.9.3"
   gem "appraisal", "~> 2.5"
   gem "capybara", "~> 3.40"
   gem "capybara-screenshot", "~> 1.0.26"
   gem "selenium-webdriver", "~> 4.39.0"
   gem "rspec", "~> 3.13.2"
   gem "simplecov", "~> 0.22.0", require: false
+  gem "sqlite3", "~> 2.5"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "action_text-trix", ">= 2.1.18"
 gem "rails", "~> 8.1.0"
 
 group :development do
@@ -10,15 +11,19 @@ group :development do
   gem "standard", "~> 1.52.0"
   gem "standard-performance", "~> 1.9.0"
   gem "guard-rspec", "~> 4.7.3"
+  gem "benchmark", "~> 0.5.0"
+  gem "puma"
 end
 
 group :test do
+  gem "bundler-audit", "~> 0.9.3"
   gem "appraisal", "~> 2.5"
   gem "capybara", "~> 3.40"
   gem "capybara-screenshot", "~> 1.0.26"
   gem "selenium-webdriver", "~> 4.39.0"
   gem "rspec", "~> 3.13.2"
   gem "simplecov", "~> 0.22.0", require: false
+  gem "sqlite3", "~> 2.5"
 end
 
 gemspec path: "../"

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -45,7 +45,9 @@ module SolidObserver
     attr_reader :sampling_rate,
       :warning_threshold,
       :buffer_size,
-      :flush_interval
+      :flush_interval,
+      :max_buffer_size,
+      :buffer_overflow_strategy
 
     # Correlation Settings
     attr_accessor :correlation_id_generator
@@ -79,12 +81,15 @@ module SolidObserver
       @cache_sampling_rate = 0.1
       @buffer_size = 1000
       @flush_interval = 10.seconds
+      @max_buffer_size = 10_000
+      @buffer_overflow_strategy = :drop_old
 
       # Correlation defaults
       @correlation_id_generator = nil
     end
 
     STORAGE_MODES = %i[persistence realtime].freeze
+    BUFFER_OVERFLOW_STRATEGIES = %i[drop_old drop_new].freeze
 
     def storage_mode=(value)
       value = value.to_sym
@@ -113,12 +118,32 @@ module SolidObserver
 
     def buffer_size=(value)
       validate_positive_integer!(:buffer_size, value)
+      if defined?(@max_buffer_size) && value > @max_buffer_size
+        raise ArgumentError, "buffer_size must be <= max_buffer_size"
+      end
+
       @buffer_size = value
     end
 
     def flush_interval=(value)
       validate_positive_numeric!(:flush_interval, value)
       @flush_interval = value
+    end
+
+    def max_buffer_size=(value)
+      validate_positive_integer!(:max_buffer_size, value)
+      if defined?(@buffer_size) && value < @buffer_size
+        raise ArgumentError, "max_buffer_size must be >= buffer_size"
+      end
+
+      @max_buffer_size = value
+    end
+
+    def buffer_overflow_strategy=(value)
+      value = value.to_sym
+      raise_invalid_buffer_overflow_strategy! unless BUFFER_OVERFLOW_STRATEGIES.include?(value)
+
+      @buffer_overflow_strategy = value
     end
 
     private
@@ -143,6 +168,10 @@ module SolidObserver
 
     def production?
       defined?(Rails) && Rails.env.production?
+    end
+
+    def raise_invalid_buffer_overflow_strategy!
+      raise ArgumentError, "buffer_overflow_strategy must be :drop_old or :drop_new"
     end
   end
 end

--- a/lib/solid_observer/queue_event_buffer.rb
+++ b/lib/solid_observer/queue_event_buffer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "singleton"
+require "concurrent/timer_task"
 
 module SolidObserver
   # Thread-safe buffer for collecting queue events before batch insertion.
@@ -14,10 +15,20 @@ module SolidObserver
   class QueueEventBuffer
     include Singleton
 
+    INITIAL_METRICS = {
+      flush_failures_count: 0,
+      drops_count: 0,
+      last_flush_at: nil,
+      last_flush_duration_ms: nil,
+      last_flush_error: nil
+    }.freeze
+
     def initialize
       @mutex = Mutex.new
+      @metrics_mutex = Mutex.new
       @buffer = []
-      @flush_scheduled = false
+      @metrics = INITIAL_METRICS.dup
+      @timer_task = nil
     end
 
     # Adds an event to the buffer and triggers flush if threshold reached.
@@ -29,13 +40,15 @@ module SolidObserver
       return unless config.persistence_mode?
 
       should_flush = false
+      drops_count = 0
 
       @mutex.synchronize do
-        @buffer << event_data
-        schedule_flush unless @flush_scheduled
+        drops_count = apply_overflow_policy(event_data, config)
         should_flush = @buffer.size >= config.buffer_size
       end
 
+      record_drop(drops_count) if drops_count.positive?
+      ensure_timer_running
       flush! if should_flush
     end
 
@@ -51,10 +64,16 @@ module SolidObserver
         @buffer.clear
       end
 
-      Services::FlushEventBuffer.call(events_to_flush)
-    rescue => e
-      @mutex.synchronize { @buffer.unshift(*events_to_flush) }
-      Rails.logger&.error "[SolidObserver] Buffer flush failed: #{e.message}" if defined?(Rails)
+      started_at_ms = monotonic_ms
+      begin
+        Services::FlushEventBuffer.call(events_to_flush)
+      rescue => e
+        requeue_failed_events(events_to_flush)
+        record_flush_failure(e)
+        Rails.logger&.error "[SolidObserver] Buffer flush failed: #{e.message}" if defined?(Rails)
+        return
+      end
+      record_flush_success(monotonic_ms - started_at_ms)
     end
 
     def size
@@ -65,19 +84,132 @@ module SolidObserver
       @mutex.synchronize { @buffer.clear }
     end
 
+    def metrics
+      current_size = @mutex.synchronize { @buffer.size }
+      snapshot = @metrics_mutex.synchronize { @metrics.dup }
+      {
+        size: current_size,
+        max_buffer_size: SolidObserver.config.max_buffer_size
+      }.merge(snapshot)
+    end
+
+    def shutdown
+      stop_timer
+      flush!
+    end
+
     private
 
-    def schedule_flush
-      @flush_scheduled = true
-      thread = Thread.new do
-        sleep SolidObserver.config.flush_interval
-        @mutex.synchronize { @flush_scheduled = false }
-        flush!
-      rescue => e
-        Rails.logger&.error "[SolidObserver] Scheduled flush failed: #{e.message}" if defined?(Rails)
+    def apply_overflow_policy(event_data, config)
+      if @buffer.size < config.max_buffer_size
+        @buffer << event_data
+        return 0
       end
-      thread.name = "SolidObserver::QueueEventBuffer#flush"
-      thread.report_on_exception = false
+
+      handle_overflow(event_data, config.buffer_overflow_strategy)
+    end
+
+    def handle_overflow(event_data, overflow_strategy)
+      case overflow_strategy
+      when :drop_old
+        @buffer.shift
+        @buffer << event_data
+      when :drop_new
+        # No-op: drop incoming event, keep oldest buffered events.
+      else
+        raise ArgumentError, "Unsupported buffer_overflow_strategy: #{overflow_strategy.inspect}"
+      end
+
+      1
+    end
+
+    def requeue_failed_events(events_to_flush)
+      return unless events_to_flush
+
+      config = SolidObserver.config
+      dropped_count = 0
+
+      @mutex.synchronize do
+        combined_events = events_to_flush + @buffer
+        combined_events, dropped_count = trim_events_for_capacity(combined_events, config.max_buffer_size)
+        @buffer.replace(combined_events)
+      end
+
+      record_drop(dropped_count) if dropped_count.positive?
+    end
+
+    def trim_events_for_capacity(events, max_buffer_size)
+      events_size = events.size
+      return [events, 0] if events_size <= max_buffer_size
+
+      dropped_count = events_size - max_buffer_size
+      overflow_strategy = SolidObserver.config.buffer_overflow_strategy
+      kept_events =
+        if overflow_strategy == :drop_old
+          events.last(max_buffer_size)
+        else
+          events.first(max_buffer_size)
+        end
+
+      [kept_events, dropped_count]
+    end
+
+    def ensure_timer_running
+      timer_to_start, timer_to_stop = replace_timer_if_stopped
+      return unless timer_to_start
+
+      timer_to_stop&.shutdown
+      timer_to_start.execute
+    end
+
+    def replace_timer_if_stopped
+      @mutex.synchronize do
+        current_timer_task = @timer_task
+        return [nil, nil] if current_timer_task && !current_timer_task.shuttingdown?
+
+        @timer_task = Concurrent::TimerTask.new(
+          execution_interval: SolidObserver.config.flush_interval,
+          run_now: false
+        ) { flush! }
+        [@timer_task, current_timer_task]
+      end
+    end
+
+    def stop_timer
+      timer_to_stop = @mutex.synchronize do
+        current_timer = @timer_task
+        @timer_task = nil
+        current_timer
+      end
+
+      timer_to_stop&.shutdown
+    end
+
+    def record_flush_success(duration_ms)
+      @metrics_mutex.synchronize do
+        @metrics.merge!(
+          last_flush_at: Time.current,
+          last_flush_duration_ms: duration_ms,
+          last_flush_error: nil
+        )
+      end
+    end
+
+    def record_flush_failure(error)
+      @metrics_mutex.synchronize do
+        @metrics[:flush_failures_count] += 1
+        @metrics[:last_flush_error] = error.message
+      end
+    end
+
+    def record_drop(count = 1)
+      @metrics_mutex.synchronize do
+        @metrics[:drops_count] += count
+      end
+    end
+
+    def monotonic_ms
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
     end
   end
 end

--- a/solid_observer.gemspec
+++ b/solid_observer.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= #{SolidObserver::RUBY_MINIMUM_VERSION}"
   spec.add_dependency "rails", ">= #{SolidObserver::RAILS_MINIMUM_VERSION}"
+  spec.add_dependency "concurrent-ruby", ">= 1.3.1"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/spec/performance/benchmark_spec.rb
+++ b/spec/performance/benchmark_spec.rb
@@ -28,11 +28,14 @@ RSpec.describe "Performance Benchmarks", type: :performance do
     end
 
     @original_buffer_size = SolidObserver.config.buffer_size
+    @original_max_buffer_size = SolidObserver.config.max_buffer_size
+    SolidObserver.config.max_buffer_size = 100_000
     SolidObserver.config.buffer_size = 100_000
   end
 
   after(:all) do
     SolidObserver.config.buffer_size = @original_buffer_size if @original_buffer_size
+    SolidObserver.config.max_buffer_size = @original_max_buffer_size if @original_max_buffer_size
   end
 
   let(:buffer) { SolidObserver::QueueEventBuffer.instance }

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SolidObserver::Configuration do
 
     expect(config.sampling_rate).to eq(1.0)
     expect(config.buffer_size).to eq(1000)
+    expect(config.max_buffer_size).to eq(10_000)
+    expect(config.buffer_overflow_strategy).to eq(:drop_old)
     expect(config.observe_queue).to be true
     expect(config.max_db_size).to eq(1.gigabyte)
     expect(config.warning_threshold).to eq(0.8)
@@ -70,6 +72,75 @@ RSpec.describe SolidObserver::Configuration do
     it "returns false when storage_mode is :persistence" do
       config = described_class.new
       expect(config.realtime_mode?).to be false
+    end
+  end
+
+  describe "#max_buffer_size" do
+    it "accepts positive integers greater than or equal to buffer_size" do
+      config = described_class.new
+      config.buffer_size = 1000
+      config.max_buffer_size = 5000
+
+      expect(config.max_buffer_size).to eq(5000)
+    end
+
+    it "raises when value is not a positive integer" do
+      config = described_class.new
+
+      expect { config.max_buffer_size = 0 }.to raise_error(
+        ArgumentError, "max_buffer_size must be a positive integer"
+      )
+    end
+
+    it "raises when value is smaller than buffer_size" do
+      config = described_class.new
+      config.buffer_size = 300
+
+      expect { config.max_buffer_size = 299 }.to raise_error(
+        ArgumentError, "max_buffer_size must be >= buffer_size"
+      )
+    end
+  end
+
+  describe "#buffer_size" do
+    it "raises when value is greater than max_buffer_size" do
+      config = described_class.new
+      config.max_buffer_size = 2000
+
+      expect { config.buffer_size = 2001 }.to raise_error(
+        ArgumentError, "buffer_size must be <= max_buffer_size"
+      )
+    end
+  end
+
+  describe "#buffer_overflow_strategy" do
+    it "accepts :drop_old" do
+      config = described_class.new
+      config.buffer_overflow_strategy = :drop_old
+
+      expect(config.buffer_overflow_strategy).to eq(:drop_old)
+    end
+
+    it "accepts :drop_new" do
+      config = described_class.new
+      config.buffer_overflow_strategy = :drop_new
+
+      expect(config.buffer_overflow_strategy).to eq(:drop_new)
+    end
+
+    it "accepts string values" do
+      config = described_class.new
+      config.buffer_overflow_strategy = "drop_new"
+
+      expect(config.buffer_overflow_strategy).to eq(:drop_new)
+    end
+
+    it "raises for unsupported values" do
+      config = described_class.new
+
+      expect { config.buffer_overflow_strategy = :invalid }.to raise_error(
+        ArgumentError, "buffer_overflow_strategy must be :drop_old or :drop_new"
+      )
     end
   end
 

--- a/spec/solid_observer/queue_event_buffer_spec.rb
+++ b/spec/solid_observer/queue_event_buffer_spec.rb
@@ -5,8 +5,20 @@ require "spec_helper"
 RSpec.describe SolidObserver::QueueEventBuffer do
   subject(:buffer) { described_class.instance }
 
+  before do
+    SolidObserver.reset_configuration!
+    buffer.shutdown
+    buffer.clear
+  end
+
   after do
     buffer.clear
+    buffer.shutdown
+    SolidObserver.reset_configuration!
+  end
+
+  after(:all) do
+    described_class.instance.shutdown
   end
 
   describe "#push" do
@@ -177,6 +189,222 @@ RSpec.describe SolidObserver::QueueEventBuffer do
 
     it "cannot be instantiated directly" do
       expect { described_class.new }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe "#metrics" do
+    let(:event_data) { {event_type: "test", recorded_at: Time.current} }
+
+    before do
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call)
+    end
+
+    it "returns exactly the expected keys" do
+      expect(buffer.metrics.keys).to eq(
+        %i[
+          size
+          max_buffer_size
+          flush_failures_count
+          drops_count
+          last_flush_at
+          last_flush_duration_ms
+          last_flush_error
+        ]
+      )
+    end
+
+    it "tracks successful flush metadata" do
+      buffer.push(event_data)
+      buffer.flush!
+
+      metrics = buffer.metrics
+      expect(metrics[:last_flush_at]).to be_a(Time)
+      expect(metrics[:last_flush_duration_ms]).to be_a(Numeric)
+      expect(metrics[:last_flush_error]).to be_nil
+    end
+
+    it "tracks flush failures and last error" do
+      logger = instance_double(Logger, error: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call).and_raise(StandardError, "DB down")
+
+      initial_failures = buffer.metrics[:flush_failures_count]
+      buffer.push(event_data)
+      buffer.flush!
+
+      metrics = buffer.metrics
+      expect(metrics[:flush_failures_count]).to eq(initial_failures + 1)
+      expect(metrics[:last_flush_error]).to eq("DB down")
+    end
+  end
+
+  describe "#shutdown" do
+    let(:event_data) { {event_type: "test", recorded_at: Time.current} }
+
+    before do
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call)
+      SolidObserver.config.buffer_size = 1000
+      SolidObserver.config.flush_interval = 60
+    end
+
+    it "drains buffered events and stops the timer" do
+      2.times { buffer.push(event_data) }
+      expect(buffer.instance_variable_get(:@timer_task)).not_to be_nil
+
+      buffer.shutdown
+
+      expect(SolidObserver::Services::FlushEventBuffer).to have_received(:call).with(array_including(event_data))
+      expect(buffer.size).to eq(0)
+      expect(buffer.instance_variable_get(:@timer_task)).to be_nil
+    end
+
+    it "allows timer restart after shutdown on subsequent push" do
+      buffer.push(event_data)
+      buffer.shutdown
+
+      expect(buffer.instance_variable_get(:@timer_task)).to be_nil
+
+      buffer.push(event_data)
+
+      expect(buffer.instance_variable_get(:@timer_task)).not_to be_nil
+    end
+  end
+
+  describe "overflow policy" do
+    before do
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call)
+      SolidObserver.config.buffer_size = 3
+      SolidObserver.config.max_buffer_size = 3
+      allow(SolidObserver.config).to receive(:buffer_size).and_return(100)
+    end
+
+    context "when strategy is :drop_old" do
+      before do
+        SolidObserver.config.buffer_overflow_strategy = :drop_old
+      end
+
+      it "keeps newest events when over capacity" do
+        5.times { |i| buffer.push({id: i + 1, event_type: "test"}) }
+
+        payload = nil
+        allow(SolidObserver::Services::FlushEventBuffer).to receive(:call) { |events| payload = events }
+        buffer.flush!
+
+        expect(payload.map { |event| event[:id] }).to eq([3, 4, 5])
+      end
+
+      it "increments drops_count when overflowing" do
+        initial_drops = buffer.metrics[:drops_count]
+        5.times { |i| buffer.push({id: i + 1, event_type: "test"}) }
+
+        expect(buffer.metrics[:drops_count]).to eq(initial_drops + 2)
+      end
+    end
+
+    context "when strategy is :drop_new" do
+      before do
+        SolidObserver.config.buffer_overflow_strategy = :drop_new
+      end
+
+      it "keeps oldest events when over capacity" do
+        5.times { |i| buffer.push({id: i + 1, event_type: "test"}) }
+
+        payload = nil
+        allow(SolidObserver::Services::FlushEventBuffer).to receive(:call) { |events| payload = events }
+        buffer.flush!
+
+        expect(payload.map { |event| event[:id] }).to eq([1, 2, 3])
+      end
+
+      it "increments drops_count when overflowing" do
+        initial_drops = buffer.metrics[:drops_count]
+        5.times { |i| buffer.push({id: i + 1, event_type: "test"}) }
+
+        expect(buffer.metrics[:drops_count]).to eq(initial_drops + 2)
+      end
+    end
+  end
+
+  describe "failure resilience" do
+    let(:event_data) { {event_type: "test", recorded_at: Time.current} }
+
+    before do
+      logger = instance_double(Logger, error: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call).and_raise(StandardError, "DB down")
+      SolidObserver.config.buffer_size = 25
+      SolidObserver.config.max_buffer_size = 50
+      SolidObserver.config.flush_interval = 60
+      SolidObserver.config.buffer_overflow_strategy = :drop_old
+    end
+
+    it "keeps buffer bounded during 100 consecutive failing flushes" do
+      100.times do
+        100.times { buffer.push(event_data) }
+        buffer.flush!
+        expect(buffer.size).to be <= 50
+      end
+    end
+  end
+
+  describe "high-concurrency pushes" do
+    let(:event_data) { {event_type: "test", recorded_at: Time.current} }
+
+    before do
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call)
+      SolidObserver.config.max_buffer_size = 5000
+      SolidObserver.config.buffer_size = 5000
+      allow(SolidObserver.config).to receive(:buffer_size).and_return(20_000)
+      SolidObserver.config.flush_interval = 60
+      SolidObserver.config.buffer_overflow_strategy = :drop_old
+    end
+
+    it "preserves invariant: size + drops_count == pushes" do
+      initial_drops = buffer.metrics[:drops_count]
+      threads = 100.times.map do
+        Thread.new do
+          100.times { buffer.push(event_data) }
+        end
+      end
+      threads.each(&:join)
+
+      metrics = buffer.metrics
+      expect(metrics[:size] + (metrics[:drops_count] - initial_drops)).to eq(10_000)
+      expect(metrics[:size]).to be <= 5000
+    end
+  end
+
+  describe "timer lifecycle" do
+    let(:event_data) { {event_type: "test", recorded_at: Time.current} }
+
+    before do
+      allow(SolidObserver::Services::FlushEventBuffer).to receive(:call)
+      SolidObserver.config.buffer_size = 1000
+      SolidObserver.config.max_buffer_size = 10_000
+      SolidObserver.config.flush_interval = 0.02
+    end
+
+    it "starts lazily on first push" do
+      expect(buffer.instance_variable_get(:@timer_task)).to be_nil
+
+      buffer.push(event_data)
+
+      expect(buffer.instance_variable_get(:@timer_task)).not_to be_nil
+    end
+
+    it "uses one persistent timer across flush cycles without thread growth" do
+      baseline_threads = Thread.list.size
+
+      buffer.push(event_data)
+      timer_task = buffer.instance_variable_get(:@timer_task)
+
+      10.times do
+        sleep(0.03)
+        buffer.push(event_data)
+        expect(buffer.instance_variable_get(:@timer_task)).to be(timer_task)
+      end
+
+      expect(Thread.list.size).to be <= baseline_threads + 4
     end
   end
 end

--- a/spec/solid_observer/subscriber_spec.rb
+++ b/spec/solid_observer/subscriber_spec.rb
@@ -4,6 +4,10 @@ require "spec_helper"
 
 RSpec.describe SolidObserver::Subscriber do
   before do
+    # Engine boot (via dummy app) subscribes globally. Clear before each example
+    # so tests operate on a fresh notifier state and assertions aren't affected
+    # by pre-existing ActiveSupport::Notifications listeners.
+    described_class.unsubscribe!
     allow(SolidObserver::Services::RecordEvent).to receive(:call)
   end
 
@@ -139,9 +143,9 @@ RSpec.describe SolidObserver::Subscriber do
       expect(described_class.subscribed?).to be false
     end
 
-    it "does nothing when not subscribed" do
-      described_class.instance_variable_set(:@subscriptions, nil)
+    it "is a no-op when called without prior subscribe" do
       expect { described_class.unsubscribe! }.not_to raise_error
+      expect(described_class.subscribed?).to be false
     end
   end
 


### PR DESCRIPTION
## Summary of changes

- Cap buffer at `max_buffer_size` (10_000 default) with `:drop_old` / `:drop_new` strategies
- Replace thread-per-cycle scheduling with single persistent `Concurrent::TimerTask`
- Add `#metrics` (size, drops, failures, last flush timing/error) and `#shutdown` for graceful drain
- Declare `concurrent-ruby (>= 1.3.1)` explicitly in gemspec (previously transitive via Rails)
- Also: re-sync `gemfiles/rails_8.{0,1}.gemfile` with root Gemfile - stale since Jan 2026, required for appraisal suites to run
