### PR TITLE
[SO-040][REFACTOR] Simplify DatabaseSize + CleanupStorage after review

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -29,6 +29,7 @@ detectors:
       - SolidObserver::Services::FlushEventBuffer#call
       - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
       - SolidObserver::Services::RecordEvent#extract_metadata
+      - SolidObserver::Services::DatabaseSize#call
       - SolidObserver::Services::CleanupStorage#call
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
       - SolidObserver::Services::CleanupStorage#vacuum_database
@@ -38,7 +39,6 @@ detectors:
       - SolidObserver::CLI::Jobs#retry_job
       - SolidObserver::CLI::Jobs#discard
       - SolidObserver::CLI::Storage#call
-      - SolidObserver::CLI::Storage#calculate_database_size
       - SolidObserver::CLI::Storage#print_configuration
       - SolidObserver::Engine#activate_subscribers
       - SolidObserver::Engine#self.activate_subscribers
@@ -112,6 +112,7 @@ detectors:
       - SolidObserver::ApplicationController
       - SolidObserver::JobsController
       - SolidObserver::EventsController
+      - SolidObserver::Services::CleanupStorage
 
   MissingSafeMethod:
     exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,13 @@
 - Rescue clause in `activate_subscribers` extended to cover `ConnectionNotEstablished`, `StatementInvalid`, and adapter-specific connection errors (`PG::ConnectionBad`, `Mysql2::Error::ConnectionError`, `SQLite3::CantOpenException`)
 - QueueEventBuffer hard-caps at `max_buffer_size` (default 10_000) with configurable overflow strategy; prevents OOM during prolonged DB outages
 - QueueEventBuffer uses a single persistent `Concurrent::TimerTask` for scheduled flushes instead of spawning a new thread every cycle
+- Storage monitoring now uses adapter-native size queries (SQLite/PostgreSQL/MySQL/Trilogy) instead of filesystem path checks, fixing `0 MB` false readings on non-SQLite deployments
 
 ### Added
 - `SolidObserver::QueueEventBuffer#metrics` — exposes flush latency, failure count, drops count, and last-error for observability
 - `SolidObserver::QueueEventBuffer#shutdown` — graceful drain and timer stop for app-exit hooks
 - `Configuration#max_buffer_size` (default 10_000) and `Configuration#buffer_overflow_strategy` (`:drop_old` default, `:drop_new` alternative)
+- `SolidObserver::Services::DatabaseSize` service for cross-adapter queue table size measurement and shared use in cleanup + CLI
 
 ### Changed
 - Removed `allow_any_instance_of` anti-pattern from specs; replaced with `instance_double` stubs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-94.84%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.15%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---
@@ -136,6 +136,10 @@ bin/rails "solid_observer:jobs:discard[JOB_ID]"
 ```
 
 ### Check Storage (Persistence Mode)
+
+Storage monitoring is cross-adapter: SQLite, PostgreSQL, MySQL, and Trilogy are supported.
+SolidObserver uses adapter-native SQL queries to measure size (not filesystem `File.size`),
+so production deployments report real values even when the database is remote.
 
 ```bash
 bin/rails solid_observer:storage

--- a/lib/solid_observer/cli/storage.rb
+++ b/lib/solid_observer/cli/storage.rb
@@ -29,7 +29,7 @@ module SolidObserver
 
       def gather_storage_stats
         {
-          db_size_bytes: calculate_database_size,
+          db_size_bytes: SolidObserver::Services::DatabaseSize.call(connection: QueueEvent.connection),
           event_count: QueueEvent.count,
           max_size_bytes: SolidObserver.config.max_db_size
         }
@@ -37,35 +37,36 @@ module SolidObserver
         {error: "Failed to gather storage stats: #{e.message}"}
       end
 
-      def calculate_database_size
-        db_config = QueueEvent.connection_db_config
-        db_path = db_config.database
-
-        return 0 unless File.exist?(db_path)
-
-        File.size(db_path)
-      rescue => e
-        warning("Could not calculate database size: #{e.message}")
-        0
-      end
-
       def print_storage_table(stats)
-        size_mb = bytes_to_mb(stats[:db_size_bytes])
-        percentage = calculate_percentage(stats[:db_size_bytes], stats[:max_size_bytes])
-        status = status_indicator(percentage)
+        event_count = stats[:event_count]
+        db_size_bytes = stats[:db_size_bytes]
+        max_size_bytes = stats[:max_size_bytes]
 
         table(
           headers: ["Component", "Size", "Events", "Usage", "Status"],
-          rows: [[
-            "Queue",
-            format_size(size_mb),
-            format_number(stats[:event_count]),
-            "#{percentage}%",
-            status
-          ]]
+          rows: [storage_row(event_count: event_count, db_size_bytes: db_size_bytes, max_size_bytes: max_size_bytes)]
         )
 
         output("")
+      end
+
+      def storage_row(event_count:, db_size_bytes:, max_size_bytes:)
+        size, usage, status = storage_displays(db_size_bytes, max_size_bytes)
+
+        [
+          "Queue",
+          size,
+          format_number(event_count),
+          usage,
+          status
+        ]
+      end
+
+      def storage_displays(db_size_bytes, max_size_bytes)
+        return ["N/A", "N/A", "— Unknown"] unless db_size_bytes
+
+        percentage = calculate_percentage(db_size_bytes, max_size_bytes)
+        [format_size(bytes_to_mb(db_size_bytes)), "#{percentage}%", status_indicator(percentage)]
       end
 
       def print_configuration

--- a/lib/solid_observer/services/cleanup_storage.rb
+++ b/lib/solid_observer/services/cleanup_storage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "database_size"
+
 module SolidObserver
   module Services
     class CleanupStorage
@@ -36,12 +38,10 @@ module SolidObserver
       end
 
       def record_snapshot_after_cleanup
-        db_size = calculate_database_size
-        event_count = QueueEvent.count
-
+        # StorageInfo.db_size_bytes is NOT NULL; record_snapshot coerces nil to 0.
         StorageInfo.record_snapshot(
-          db_size: db_size,
-          event_count: event_count
+          db_size: current_database_size,
+          event_count: QueueEvent.count
         )
       end
 
@@ -59,23 +59,23 @@ module SolidObserver
         Rails.logger.warn "[SolidObserver] Database maintenance failed: #{e.message}"
       end
 
-      def calculate_database_size
-        db_path = QueueEvent.connection_db_config.database
-        File.size(db_path) if File.exist?(db_path)
-      rescue => e
-        Rails.logger.warn "[SolidObserver] Could not calculate DB size: #{e.message}"
-        0
-      end
-
       def check_storage_warnings
+        current_size = current_database_size
+        return unless current_size
+
         max_size = SolidObserver.config.max_db_size
         threshold = SolidObserver.config.warning_threshold
-        current_size = calculate_database_size
 
         return unless current_size > (max_size * threshold)
 
         percentage = ((current_size.to_f / max_size) * 100).round(1)
         Rails.logger.warn "[SolidObserver] Queue DB approaching limit: #{format_bytes(current_size)} / #{format_bytes(max_size)} (#{percentage}%)"
+      end
+
+      def current_database_size
+        return @current_database_size if defined?(@current_database_size)
+
+        @current_database_size = DatabaseSize.call(connection: QueueEvent.connection)
       end
 
       def log_results(deleted_count)

--- a/lib/solid_observer/services/database_size.rb
+++ b/lib/solid_observer/services/database_size.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    # Returns bytes used by solid_observer_queue_events across supported adapters.
+    #
+    # SQLite uses whole-database page accounting; PostgreSQL and MySQL/Trilogy
+    # use table + index size from adapter-native system functions.
+    class DatabaseSize
+      TABLE_NAME = "solid_observer_queue_events"
+
+      def self.call(connection:)
+        new(connection).call
+      end
+
+      def initialize(connection)
+        @connection = connection
+      end
+
+      def call
+        case adapter_key
+        when :sqlite then sqlite_size
+        when :postgresql then postgresql_size
+        when :mysql then mysql_size
+        else
+          log_unknown_adapter
+          nil
+        end
+      rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished => e
+        Rails.logger&.warn("[SolidObserver] DatabaseSize query failed: #{e.message}")
+        nil
+      end
+
+      private
+
+      attr_reader :connection
+
+      def adapter_key
+        case connection.adapter_name.to_s.downcase
+        when /sqlite/ then :sqlite
+        when /postgres|postgis/ then :postgresql
+        when "mysql2", "trilogy" then :mysql
+        end
+      end
+
+      def sqlite_size
+        connection.query_value("SELECT pragma_page_count() * pragma_page_size()")&.to_i
+      end
+
+      def postgresql_size
+        quoted_table = connection.quote(TABLE_NAME)
+        connection.query_value("SELECT pg_total_relation_size(#{quoted_table})")&.to_i
+      end
+
+      def mysql_size
+        quoted_table = connection.quote(TABLE_NAME)
+
+        connection.query_value(<<~SQL)&.to_i
+          SELECT COALESCE(data_length + index_length, 0)
+          FROM information_schema.tables
+          WHERE table_schema = DATABASE()
+            AND table_name = #{quoted_table}
+        SQL
+      end
+
+      def log_unknown_adapter
+        Rails.logger&.warn(
+          "[SolidObserver] Unknown adapter for DatabaseSize: " \
+          "#{connection.adapter_name.inspect} — storage monitoring disabled"
+        )
+      end
+    end
+  end
+end

--- a/spec/solid_observer/cli/storage_spec.rb
+++ b/spec/solid_observer/cli/storage_spec.rb
@@ -4,15 +4,13 @@ require "spec_helper"
 
 RSpec.describe SolidObserver::CLI::Storage do
   let(:storage_cli) { described_class.new }
-  let(:temp_db_path) { File.join(Dir.tmpdir, "test_queue_#{Process.pid}.sqlite3") }
+  let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
 
   before do
     allow(SolidObserver.config).to receive(:max_db_size).and_return(1.gigabyte)
     allow(SolidObserver.config).to receive(:warning_threshold).and_return(0.8)
     allow(SolidObserver.config).to receive(:event_retention).and_return(30.days)
-
-    db_config = double("db_config", database: temp_db_path)
-    allow(SolidObserver::QueueEvent).to receive(:connection_db_config).and_return(db_config)
+    allow(SolidObserver::QueueEvent).to receive(:connection).and_return(connection)
   end
 
   after { SolidObserver.reset_configuration! }
@@ -33,20 +31,16 @@ RSpec.describe SolidObserver::CLI::Storage do
 
       it "does not query the database" do
         expect(SolidObserver::QueueEvent).not_to receive(:count)
+        expect(SolidObserver::Services::DatabaseSize).not_to receive(:call)
 
         capture_stdout { storage_cli.call }
       end
     end
 
-    context "when database file exists" do
+    context "when database size is available" do
       before do
-        FileUtils.mkdir_p(File.dirname(temp_db_path))
-        File.write(temp_db_path, "x" * 10_485_760)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(10_485_760)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(45_231)
-      end
-
-      after do
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
 
       it "displays storage status with correct calculations" do
@@ -82,13 +76,8 @@ RSpec.describe SolidObserver::CLI::Storage do
 
     context "when database size exceeds warning threshold" do
       before do
-        FileUtils.mkdir_p(File.dirname(temp_db_path))
-        File.write(temp_db_path, "x" * 891_289_600)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(891_289_600)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100_000)
-      end
-
-      after do
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
 
       it "shows warning indicator" do
@@ -99,7 +88,7 @@ RSpec.describe SolidObserver::CLI::Storage do
       end
 
       it "displays size in GB when over 1024 MB" do
-        File.write(temp_db_path, "x" * 1_610_612_736)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_610_612_736)
 
         output = capture_stdout { storage_cli.call }
 
@@ -107,23 +96,24 @@ RSpec.describe SolidObserver::CLI::Storage do
       end
     end
 
-    context "when database file does not exist" do
+    context "when DatabaseSize returns nil" do
       before do
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(0)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(nil)
+        allow(SolidObserver::QueueEvent).to receive(:count).and_return(1_000)
       end
 
-      it "displays zero size gracefully" do
+      it "displays unknown storage values as N/A" do
         output = capture_stdout { storage_cli.call }
 
-        expect(output).to include("0.0 MB")
-        expect(output).to include("0%")
-        expect(output).to include("✓ OK")
+        expect(output).to include("N/A")
+        expect(output.scan("N/A").length).to be >= 2
+        expect(output).to include("— Unknown")
       end
     end
 
     context "when there is an error gathering stats" do
       before do
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(10_485_760)
         allow(SolidObserver::QueueEvent).to receive(:count).and_raise(StandardError.new("Connection failed"))
       end
 
@@ -135,95 +125,80 @@ RSpec.describe SolidObserver::CLI::Storage do
       end
     end
 
-    context "when database size calculation fails" do
+    context "when DatabaseSize raises an unexpected error" do
       before do
-        allow(File).to receive(:exist?).and_return(true)
-        allow(File).to receive(:size).and_raise(StandardError.new("Permission denied"))
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_raise(StandardError.new("Permission denied"))
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(1000)
       end
 
-      it "displays warning and continues with zero size" do
+      it "displays error message" do
         output = capture_stdout { storage_cli.call }
 
-        expect(output).to include("Could not calculate database size")
-        expect(output).to include("0.0 MB")
+        expect(output).to include("Failed to gather storage stats")
+        expect(output).to include("Permission denied")
       end
     end
 
     context "with different retention periods" do
       it "displays 7 days retention" do
         allow(SolidObserver.config).to receive(:event_retention).and_return(7.days)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-        File.write(temp_db_path, "x" * 1_048_576)
 
         output = capture_stdout { storage_cli.call }
 
         expect(output).to include("Retention: 7 days")
-
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
 
       it "displays 90 days retention" do
         allow(SolidObserver.config).to receive(:event_retention).and_return(90.days)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-        File.write(temp_db_path, "x" * 1_048_576)
 
         output = capture_stdout { storage_cli.call }
 
         expect(output).to include("Retention: 90 days")
-
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
     end
 
     context "with different max_db_size configurations" do
       it "displays 500 MB max size" do
         allow(SolidObserver.config).to receive(:max_db_size).and_return(500.megabytes)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-        File.write(temp_db_path, "x" * 1_048_576) # 1 MB
 
         output = capture_stdout { storage_cli.call }
 
         expect(output).to include("Max size:  500.0 MB per database")
-
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
 
       it "displays 2 GB max size" do
         allow(SolidObserver.config).to receive(:max_db_size).and_return(2.gigabytes)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-        File.write(temp_db_path, "x" * 1_048_576)
 
         output = capture_stdout { storage_cli.call }
 
         expect(output).to include("Max size:  2.0 GB per database")
-
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
     end
 
     context "with different warning thresholds" do
       it "shows warning at 90% threshold" do
         allow(SolidObserver.config).to receive(:warning_threshold).and_return(0.9)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(943_718_400)
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-        File.write(temp_db_path, "x" * 943_718_400)
 
         output = capture_stdout { storage_cli.call }
 
         expect(output).to include("Warning:   90% threshold")
         expect(output).to include("✓ OK")
-
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
       end
     end
 
     context "number formatting" do
       before do
-        File.write(temp_db_path, "x" * 1_048_576)
-      end
-
-      after do
-        File.delete(temp_db_path) if File.exist?(temp_db_path)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
       end
 
       it "formats small numbers without commas" do

--- a/spec/solid_observer/services/cleanup_storage_spec.rb
+++ b/spec/solid_observer/services/cleanup_storage_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
   let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil) }
   let(:relation) { instance_double(ActiveRecord::Relation) }
   let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
-  let(:db_config) { instance_double(ActiveRecord::DatabaseConfigurations::HashConfig, database: "/tmp/test.sqlite3") }
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
@@ -18,15 +17,13 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
     allow(SolidObserver::QueueEvent).to receive(:where).and_return(relation)
     allow(SolidObserver::QueueEvent).to receive(:count).and_return(500)
     allow(SolidObserver::QueueEvent).to receive(:connection).and_return(connection)
-    allow(SolidObserver::QueueEvent).to receive(:connection_db_config).and_return(db_config)
 
     allow(relation).to receive(:delete_all).and_return(10)
     allow(connection).to receive(:execute)
     allow(connection).to receive(:adapter_name).and_return("SQLite")
 
     allow(SolidObserver::StorageInfo).to receive(:record_snapshot)
-    allow(File).to receive(:exist?).and_return(true)
-    allow(File).to receive(:size).and_return(500.kilobytes)
+    allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(500.kilobytes)
   end
 
   after { SolidObserver.reset_configuration! }
@@ -61,8 +58,15 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
 
     it "records snapshot within transaction" do
       expect(SolidObserver::StorageInfo).to receive(:record_snapshot).with(
-        hash_including(:db_size, :event_count)
+        db_size: 500.kilobytes,
+        event_count: 500
       )
+
+      described_class.call
+    end
+
+    it "measures DB size at most once per call" do
+      expect(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).once.and_return(500.kilobytes)
 
       described_class.call
     end
@@ -95,7 +99,7 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
 
     context "when database size exceeds warning threshold" do
       before do
-        allow(File).to receive(:size).with("/tmp/test.sqlite3").and_return(850.kilobytes)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(850.kilobytes)
       end
 
       it "logs warning" do
@@ -107,10 +111,26 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
 
     context "when database size is below warning threshold" do
       before do
-        allow(File).to receive(:size).with("/tmp/test.sqlite3").and_return(500.kilobytes)
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(500.kilobytes)
       end
 
       it "does not log warning" do
+        expect(logger).not_to receive(:warn).with(/Queue DB approaching limit/)
+
+        described_class.call
+      end
+    end
+
+    context "when DatabaseSize returns nil" do
+      before do
+        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(nil)
+      end
+
+      it "records snapshot with nil size and skips warning check" do
+        expect(SolidObserver::StorageInfo).to receive(:record_snapshot).with(
+          db_size: nil,
+          event_count: 500
+        )
         expect(logger).not_to receive(:warn).with(/Queue DB approaching limit/)
 
         described_class.call

--- a/spec/solid_observer/services/database_size_spec.rb
+++ b/spec/solid_observer/services/database_size_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Services::DatabaseSize do
+  let(:logger) { instance_double(Logger, warn: nil) }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(logger)
+  end
+
+  describe ".call" do
+    let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, adapter_name: adapter_name) }
+    let(:adapter_name) { "SQLite" }
+
+    it "returns sqlite size via pragma query" do
+      allow(connection).to receive(:query_value)
+        .with("SELECT pragma_page_count() * pragma_page_size()")
+        .and_return(4_096_000)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to eq(4_096_000)
+    end
+
+    it "returns postgresql table size as integer bytes" do
+      allow(connection).to receive(:adapter_name).and_return("PostgreSQL")
+      allow(connection).to receive(:quote).with("solid_observer_queue_events").and_return("'solid_observer_queue_events'")
+      allow(connection).to receive(:query_value)
+        .with("SELECT pg_total_relation_size('solid_observer_queue_events')")
+        .and_return("134217728")
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to eq(134_217_728)
+    end
+
+    it "treats PostGIS as postgresql" do
+      allow(connection).to receive(:adapter_name).and_return("PostGIS")
+      allow(connection).to receive(:quote).with("solid_observer_queue_events").and_return("'solid_observer_queue_events'")
+      allow(connection).to receive(:query_value)
+        .with("SELECT pg_total_relation_size('solid_observer_queue_events')")
+        .and_return(1024)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to eq(1024)
+    end
+
+    it "returns mysql2 table size from information_schema" do
+      allow(connection).to receive(:adapter_name).and_return("Mysql2")
+      allow(connection).to receive(:quote).with("solid_observer_queue_events").and_return("'solid_observer_queue_events'")
+      allow(connection).to receive(:query_value)
+        .with(
+          a_string_including(
+            "information_schema.tables",
+            "table_schema = DATABASE()",
+            "table_name = 'solid_observer_queue_events'"
+          )
+        )
+        .and_return(67_108_864)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to eq(67_108_864)
+    end
+
+    it "returns trilogy table size from information_schema" do
+      allow(connection).to receive(:adapter_name).and_return("Trilogy")
+      allow(connection).to receive(:quote).with("solid_observer_queue_events").and_return("'solid_observer_queue_events'")
+      allow(connection).to receive(:query_value)
+        .with(a_string_including("information_schema.tables"))
+        .and_return(12_345)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to eq(12_345)
+    end
+
+    it "returns nil and logs one warning for unknown adapter" do
+      allow(connection).to receive(:adapter_name).and_return("Oracle")
+
+      expect(connection).not_to receive(:query_value)
+      expect(logger).to receive(:warn).with(/Unknown adapter for DatabaseSize: "Oracle"/).once
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to be_nil
+    end
+
+    it "rescues StatementInvalid and returns nil" do
+      allow(connection).to receive(:adapter_name).and_return("PostgreSQL")
+      allow(connection).to receive(:quote).with("solid_observer_queue_events").and_return("'solid_observer_queue_events'")
+      allow(connection).to receive(:query_value).and_raise(ActiveRecord::StatementInvalid.new("boom"))
+
+      expect(logger).to receive(:warn).with(/DatabaseSize query failed: boom/)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to be_nil
+    end
+
+    it "rescues ConnectionNotEstablished and returns nil" do
+      allow(connection).to receive(:query_value).and_raise(ActiveRecord::ConnectionNotEstablished.new("offline"))
+
+      expect(logger).to receive(:warn).with(/DatabaseSize query failed: offline/)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when adapter query_value returns nil" do
+      allow(connection).to receive(:adapter_name).and_return("Mysql2")
+      allow(connection).to receive(:quote).with("solid_observer_queue_events").and_return("'solid_observer_queue_events'")
+      allow(connection).to receive(:query_value).and_return(nil)
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to be_nil
+    end
+
+    it "does not rescue NoMethodError" do
+      bad_connection = Object.new
+
+      expect { described_class.call(connection: bad_connection) }.to raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of the changes

- Collapse SIZE_FETCHERS hash + send dispatch into single case/rescue
- Replace UNMEASURED_DATABASE_SIZE sentinel with defined?-memoization
- Clean stale .reek.yml entry for removed calculate_database_size

No behavior change.