### PR TITLE
[SO-042][FIX] EventsController filter cache + composite indexes

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -21,6 +21,7 @@ detectors:
       - CreateSolidObserverQueueEvents#change
       - CreateSolidObserverMetrics#change
       - CreateSolidObserverStorageInfo#change
+      - AddCompositeIndexesToQueueEvents#change
       - SolidObserver::QueueEventBuffer#flush!
       - SolidObserver::QueueEventBuffer#push
       - SolidObserver::QueueEventBuffer#replace_timer_if_stopped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@
 - QueueEventBuffer hard-caps at `max_buffer_size` (default 10_000) with configurable overflow strategy; prevents OOM during prolonged DB outages
 - QueueEventBuffer uses a single persistent `Concurrent::TimerTask` for scheduled flushes instead of spawning a new thread every cycle
 - Storage monitoring now uses adapter-native size queries (SQLite/PostgreSQL/MySQL/Trilogy) instead of filesystem path checks, fixing `0 MB` false readings on non-SQLite deployments
+- EventsController filter dropdowns were full-table scans on every request
 
 ### Added
 - `SolidObserver::QueueEventBuffer#metrics` — exposes flush latency, failure count, drops count, and last-error for observability
 - `SolidObserver::QueueEventBuffer#shutdown` — graceful drain and timer stop for app-exit hooks
 - `Configuration#max_buffer_size` (default 10_000) and `Configuration#buffer_overflow_strategy` (`:drop_old` default, `:drop_new` alternative)
 - `SolidObserver::Services::DatabaseSize` service for cross-adapter queue table size measurement and shared use in cleanup + CLI
+- `Configuration#filter_cache_ttl`; `QueueEvent.distinct_job_classes` / `distinct_queue_names` scopes; composite indexes
 
 ### Changed
 - Removed `allow_any_instance_of` anti-pattern from specs; replaced with `instance_double` stubs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.15%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.28%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---
@@ -134,6 +134,11 @@ bin/rails "solid_observer:jobs:retry[JOB_ID]"
 # Discard a failed job
 bin/rails "solid_observer:jobs:discard[JOB_ID]"
 ```
+
+### Events Page Filters (Web UI)
+
+Filter dropdowns on `/solid_observer/events` (job class and queue) are cached for 1 minute by default and scoped to the configured retention window.
+Tune the cache TTL with `config.filter_cache_ttl`.
 
 ### Check Storage (Persistence Mode)
 
@@ -305,11 +310,12 @@ SolidObserver is actively developed. Here's what's coming:
 |---------|-------|--------|
 | v0.1.0 | Solid Queue monitoring, CLI tools | ✅ Released |
 | v0.1.1 | Real-time mode (no migrations needed) | ✅ Current |
-| v0.2.0 | Web UI dashboard (vanilla HTML/CSS) | 🔜 Planned |
-| v0.3.0 | Solid Cache monitoring | 🔜 Planned |
-| v0.4.0 | Solid Cable monitoring | 🔜 Planned |
-| v0.5.0 | Cross-component correlation, health scores | 🔜 Planned |
-| v0.6.0 | Alerting & notifications | 🔜 Planned |
+| v0.2.0 | Stability & Refactoring | 🔜 In progress |
+| v0.3.0 | Web UI dashboard (vanilla HTML/CSS) | 🔜 In progress |
+| v0.4.0 | Solid Cache monitoring | 🔜 Planned |
+| v0.5.0 | Solid Cable monitoring | 🔜 Planned |
+| v0.6.0 | Cross-component correlation, health scores | 🔜 Planned |
+| v0.7.0 | Alerting & notifications | 🔜 Planned |
 | v1.0.0 | Production stable release | 🎯 Goal |
 
 See [GitHub Milestones](https://github.com/bart-oz/solid_observer/milestones) for detailed plans.

--- a/app/controllers/solid_observer/events_controller.rb
+++ b/app/controllers/solid_observer/events_controller.rb
@@ -45,10 +45,17 @@ module SolidObserver
     end
 
     def load_available_options
-      scope = SolidObserver::QueueEvent.distinct
       @available_event_types = SolidObserver::QueueEvent::EVENT_TYPES
-      @available_job_classes = scope.pluck(:job_class).compact.sort
-      @available_queues = scope.pluck(:queue_name).compact.sort
+      @available_job_classes = cached_filter_options("solid_observer/events/distinct_job_classes") {
+        SolidObserver::QueueEvent.distinct_job_classes
+      }
+      @available_queues = cached_filter_options("solid_observer/events/distinct_queue_names") {
+        SolidObserver::QueueEvent.distinct_queue_names
+      }
+    end
+
+    def cached_filter_options(key, &block)
+      Rails.cache.fetch(key, expires_in: SolidObserver.config.filter_cache_ttl, &block)
     end
 
     def set_event

--- a/app/models/solid_observer/queue_event.rb
+++ b/app/models/solid_observer/queue_event.rb
@@ -10,6 +10,7 @@ module SolidObserver
       job_failed
       job_discarded
     ].freeze
+    DISTINCT_FILTER_LIMIT = 500
 
     validates :event_type, presence: true, inclusion: {in: EVENT_TYPES}
     validates :recorded_at, presence: true
@@ -21,5 +22,21 @@ module SolidObserver
     scope :before, ->(time) { where("recorded_at < ?", time) }
     scope :recent, ->(limit = 10) { order(recorded_at: :desc).limit(limit) }
     scope :recent_failures, ->(limit = 5) { by_event_type("job_failed").order(recorded_at: :desc).limit(limit) }
+    scope :distinct_job_classes, -> {
+      where("recorded_at >= ?", SolidObserver.config.event_retention.ago)
+        .where.not(job_class: nil)
+        .distinct
+        .limit(DISTINCT_FILTER_LIMIT)
+        .pluck(:job_class)
+        .sort
+    }
+    scope :distinct_queue_names, -> {
+      where("recorded_at >= ?", SolidObserver.config.event_retention.ago)
+        .where.not(queue_name: nil)
+        .distinct
+        .limit(DISTINCT_FILTER_LIMIT)
+        .pluck(:queue_name)
+        .sort
+    }
   end
 end

--- a/db/migrate/20260424000001_add_composite_indexes_to_queue_events.rb
+++ b/db/migrate/20260424000001_add_composite_indexes_to_queue_events.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddCompositeIndexesToQueueEvents < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    options = concurrent_supported? ? {algorithm: :concurrently} : {}
+
+    add_index :solid_observer_queue_events,
+      %i[job_class recorded_at],
+      order: {recorded_at: :desc},
+      if_not_exists: true,
+      **options
+
+    add_index :solid_observer_queue_events,
+      %i[queue_name recorded_at],
+      order: {recorded_at: :desc},
+      if_not_exists: true,
+      **options
+
+    remove_index :solid_observer_queue_events, :job_class, if_exists: true, **options
+    remove_index :solid_observer_queue_events, :queue_name, if_exists: true, **options
+  end
+
+  private
+
+  def concurrent_supported?
+    connection.adapter_name.match?(/postgres/i)
+  end
+end

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -47,7 +47,8 @@ module SolidObserver
       :buffer_size,
       :flush_interval,
       :max_buffer_size,
-      :buffer_overflow_strategy
+      :buffer_overflow_strategy,
+      :filter_cache_ttl
 
     # Correlation Settings
     attr_accessor :correlation_id_generator
@@ -83,6 +84,7 @@ module SolidObserver
       @flush_interval = 10.seconds
       @max_buffer_size = 10_000
       @buffer_overflow_strategy = :drop_old
+      @filter_cache_ttl = 1.minute
 
       # Correlation defaults
       @correlation_id_generator = nil
@@ -141,9 +143,16 @@ module SolidObserver
 
     def buffer_overflow_strategy=(value)
       value = value.to_sym
-      raise_invalid_buffer_overflow_strategy! unless BUFFER_OVERFLOW_STRATEGIES.include?(value)
+      unless BUFFER_OVERFLOW_STRATEGIES.include?(value)
+        raise ArgumentError, "buffer_overflow_strategy must be :drop_old or :drop_new"
+      end
 
       @buffer_overflow_strategy = value
+    end
+
+    def filter_cache_ttl=(value)
+      validate_positive_numeric!(:filter_cache_ttl, value)
+      @filter_cache_ttl = value
     end
 
     private
@@ -168,10 +177,6 @@ module SolidObserver
 
     def production?
       defined?(Rails) && Rails.env.production?
-    end
-
-    def raise_invalid_buffer_overflow_strategy!
-      raise ArgumentError, "buffer_overflow_strategy must be :drop_old or :drop_new"
     end
   end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -5,4 +5,5 @@ Rails.application.configure do
   config.eager_load = false
   config.consider_all_requests_local = true
   config.action_dispatch.show_exceptions = :none
+  config.cache_store = :memory_store
 end

--- a/spec/models/solid_observer/queue_event_spec.rb
+++ b/spec/models/solid_observer/queue_event_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe "SolidObserver::QueueEvent" do
+  after { SolidObserver.reset_configuration! }
+
   it "model file exists" do
     model_path = File.join(__dir__, "../../../app/models/solid_observer/queue_event.rb")
     expect(File.exist?(model_path)).to be true
@@ -19,5 +21,76 @@ RSpec.describe "SolidObserver::QueueEvent" do
 
   it "uses solid_observer_queue_events table" do
     expect(SolidObserver::QueueEvent.table_name).to eq("solid_observer_queue_events")
+  end
+
+  describe "distinct filter scopes" do
+    before(:all) do
+      connection = SolidObserver::QueueEvent.connection
+      next if connection.table_exists?(:solid_observer_queue_events)
+
+      connection.create_table :solid_observer_queue_events do |t|
+        t.string :event_type, null: false, limit: 50
+        t.string :job_class, limit: 100
+        t.string :queue_name, limit: 50
+        t.datetime :recorded_at, null: false
+      end
+    end
+
+    before do
+      SolidObserver.config.event_retention = 30.days
+      SolidObserver::QueueEvent.delete_all
+    end
+
+    it "uses a default distinct filter limit of 500" do
+      expect(SolidObserver::QueueEvent::DISTINCT_FILTER_LIMIT).to eq(500)
+    end
+
+    it "returns distinct sorted job classes within retention and without nils" do
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "ZJob", queue_name: "default", recorded_at: 1.day.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "AJob", queue_name: "default", recorded_at: 2.days.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "AJob", queue_name: "urgent", recorded_at: 3.days.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: nil, queue_name: "default", recorded_at: 1.day.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "OldJob", queue_name: "default", recorded_at: 40.days.ago)
+
+      expect(SolidObserver::QueueEvent.distinct_job_classes).to eq(%w[AJob ZJob])
+    end
+
+    it "returns distinct sorted queue names within retention and without nils" do
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "MyJob", queue_name: "urgent", recorded_at: 1.day.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "MyJob", queue_name: "default", recorded_at: 2.days.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "MyJob", queue_name: "default", recorded_at: 3.days.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "MyJob", queue_name: nil, recorded_at: 1.day.ago)
+      SolidObserver::QueueEvent.create!(event_type: "job_enqueued", job_class: "MyJob", queue_name: "archive", recorded_at: 40.days.ago)
+
+      expect(SolidObserver::QueueEvent.distinct_queue_names).to eq(%w[default urgent])
+    end
+
+    it "applies DISTINCT_FILTER_LIMIT to job classes" do
+      stub_const("SolidObserver::QueueEvent::DISTINCT_FILTER_LIMIT", 3)
+      5.times do |index|
+        SolidObserver::QueueEvent.create!(
+          event_type: "job_enqueued",
+          job_class: "Job#{index}",
+          queue_name: "default",
+          recorded_at: 1.day.ago
+        )
+      end
+
+      expect(SolidObserver::QueueEvent.distinct_job_classes.count).to eq(3)
+    end
+
+    it "applies DISTINCT_FILTER_LIMIT to queue names" do
+      stub_const("SolidObserver::QueueEvent::DISTINCT_FILTER_LIMIT", 3)
+      5.times do |index|
+        SolidObserver::QueueEvent.create!(
+          event_type: "job_enqueued",
+          job_class: "MyJob",
+          queue_name: "queue_#{index}",
+          recorded_at: 1.day.ago
+        )
+      end
+
+      expect(SolidObserver::QueueEvent.distinct_queue_names.count).to eq(3)
+    end
   end
 end

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SolidObserver::Configuration do
     expect(config.buffer_size).to eq(1000)
     expect(config.max_buffer_size).to eq(10_000)
     expect(config.buffer_overflow_strategy).to eq(:drop_old)
+    expect(config.filter_cache_ttl).to eq(1.minute)
     expect(config.observe_queue).to be true
     expect(config.max_db_size).to eq(1.gigabyte)
     expect(config.warning_threshold).to eq(0.8)
@@ -140,6 +141,48 @@ RSpec.describe SolidObserver::Configuration do
 
       expect { config.buffer_overflow_strategy = :invalid }.to raise_error(
         ArgumentError, "buffer_overflow_strategy must be :drop_old or :drop_new"
+      )
+    end
+  end
+
+  describe "#filter_cache_ttl=" do
+    it "accepts positive numeric duration values" do
+      config = described_class.new
+      config.filter_cache_ttl = 5.minutes
+      expect(config.filter_cache_ttl).to eq(5.minutes)
+    end
+
+    it "accepts positive numeric seconds" do
+      config = described_class.new
+      config.filter_cache_ttl = 30
+      expect(config.filter_cache_ttl).to eq(30)
+    end
+
+    it "rejects zero" do
+      config = described_class.new
+      expect { config.filter_cache_ttl = 0 }.to raise_error(
+        ArgumentError, "filter_cache_ttl must be a positive number"
+      )
+    end
+
+    it "rejects negative values" do
+      config = described_class.new
+      expect { config.filter_cache_ttl = -1 }.to raise_error(
+        ArgumentError, "filter_cache_ttl must be a positive number"
+      )
+    end
+
+    it "rejects strings" do
+      config = described_class.new
+      expect { config.filter_cache_ttl = "abc" }.to raise_error(
+        ArgumentError, "filter_cache_ttl must be a positive number"
+      )
+    end
+
+    it "rejects nil" do
+      config = described_class.new
+      expect { config.filter_cache_ttl = nil }.to raise_error(
+        ArgumentError, "filter_cache_ttl must be a positive number"
       )
     end
   end

--- a/spec/solid_observer/events_controller_spec.rb
+++ b/spec/solid_observer/events_controller_spec.rb
@@ -197,12 +197,10 @@ RSpec.describe SolidObserver::EventsController do
   end
 
   describe "#load_available_options" do
-    let(:distinct) { double("distinct") }
-
     before do
-      allow(SolidObserver::QueueEvent).to receive(:distinct).and_return(distinct)
-      allow(distinct).to receive(:pluck).with(:job_class).and_return([])
-      allow(distinct).to receive(:pluck).with(:queue_name).and_return([])
+      SolidObserver.config.filter_cache_ttl = 1.minute
+      allow(SolidObserver::QueueEvent).to receive(:distinct_job_classes).and_return(["MyJob", "OtherJob"])
+      allow(SolidObserver::QueueEvent).to receive(:distinct_queue_names).and_return(%w[default urgent])
     end
 
     it "sets @available_event_types from EVENT_TYPES constant" do
@@ -210,16 +208,34 @@ RSpec.describe SolidObserver::EventsController do
       expect(controller.instance_variable_get(:@available_event_types)).to eq(SolidObserver::QueueEvent::EVENT_TYPES)
     end
 
-    it "sets @available_job_classes from distinct pluck" do
-      allow(distinct).to receive(:pluck).with(:job_class).and_return(["MyJob", nil, "OtherJob"])
+    it "invokes each distinct scope once on cold cache then serves from cache" do
+      expect(SolidObserver::QueueEvent).to receive(:distinct_job_classes).once.and_return(["A"])
+      expect(SolidObserver::QueueEvent).to receive(:distinct_queue_names).once.and_return(["q"])
+
       controller.send(:load_available_options)
-      expect(controller.instance_variable_get(:@available_job_classes)).to eq(["MyJob", "OtherJob"])
+      controller.send(:load_available_options)
+
+      expect(controller.instance_variable_get(:@available_job_classes)).to eq(["A"])
+      expect(controller.instance_variable_get(:@available_queues)).to eq(["q"])
     end
 
-    it "sets @available_queues from distinct pluck" do
-      allow(distinct).to receive(:pluck).with(:queue_name).and_return(["default", nil, "urgent"])
+    it "does not invoke scopes on hot cache" do
       controller.send(:load_available_options)
-      expect(controller.instance_variable_get(:@available_queues)).to eq(["default", "urgent"])
+
+      expect(SolidObserver::QueueEvent).not_to receive(:distinct_job_classes)
+      expect(SolidObserver::QueueEvent).not_to receive(:distinct_queue_names)
+
+      controller.send(:load_available_options)
+    end
+
+    it "re-invokes scope after TTL expiry" do
+      expect(SolidObserver::QueueEvent).to receive(:distinct_job_classes).twice.and_return(["A"])
+      expect(SolidObserver::QueueEvent).to receive(:distinct_queue_names).twice.and_return(["q"])
+
+      controller.send(:load_available_options)
+      travel_to(2.minutes.from_now) do
+        controller.send(:load_available_options)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require "rails"
 require "action_controller/railtie"
 require "active_record/railtie"
 require "active_job/railtie"
+require "active_support/testing/time_helpers"
 
 ENV["RAILS_ENV"] = "test"
 Rails.env = ActiveSupport::StringInquirer.new("test")
@@ -35,12 +36,15 @@ ActiveRecord::Base.configurations = {
   }
 }
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
 
 Dir[File.join(__dir__, "../app/models/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "../app/jobs/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "../app/controllers/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
@@ -62,5 +66,10 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     ActiveJob::Base.logger = Logger.new(nil)
+    ActiveRecord::Base.logger = Logger.new(nil)
+  end
+
+  config.before(:each) do
+    Rails.cache.clear if defined?(Rails.cache) && Rails.cache
   end
 end


### PR DESCRIPTION
- Cache distinct `job_class` / `queue_name` dropdowns via `Rails.cache.fetch` (`SolidObserver.config.filter_cache_ttl`, default 1.minute)
- Add composite indexes (`job_class`, `recorded_at DESC`) and (`queue_name`, `recorded_at DESC`); drop redundant single-col indexes
- Scope distinct lookups to event_retention window with LIMIT 500
- Silence AR SQL logging in test suite