### PR TITLE
[SO-044][REFACTOR] Simplify thin-controllers refactor and specs

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -8,9 +8,10 @@ detectors:
   TooManyInstanceVariables:
     exclude:
       - SolidObserver::Configuration
+      - SolidObserver::QueueEventBuffer
       - SolidObserver::JobsController
       - SolidObserver::EventsController
-      - SolidObserver::QueueEventBuffer
+      - SolidObserver::Params::EventsFilter
 
   TooManyStatements:
     exclude:
@@ -47,8 +48,10 @@ detectors:
       - SolidObserver::Engine#self.configure_database_connection
       - SolidObserver::Subscriber#subscribe!
       - SolidObserver::Subscriber#self.subscribe!
-      - SolidObserver::EventsController#set_filter_params
-      - SolidObserver::EventsController#build_event_scope
+      - SolidObserver::JobsController#index
+      - SolidObserver::EventsController#index
+      - SolidObserver::Queries::EventsQuery#call
+      - SolidObserver::Params::EventsFilter#initialize
 
   LongParameterList:
     exclude:
@@ -57,6 +60,7 @@ detectors:
       - SolidObserver::Services::RecordEvent#self.call
       - SolidObserver::CLI::Jobs#list
       - SolidObserver::CLI::Jobs#fetch_job
+      - SolidObserver::Params::EventsFilter#initialize
 
   UtilityFunction:
     enabled: false
@@ -80,8 +84,7 @@ detectors:
       - SolidObserver::Configuration#validate_rate!
       - SolidObserver::Configuration#validate_positive_integer!
       - SolidObserver::Configuration#validate_positive_numeric!
-      - SolidObserver::Services::CleanupStorage#format_bytes
-      - SolidObserver::ApplicationHelper#format_bytes
+      - SolidObserver::Queries::JobExecutionsQuery#apply_queue_filter
       - SolidObserver::ApplicationHelper#mode_badge
 
   DuplicateMethodCall:
@@ -110,10 +113,9 @@ detectors:
   InstanceVariableAssumption:
     exclude:
       - SolidObserver::Subscriber
-      - SolidObserver::ApplicationController
+      - SolidObserver::Services::CleanupStorage
       - SolidObserver::JobsController
       - SolidObserver::EventsController
-      - SolidObserver::Services::CleanupStorage
 
   MissingSafeMethod:
     exclude:
@@ -125,7 +127,6 @@ detectors:
     exclude:
       - SolidObserver::CorrelationIdResolver#resolve
       - SolidObserver::CLI::Jobs
-      - SolidObserver::JobsController
 
   UncommunicativeVariableName:
     accept:
@@ -156,7 +157,6 @@ detectors:
   TooManyMethods:
     exclude:
       - SolidObserver::CLI::Jobs
-      - SolidObserver::ApplicationController
       - SolidObserver::QueueEventBuffer
 
 exclude_paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Changed
 - Removed `allow_any_instance_of` anti-pattern from specs; replaced with `instance_double` stubs
 - Deleted dead private-method `describe` blocks; coverage preserved via public-API assertions
+- Refactor Web UI controllers to thin actions + query/param/presenter objects; replace custom number helpers with Rails built-ins
 
 ## [0.1.1] - 2026-02-10
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.28%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.53%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---

--- a/app/controllers/concerns/solid_observer/paginatable.rb
+++ b/app/controllers/concerns/solid_observer/paginatable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Paginatable
+    extend ActiveSupport::Concern
+
+    private
+
+    def paginate_scope(scope, per_page:)
+      @total_count = scope.count
+      @total_pages = (@total_count.to_f / per_page).ceil
+      @page = 1 if @page < 1
+      @page = 1 if @page > @total_pages && @total_pages > 0
+      (@page - 1) * per_page
+    end
+  end
+end

--- a/app/controllers/concerns/solid_observer/require_persistence_mode.rb
+++ b/app/controllers/concerns/solid_observer/require_persistence_mode.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module RequirePersistenceMode
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :require_persistence_mode
+    end
+
+    private
+
+    def require_persistence_mode
+      return unless SolidObserver.config.realtime_mode?
+
+      redirect_to root_path, alert: "This page is not available in real-time mode."
+    end
+  end
+end

--- a/app/controllers/concerns/solid_observer/require_solid_queue.rb
+++ b/app/controllers/concerns/solid_observer/require_solid_queue.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module RequireSolidQueue
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :require_solid_queue
+    end
+
+    private
+
+    def require_solid_queue
+      return if SolidObserver::QueueStats.solid_queue_available?
+
+      redirect_to root_path, alert: "SolidQueue is not available."
+    end
+  end
+end

--- a/app/controllers/solid_observer/application_controller.rb
+++ b/app/controllers/solid_observer/application_controller.rb
@@ -2,21 +2,20 @@
 
 module SolidObserver
   class ApplicationController < ActionController::Base
-    if defined?(ActionController::API) &&
-        begin
-          SolidObserver.config.ui_base_controller.constantize.ancestors.include?(ActionController::API)
-        rescue NameError
-          false
-        end
+    api_controller = defined?(ActionController::API) && begin
+      SolidObserver.config.ui_base_controller.constantize.ancestors.include?(ActionController::API)
+    rescue NameError
+      false
+    end
+    if api_controller
       include ActionView::Layouts
       include ActionView::Rendering
       include ActionController::RequestForgeryProtection
     end
-
     protect_from_forgery with: :exception
     before_action :verify_ui_enabled
     before_action :authenticate
-    helper_method :persistence_mode?, :realtime_mode?, :determine_status, :solid_queue_available?
+    helper_method :persistence_mode?, :realtime_mode?, :solid_queue_available?
     layout "solid_observer/application"
 
     private
@@ -27,26 +26,11 @@ module SolidObserver
 
     def authenticate
       return unless SolidObserver.config.ui_username.present?
-
-      authenticate_or_request_with_http_basic("SolidObserver") do |username, password|
-        credentials_valid?(username, password)
-      end
-    end
-
-    def require_persistence_mode
-      return unless realtime_mode?
-
-      redirect_to root_path, alert: "This page is not available in real-time mode."
-    end
-
-    def require_solid_queue
-      return if solid_queue_available?
-
-      redirect_to root_path, alert: "SolidQueue is not available."
+      authenticate_or_request_with_http_basic("SolidObserver") { |username, password| credentials_valid?(username, password) }
     end
 
     def solid_queue_available?
-      !!(defined?(SolidQueue) && defined?(SolidQueue::Job))
+      QueueStats.solid_queue_available?
     end
 
     def persistence_mode?
@@ -55,29 +39,6 @@ module SolidObserver
 
     def realtime_mode?
       SolidObserver.config.realtime_mode?
-    end
-
-    EXECUTION_STATUS_MAP = {
-      "SolidQueue::ReadyExecution" => "ready",
-      "SolidQueue::ScheduledExecution" => "scheduled",
-      "SolidQueue::ClaimedExecution" => "claimed",
-      "SolidQueue::FailedExecution" => "failed"
-    }.freeze
-
-    def determine_status(execution)
-      EXECUTION_STATUS_MAP.fetch(execution.class.name, "unknown")
-    end
-
-    def normalize_page
-      @page = 1 if @page < 1
-      @page = 1 if @page > @total_pages && @total_pages > 0
-    end
-
-    def paginate_scope(scope, per_page:)
-      @total_count = scope.count
-      @total_pages = (@total_count.to_f / per_page).ceil
-      normalize_page
-      (@page - 1) * per_page
     end
 
     def credentials_valid?(username, password)

--- a/app/controllers/solid_observer/events_controller.rb
+++ b/app/controllers/solid_observer/events_controller.rb
@@ -2,78 +2,46 @@
 
 module SolidObserver
   class EventsController < ApplicationController
-    before_action :require_persistence_mode
-    before_action :set_event, only: [:show]
+    include Paginatable
+    include RequirePersistenceMode
 
     PER_PAGE = 50
 
     def index
-      set_filter_params
-      scope = build_event_scope
-      paginate_events(scope)
+      filter = Params::EventsFilter.from_params(params)
+      @event_type = filter.event_type
+      @job_class = filter.job_class
+      @queue_name = filter.queue_name
+      @from = filter.from
+      @to = filter.to
+      @page = filter.page
+      scope = Queries::EventsQuery.new(filter).call
+      offset = paginate_scope(scope, per_page: PER_PAGE)
+      @events = scope.limit(PER_PAGE).offset(offset)
       load_available_options
     end
 
     def show
+      @event = QueueEvent.find_by(id: params[:id])
+      return redirect_to(events_path, alert: "Event not found") unless @event
+
       @metadata = parse_metadata(@event.metadata)
     end
 
     private
 
-    def set_filter_params
-      @event_type = params[:event_type].presence
-      @job_class = params[:job_class].presence
-      @queue_name = params[:queue_name].presence
-      @from = parse_date(params[:from])
-      @to = parse_date(params[:to])
-      @page = (params[:page].presence || 1).to_i
-    end
-
-    def build_event_scope
-      scope = SolidObserver::QueueEvent.order(recorded_at: :desc)
-      scope = scope.by_event_type(@event_type) if @event_type.present?
-      scope = scope.by_job_class(@job_class) if @job_class.present?
-      scope = scope.by_queue(@queue_name) if @queue_name.present?
-      scope = scope.since(@from.beginning_of_day) if @from
-      scope = scope.before(@to.end_of_day) if @to
-      scope
-    end
-
-    def paginate_events(scope)
-      offset = paginate_scope(scope, per_page: PER_PAGE)
-      @events = scope.limit(PER_PAGE).offset(offset)
-    end
-
     def load_available_options
-      @available_event_types = SolidObserver::QueueEvent::EVENT_TYPES
-      @available_job_classes = cached_filter_options("solid_observer/events/distinct_job_classes") {
-        SolidObserver::QueueEvent.distinct_job_classes
-      }
-      @available_queues = cached_filter_options("solid_observer/events/distinct_queue_names") {
-        SolidObserver::QueueEvent.distinct_queue_names
-      }
+      @available_event_types = QueueEvent::EVENT_TYPES
+      @available_job_classes = cached_filter_options("solid_observer/events/distinct_job_classes") { QueueEvent.distinct_job_classes }
+      @available_queues = cached_filter_options("solid_observer/events/distinct_queue_names") { QueueEvent.distinct_queue_names }
     end
 
     def cached_filter_options(key, &block)
       Rails.cache.fetch(key, expires_in: SolidObserver.config.filter_cache_ttl, &block)
     end
 
-    def set_event
-      @event = SolidObserver::QueueEvent.find_by(id: params[:id])
-      redirect_to(events_path, alert: "Event not found") and return unless @event
-    end
-
-    def parse_date(date_string)
-      return nil if date_string.blank?
-
-      Date.parse(date_string)
-    rescue ArgumentError
-      nil
-    end
-
     def parse_metadata(metadata)
       return nil if metadata.blank?
-
       JSON.parse(metadata)
     rescue JSON::ParserError
       {raw: metadata}

--- a/app/controllers/solid_observer/jobs_controller.rb
+++ b/app/controllers/solid_observer/jobs_controller.rb
@@ -2,29 +2,37 @@
 
 module SolidObserver
   class JobsController < ApplicationController
-    before_action :require_solid_queue
+    include Paginatable
+    include RequireSolidQueue
 
     PER_PAGE = 25
 
     def index
-      set_filter_params
-      scope = apply_filters(scope_for_status(@status))
-      paginate_jobs(scope)
-      load_available_options
+      filter = Params::JobsFilter.from_params(params)
+      @status = filter.status
+      @queue_name = filter.queue_name
+      @job_class = filter.job_class
+      @page = filter.page
+      scope = Queries::JobExecutionsQuery.new(filter).call
+      offset = paginate_scope(scope, per_page: PER_PAGE)
+      @jobs = scope.limit(PER_PAGE).offset(offset).includes(:job).to_a
+      @available_queues = fetch_available_queues
+      @available_job_classes = fetch_available_job_classes
     end
 
     def show
-      @execution = find_execution(params[:id])
+      @execution = Queries::ExecutionFinder.find_any(params[:id])
       return redirect_to jobs_path, alert: "Job not found" unless @execution
 
-      @job = @execution.job
-      @status = determine_status(@execution)
+      presenter = ExecutionPresenter.new(@execution)
+      @job = presenter.job
+      @status = presenter.status
     end
 
     def retry
       id = params[:id]
-      execution = find_failed_execution(id)
-      return unless execution
+      execution = Queries::ExecutionFinder.find_failed(id)
+      return redirect_to(jobs_path, alert: "Failed job not found") unless execution
 
       execution.retry
       redirect_to jobs_path(status: "failed"), notice: "Job #{id} queued for retry"
@@ -32,57 +40,14 @@ module SolidObserver
 
     def discard
       id = params[:id]
-      execution = find_failed_execution(id)
-      return unless execution
+      execution = Queries::ExecutionFinder.find_failed(id)
+      return redirect_to(jobs_path, alert: "Failed job not found") unless execution
 
       execution.discard
       redirect_to jobs_path(status: "failed"), notice: "Job #{id} discarded"
     end
 
     private
-
-    def set_filter_params
-      @status = params[:status].presence || "ready"
-      @queue_name = params[:queue_name].presence
-      @job_class = params[:job_class].presence
-      @page = (params[:page].presence || 1).to_i
-    end
-
-    def apply_filters(scope)
-      scope = apply_queue_filter(scope, @status, @queue_name)
-      scope = scope.joins(:job).where(solid_queue_jobs: {class_name: @job_class}) if @job_class.present?
-      scope
-    end
-
-    def paginate_jobs(scope)
-      offset = paginate_scope(scope, per_page: PER_PAGE)
-      @jobs = scope.order(created_at: :desc).limit(PER_PAGE).offset(offset).includes(:job).to_a
-    end
-
-    def load_available_options
-      @available_queues = fetch_available_queues
-      @available_job_classes = fetch_available_job_classes
-    end
-
-    def scope_for_status(status)
-      case status.to_s.downcase
-      when "scheduled" then SolidQueue::ScheduledExecution.all
-      when "claimed" then SolidQueue::ClaimedExecution.all
-      when "failed" then SolidQueue::FailedExecution.all
-      else SolidQueue::ReadyExecution.all
-      end
-    end
-
-    def apply_queue_filter(scope, status, queue_name)
-      return scope if queue_name.blank?
-
-      case status.to_s.downcase
-      when "failed", "claimed"
-        scope.joins(:job).where(solid_queue_jobs: {queue_name: queue_name})
-      else
-        scope.where(queue_name: queue_name)
-      end
-    end
 
     def fetch_available_queues
       return [] unless defined?(SolidQueue::Queue)
@@ -96,25 +61,6 @@ module SolidObserver
       SolidQueue::Job.distinct.pluck(:class_name).compact.sort
     rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished
       []
-    end
-
-    def find_failed_execution(id)
-      execution = SolidQueue::FailedExecution.find_by(id: id)
-      redirect_to jobs_path, alert: "Failed job not found" unless execution
-      execution
-    end
-
-    def find_execution(id)
-      [
-        SolidQueue::ReadyExecution,
-        SolidQueue::ScheduledExecution,
-        SolidQueue::ClaimedExecution,
-        SolidQueue::FailedExecution
-      ].each do |type|
-        execution = type.find_by(id: id)
-        return execution if execution
-      end
-      nil
     end
   end
 end

--- a/app/controllers/solid_observer/storages_controller.rb
+++ b/app/controllers/solid_observer/storages_controller.rb
@@ -2,7 +2,7 @@
 
 module SolidObserver
   class StoragesController < ApplicationController
-    before_action :require_persistence_mode
+    include RequirePersistenceMode
 
     def show
       @current_storage = SolidObserver::StorageInfo.order(recorded_at: :desc).first

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -2,10 +2,6 @@
 
 module SolidObserver
   module ApplicationHelper
-    KB = 1_024
-    MB = 1_048_576
-    GB = 1_073_741_824
-
     STATUS_COLORS = {
       "completed" => "success",
       "ready" => "success",
@@ -17,18 +13,8 @@ module SolidObserver
       "discarded" => "info"
     }.freeze
 
-    def format_bytes(bytes)
-      return "0 B" if bytes.to_f.zero?
-
-      if bytes < KB
-        "#{bytes.to_i} B"
-      elsif bytes < MB
-        "#{"%.1f" % (bytes / KB.to_f)} KB"
-      elsif bytes < GB
-        "#{"%.1f" % (bytes / MB.to_f)} MB"
-      else
-        "#{"%.1f" % (bytes / GB.to_f)} GB"
-      end
+    def execution_status(execution)
+      ExecutionPresenter.new(execution).status
     end
 
     def format_duration(seconds)
@@ -39,10 +25,6 @@ module SolidObserver
       else
         "#{"%.1f" % seconds}s"
       end
-    end
-
-    def format_number(number)
-      number.to_i.to_s.reverse.gsub(/(\d{3})(?=\d)/, "\\1,").reverse
     end
 
     def status_badge(status)

--- a/app/presenters/solid_observer/execution_presenter.rb
+++ b/app/presenters/solid_observer/execution_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class ExecutionPresenter
+    STATUS_MAP = {
+      "SolidQueue::ReadyExecution" => "ready",
+      "SolidQueue::ScheduledExecution" => "scheduled",
+      "SolidQueue::ClaimedExecution" => "claimed",
+      "SolidQueue::FailedExecution" => "failed"
+    }.freeze
+
+    def initialize(execution)
+      @execution = execution
+    end
+
+    def status
+      STATUS_MAP.fetch(@execution.class.name, "unknown")
+    end
+
+    def job
+      @execution.job
+    end
+
+    def to_model
+      @execution
+    end
+  end
+end

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -28,7 +28,7 @@
           <% @stats[:queues].each do |queue_name, count| %>
             <tr>
               <td><%= queue_name %></td>
-              <td><%= format_number(count) %></td>
+              <td><%= number_with_delimiter(count) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/solid_observer/jobs/index.html.erb
+++ b/app/views/solid_observer/jobs/index.html.erb
@@ -37,7 +37,7 @@
           <td><%= link_to execution.id, job_path(execution.id) %></td>
           <td><%= job&.class_name || "N/A" %></td>
           <td><%= job&.queue_name || execution&.queue_name || "N/A" %></td>
-          <td><%= status_badge(determine_status(execution)) %></td>
+          <td><%= status_badge(execution_status(execution)) %></td>
           <td><%= time_ago_in_words(execution.created_at) %> ago</td>
           <td>
             <%= link_to "View", job_path(execution.id), class: "so-btn" %>

--- a/app/views/solid_observer/storages/show.html.erb
+++ b/app/views/solid_observer/storages/show.html.erb
@@ -6,8 +6,8 @@
 
 <% if @current_storage %>
   <div class="so-stat-cards">
-    <%= render "solid_observer/shared/stat_card", label: "Database Size", value: format_bytes(@current_storage.db_size_bytes) %>
-    <%= render "solid_observer/shared/stat_card", label: "Event Count", value: format_number(@current_storage.event_count) %>
+    <%= render "solid_observer/shared/stat_card", label: "Database Size", value: number_to_human_size(@current_storage.db_size_bytes, precision: 1, significant: false, strip_insignificant_zeros: false) %>
+    <%= render "solid_observer/shared/stat_card", label: "Event Count", value: number_with_delimiter(@current_storage.event_count) %>
     <%= render "solid_observer/shared/stat_card", label: "Last Updated", value: time_ago_in_words(@current_storage.recorded_at) + " ago" %>
   </div>
 
@@ -26,8 +26,8 @@
           <% @storage_history.each do |snapshot| %>
             <tr>
               <td><%= snapshot.recorded_at.strftime("%Y-%m-%d %H:%M") %></td>
-              <td><%= format_bytes(snapshot.db_size_bytes) %></td>
-              <td><%= format_number(snapshot.event_count) %></td>
+              <td><%= number_to_human_size(snapshot.db_size_bytes, precision: 1, significant: false, strip_insignificant_zeros: false) %></td>
+              <td><%= number_with_delimiter(snapshot.event_count) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -5,6 +5,11 @@ require_relative "solid_observer/configuration"
 require_relative "solid_observer/correlation_id_resolver"
 require_relative "solid_observer/base_event" if defined?(ActiveRecord)
 require_relative "solid_observer/base_metric" if defined?(ActiveRecord)
+require_relative "solid_observer/params/jobs_filter"
+require_relative "solid_observer/params/events_filter"
+require_relative "solid_observer/queries/job_executions_query" if defined?(ActiveRecord)
+require_relative "solid_observer/queries/events_query" if defined?(ActiveRecord)
+require_relative "solid_observer/queries/execution_finder" if defined?(ActiveRecord)
 require_relative "solid_observer/services/record_event" if defined?(ActiveRecord)
 require_relative "solid_observer/services/flush_event_buffer" if defined?(ActiveRecord)
 require_relative "solid_observer/services/cleanup_storage" if defined?(ActiveRecord)
@@ -15,6 +20,7 @@ require_relative "solid_observer/cli/status"
 require_relative "solid_observer/cli/storage"
 require_relative "solid_observer/cli/jobs"
 require_relative "solid_observer/queue_stats"
+require_relative "../app/presenters/solid_observer/execution_presenter"
 require_relative "solid_observer/engine" if defined?(Rails::Engine)
 
 module SolidObserver

--- a/lib/solid_observer/params/events_filter.rb
+++ b/lib/solid_observer/params/events_filter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Params
+    class EventsFilter
+      def self.from_params(params)
+        new(
+          event_type: params[:event_type].presence,
+          job_class: params[:job_class].presence,
+          queue_name: params[:queue_name].presence,
+          from: parse_date(params[:from]),
+          to: parse_date(params[:to]),
+          page: (params[:page].presence || 1).to_i
+        )
+      end
+
+      class << self
+        private
+
+        def parse_date(date_string)
+          return nil if date_string.blank?
+
+          Date.parse(date_string)
+        rescue ArgumentError
+          nil
+        end
+      end
+
+      attr_reader :event_type, :job_class, :queue_name, :from, :to, :page
+
+      def initialize(event_type:, job_class:, queue_name:, from:, to:, page:)
+        @event_type = event_type
+        @job_class = job_class
+        @queue_name = queue_name
+        @from = from
+        @to = to
+        @page = page
+      end
+    end
+  end
+end

--- a/lib/solid_observer/params/jobs_filter.rb
+++ b/lib/solid_observer/params/jobs_filter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Params
+    class JobsFilter
+      ALLOWED_STATUSES = %w[ready scheduled claimed failed].freeze
+
+      def self.from_params(params)
+        new(
+          status: params[:status].presence || "ready",
+          queue_name: params[:queue_name].presence,
+          job_class: params[:job_class].presence,
+          page: (params[:page].presence || 1).to_i
+        )
+      end
+
+      attr_reader :status, :queue_name, :job_class, :page
+
+      def initialize(status:, queue_name:, job_class:, page:)
+        @status = normalize_status(status)
+        @queue_name = queue_name
+        @job_class = job_class
+        @page = page
+      end
+
+      private
+
+      def normalize_status(status)
+        normalized = status.to_s.downcase
+        ALLOWED_STATUSES.include?(normalized) ? normalized : "ready"
+      end
+    end
+  end
+end

--- a/lib/solid_observer/queries/events_query.rb
+++ b/lib/solid_observer/queries/events_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Queries
+    class EventsQuery
+      def initialize(filter)
+        @filter = filter
+      end
+
+      def call
+        event_type = @filter.event_type
+        job_class = @filter.job_class
+        queue_name = @filter.queue_name
+        from = @filter.from
+        to = @filter.to
+
+        scope = QueueEvent.order(recorded_at: :desc)
+        scope = scope.by_event_type(event_type) if event_type.present?
+        scope = scope.by_job_class(job_class) if job_class.present?
+        scope = scope.by_queue(queue_name) if queue_name.present?
+        scope = scope.since(from.beginning_of_day) if from
+        scope = scope.before(to.end_of_day) if to
+        scope
+      end
+    end
+  end
+end

--- a/lib/solid_observer/queries/execution_finder.rb
+++ b/lib/solid_observer/queries/execution_finder.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Queries
+    class ExecutionFinder
+      EXECUTION_TYPES = [
+        "SolidQueue::ReadyExecution",
+        "SolidQueue::ScheduledExecution",
+        "SolidQueue::ClaimedExecution",
+        "SolidQueue::FailedExecution"
+      ].freeze
+
+      def self.find_any(id)
+        EXECUTION_TYPES.each do |const_name|
+          execution = const_name.safe_constantize&.find_by(id: id)
+          return execution if execution
+        end
+        nil
+      end
+
+      def self.find_failed(id)
+        return nil unless defined?(SolidQueue::FailedExecution)
+
+        SolidQueue::FailedExecution.find_by(id: id)
+      end
+    end
+  end
+end

--- a/lib/solid_observer/queries/job_executions_query.rb
+++ b/lib/solid_observer/queries/job_executions_query.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Queries
+    class JobExecutionsQuery
+      STATUS_SCOPES = {
+        "ready" => -> { SolidQueue::ReadyExecution.all },
+        "scheduled" => -> { SolidQueue::ScheduledExecution.all },
+        "claimed" => -> { SolidQueue::ClaimedExecution.all },
+        "failed" => -> { SolidQueue::FailedExecution.all }
+      }.freeze
+
+      def initialize(filter)
+        @filter = filter
+      end
+
+      def call
+        status = @filter.status
+        scope = STATUS_SCOPES.fetch(status, STATUS_SCOPES["ready"]).call
+        scope = apply_queue_filter(scope, status)
+        scope = apply_job_class_filter(scope)
+        scope.order(created_at: :desc)
+      end
+
+      private
+
+      def apply_job_class_filter(scope)
+        job_class = @filter.job_class
+        return scope if job_class.blank?
+
+        scope.joins(:job).where(solid_queue_jobs: {class_name: job_class})
+      end
+
+      def apply_queue_filter(scope, status)
+        queue_name = @filter.queue_name
+        return scope if queue_name.blank?
+
+        if %w[failed claimed].include?(status)
+          scope.joins(:job).where(solid_queue_jobs: {queue_name: queue_name})
+        else
+          scope.where(queue_name: queue_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/cleanup_storage.rb
+++ b/lib/solid_observer/services/cleanup_storage.rb
@@ -61,15 +61,30 @@ module SolidObserver
 
       def check_storage_warnings
         current_size = current_database_size
-        return unless current_size
+        return unless warning_needed?(current_size)
 
+        Rails.logger.warn(storage_warning_message(current_size))
+      end
+
+      def warning_needed?(current_size)
+        return false unless current_size
+
+        config = SolidObserver.config
+        max_size = config.max_db_size
+        threshold = config.warning_threshold
+        current_size > (max_size * threshold)
+      end
+
+      def storage_warning_message(current_size)
         max_size = SolidObserver.config.max_db_size
-        threshold = SolidObserver.config.warning_threshold
-
-        return unless current_size > (max_size * threshold)
-
         percentage = ((current_size.to_f / max_size) * 100).round(1)
-        Rails.logger.warn "[SolidObserver] Queue DB approaching limit: #{format_bytes(current_size)} / #{format_bytes(max_size)} (#{percentage}%)"
+        current_size_human = human_size(current_size)
+        max_size_human = human_size(max_size)
+        "[SolidObserver] Queue DB approaching limit: #{current_size_human} / #{max_size_human} (#{percentage}%)"
+      end
+
+      def human_size(bytes)
+        ActiveSupport::NumberHelper.number_to_human_size(bytes, precision: 1, significant: false, strip_insignificant_zeros: false)
       end
 
       def current_database_size
@@ -80,16 +95,6 @@ module SolidObserver
 
       def log_results(deleted_count)
         Rails.logger.info "[SolidObserver] Cleaned #{deleted_count} queue events"
-      end
-
-      def format_bytes(bytes)
-        return "0 B" if bytes.zero?
-
-        units = ["B", "KB", "MB", "GB"]
-        exp = (Math.log(bytes) / Math.log(1024)).to_i
-        exp = [exp, units.length - 1].min
-
-        "%.1f %s" % [bytes.to_f / (1024**exp), units[exp]]
       end
     end
   end

--- a/spec/solid_observer/application_controller_spec.rb
+++ b/spec/solid_observer/application_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SolidObserver::ApplicationController do
   after { SolidObserver.reset_configuration! }
 
   let(:controller) { described_class.allocate }
+
   describe "class structure" do
     it "inherits from ActionController::Base" do
       expect(described_class.superclass).to eq(ActionController::Base)
@@ -29,10 +30,15 @@ RSpec.describe SolidObserver::ApplicationController do
       expect(described_class._helper_methods).to include(:realtime_mode?)
     end
 
+    it "exposes :solid_queue_available? as a helper method" do
+      expect(described_class._helper_methods).to include(:solid_queue_available?)
+    end
+
     it "uses the solid_observer/application layout" do
       expect(controller.send(:_layout, nil, nil, nil)).to eq("solid_observer/application")
     end
   end
+
   describe "#verify_ui_enabled" do
     context "when ui_enabled is true" do
       before { SolidObserver.config.ui_enabled = true }
@@ -52,6 +58,7 @@ RSpec.describe SolidObserver::ApplicationController do
       end
     end
   end
+
   describe "#authenticate" do
     context "when no ui_username is configured" do
       before { SolidObserver.config.ui_username = nil }
@@ -128,161 +135,11 @@ RSpec.describe SolidObserver::ApplicationController do
       expect(controller.send(:realtime_mode?)).to be true
     end
   end
-  describe "#require_persistence_mode" do
-    context "in persistence mode" do
-      before { SolidObserver.config.storage_mode = :persistence }
-
-      it "does not redirect" do
-        expect(controller).not_to receive(:redirect_to)
-        controller.send(:require_persistence_mode)
-      end
-    end
-
-    context "in realtime mode" do
-      before { SolidObserver.config.storage_mode = :realtime }
-
-      it "redirects to root with an alert" do
-        controller.define_singleton_method(:root_path) { "/solid_observer" }
-        expect(controller).to receive(:redirect_to).with(
-          "/solid_observer",
-          alert: "This page is not available in real-time mode."
-        )
-        controller.send(:require_persistence_mode)
-      end
-    end
-  end
-  describe "#require_solid_queue" do
-    context "when SolidQueue is available" do
-      before do
-        stub_const("SolidQueue", Module.new)
-        stub_const("SolidQueue::Job", Class.new)
-      end
-
-      it "does not redirect" do
-        expect(controller).not_to receive(:redirect_to)
-        controller.send(:require_solid_queue)
-      end
-    end
-
-    context "when SolidQueue is not available" do
-      it "redirects to root with an alert" do
-        controller.define_singleton_method(:root_path) { "/solid_observer" }
-        expect(controller).to receive(:redirect_to).with(
-          "/solid_observer",
-          alert: "SolidQueue is not available."
-        )
-        controller.send(:require_solid_queue)
-      end
-    end
-  end
 
   describe "#solid_queue_available?" do
-    context "when SolidQueue and SolidQueue::Job are defined" do
-      before do
-        stub_const("SolidQueue", Module.new)
-        stub_const("SolidQueue::Job", Class.new)
-      end
-
-      it "returns true" do
-        expect(controller.send(:solid_queue_available?)).to be true
-      end
-    end
-
-    context "when SolidQueue is not defined" do
-      it "returns false" do
-        hide_const("SolidQueue") if defined?(SolidQueue)
-        expect(controller.send(:solid_queue_available?)).to be false
-      end
-    end
-  end
-
-  describe "#determine_status" do
-    before do
-      stub_const("SolidQueue::ReadyExecution", Class.new)
-      stub_const("SolidQueue::ScheduledExecution", Class.new)
-      stub_const("SolidQueue::ClaimedExecution", Class.new)
-      stub_const("SolidQueue::FailedExecution", Class.new)
-    end
-
-    it "returns 'ready' for ReadyExecution" do
-      execution = SolidQueue::ReadyExecution.new
-      expect(controller.send(:determine_status, execution)).to eq("ready")
-    end
-
-    it "returns 'scheduled' for ScheduledExecution" do
-      execution = SolidQueue::ScheduledExecution.new
-      expect(controller.send(:determine_status, execution)).to eq("scheduled")
-    end
-
-    it "returns 'claimed' for ClaimedExecution" do
-      execution = SolidQueue::ClaimedExecution.new
-      expect(controller.send(:determine_status, execution)).to eq("claimed")
-    end
-
-    it "returns 'failed' for FailedExecution" do
-      execution = SolidQueue::FailedExecution.new
-      expect(controller.send(:determine_status, execution)).to eq("failed")
-    end
-
-    it "returns 'unknown' for unrecognized class" do
-      expect(controller.send(:determine_status, Object.new)).to eq("unknown")
-    end
-  end
-
-  describe "#normalize_page" do
-    it "sets @page to 1 when below 1" do
-      controller.instance_variable_set(:@page, 0)
-      controller.instance_variable_set(:@total_pages, 5)
-      controller.send(:normalize_page)
-      expect(controller.instance_variable_get(:@page)).to eq(1)
-    end
-
-    it "sets @page to 1 when above total_pages" do
-      controller.instance_variable_set(:@page, 10)
-      controller.instance_variable_set(:@total_pages, 3)
-      controller.send(:normalize_page)
-      expect(controller.instance_variable_get(:@page)).to eq(1)
-    end
-
-    it "does not change @page when within valid range" do
-      controller.instance_variable_set(:@page, 2)
-      controller.instance_variable_set(:@total_pages, 5)
-      controller.send(:normalize_page)
-      expect(controller.instance_variable_get(:@page)).to eq(2)
-    end
-
-    it "does not clamp when total_pages is 0" do
-      controller.instance_variable_set(:@page, 1)
-      controller.instance_variable_set(:@total_pages, 0)
-      controller.send(:normalize_page)
-      expect(controller.instance_variable_get(:@page)).to eq(1)
-    end
-  end
-
-  describe "#paginate_scope" do
-    let(:scope) { double("scope", count: 60) }
-
-    before { controller.instance_variable_set(:@page, 2) }
-
-    it "sets @total_count from scope.count" do
-      controller.send(:paginate_scope, scope, per_page: 25)
-      expect(controller.instance_variable_get(:@total_count)).to eq(60)
-    end
-
-    it "sets @total_pages based on count and per_page" do
-      controller.send(:paginate_scope, scope, per_page: 25)
-      expect(controller.instance_variable_get(:@total_pages)).to eq(3)
-    end
-
-    it "returns the correct offset for page 2" do
-      offset = controller.send(:paginate_scope, scope, per_page: 25)
-      expect(offset).to eq(25)
-    end
-
-    it "returns offset 0 for page 1" do
-      controller.instance_variable_set(:@page, 1)
-      offset = controller.send(:paginate_scope, scope, per_page: 25)
-      expect(offset).to eq(0)
+    it "delegates to QueueStats" do
+      expect(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(true)
+      expect(controller.send(:solid_queue_available?)).to be true
     end
   end
 

--- a/spec/solid_observer/application_helper_spec.rb
+++ b/spec/solid_observer/application_helper_spec.rb
@@ -9,32 +9,6 @@ RSpec.describe SolidObserver::ApplicationHelper do
   include ActionView::Helpers::OutputSafetyHelper
   include described_class
 
-  describe "#format_bytes" do
-    it "returns '0 B' for nil" do
-      expect(format_bytes(nil)).to eq("0 B")
-    end
-
-    it "returns '0 B' for zero" do
-      expect(format_bytes(0)).to eq("0 B")
-    end
-
-    it "returns byte count for values under 1 KB" do
-      expect(format_bytes(500)).to eq("500 B")
-    end
-
-    it "formats KB" do
-      expect(format_bytes(2_048)).to eq("2.0 KB")
-    end
-
-    it "formats MB" do
-      expect(format_bytes(5 * 1_048_576)).to eq("5.0 MB")
-    end
-
-    it "formats GB" do
-      expect(format_bytes(2 * 1_073_741_824)).to eq("2.0 GB")
-    end
-  end
-
   describe "#format_duration" do
     it "returns '0ms' for nil" do
       expect(format_duration(nil)).to eq("0ms")
@@ -54,20 +28,6 @@ RSpec.describe SolidObserver::ApplicationHelper do
 
     it "formats exactly 1 second" do
       expect(format_duration(1.0)).to eq("1.0s")
-    end
-  end
-
-  describe "#format_number" do
-    it "returns '0' for nil" do
-      expect(format_number(nil)).to eq("0")
-    end
-
-    it "formats large numbers with commas" do
-      expect(format_number(1_234_567)).to eq("1,234,567")
-    end
-
-    it "returns small numbers unchanged" do
-      expect(format_number(42)).to eq("42")
     end
   end
 

--- a/spec/solid_observer/concerns/paginatable_spec.rb
+++ b/spec/solid_observer/concerns/paginatable_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Paginatable do
+  let(:host_class) do
+    Class.new do
+      include SolidObserver::Paginatable
+    end
+  end
+  let(:host) { host_class.new }
+  let(:scope) { double("scope", count: 60) }
+
+  describe "#paginate_scope" do
+    before { host.instance_variable_set(:@page, 2) }
+
+    it "sets @total_count from scope.count" do
+      host.send(:paginate_scope, scope, per_page: 25)
+      expect(host.instance_variable_get(:@total_count)).to eq(60)
+    end
+
+    it "sets @total_pages based on count and per_page" do
+      host.send(:paginate_scope, scope, per_page: 25)
+      expect(host.instance_variable_get(:@total_pages)).to eq(3)
+    end
+
+    it "returns the correct offset for page 2" do
+      offset = host.send(:paginate_scope, scope, per_page: 25)
+      expect(offset).to eq(25)
+    end
+
+    it "returns offset 0 for page 1" do
+      host.instance_variable_set(:@page, 1)
+      offset = host.send(:paginate_scope, scope, per_page: 25)
+      expect(offset).to eq(0)
+    end
+
+    it "sets @page to 1 when below 1" do
+      host.instance_variable_set(:@page, 0)
+      host.send(:paginate_scope, scope, per_page: 25)
+      expect(host.instance_variable_get(:@page)).to eq(1)
+    end
+
+    it "sets @page to 1 when above total_pages" do
+      host.instance_variable_set(:@page, 10)
+      host.send(:paginate_scope, scope, per_page: 25)
+      expect(host.instance_variable_get(:@page)).to eq(1)
+    end
+
+    it "does not change @page when within valid range" do
+      host.instance_variable_set(:@page, 2)
+      host.send(:paginate_scope, scope, per_page: 25)
+      expect(host.instance_variable_get(:@page)).to eq(2)
+    end
+
+    it "does not clamp when total_pages is 0" do
+      host.instance_variable_set(:@page, 1)
+      zero_scope = double("zero_scope", count: 0)
+      host.send(:paginate_scope, zero_scope, per_page: 25)
+      expect(host.instance_variable_get(:@page)).to eq(1)
+    end
+  end
+end

--- a/spec/solid_observer/concerns/require_persistence_mode_spec.rb
+++ b/spec/solid_observer/concerns/require_persistence_mode_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::RequirePersistenceMode do
+  after { SolidObserver.reset_configuration! }
+
+  let(:controller_class) do
+    Class.new(ActionController::Base) do
+      include SolidObserver::RequirePersistenceMode
+
+      def root_path
+        "/solid_observer"
+      end
+    end
+  end
+  let(:controller) { controller_class.allocate }
+
+  describe "class structure" do
+    it "registers :require_persistence_mode as a before_action" do
+      callbacks = controller_class._process_action_callbacks.map(&:filter)
+      expect(callbacks).to include(:require_persistence_mode)
+    end
+  end
+
+  describe "#require_persistence_mode" do
+    context "in persistence mode" do
+      before { SolidObserver.config.storage_mode = :persistence }
+
+      it "does not redirect" do
+        expect(controller).not_to receive(:redirect_to)
+        controller.send(:require_persistence_mode)
+      end
+    end
+
+    context "in realtime mode" do
+      before { SolidObserver.config.storage_mode = :realtime }
+
+      it "redirects to root with an alert" do
+        expect(controller).to receive(:redirect_to).with(
+          "/solid_observer",
+          alert: "This page is not available in real-time mode."
+        )
+        controller.send(:require_persistence_mode)
+      end
+    end
+  end
+end

--- a/spec/solid_observer/concerns/require_solid_queue_spec.rb
+++ b/spec/solid_observer/concerns/require_solid_queue_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::RequireSolidQueue do
+  let(:controller_class) do
+    Class.new(ActionController::Base) do
+      include SolidObserver::RequireSolidQueue
+
+      def root_path
+        "/solid_observer"
+      end
+    end
+  end
+  let(:controller) { controller_class.allocate }
+
+  describe "class structure" do
+    it "registers :require_solid_queue as a before_action" do
+      callbacks = controller_class._process_action_callbacks.map(&:filter)
+      expect(callbacks).to include(:require_solid_queue)
+    end
+  end
+
+  describe "#require_solid_queue" do
+    context "when SolidQueue is available" do
+      before { allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(true) }
+
+      it "does not redirect" do
+        expect(controller).not_to receive(:redirect_to)
+        controller.send(:require_solid_queue)
+      end
+    end
+
+    context "when SolidQueue is not available" do
+      before { allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(false) }
+
+      it "redirects to root with an alert" do
+        expect(controller).to receive(:redirect_to).with(
+          "/solid_observer",
+          alert: "SolidQueue is not available."
+        )
+        controller.send(:require_solid_queue)
+      end
+    end
+  end
+end

--- a/spec/solid_observer/events_controller_spec.rb
+++ b/spec/solid_observer/events_controller_spec.rb
@@ -17,118 +17,59 @@ RSpec.describe SolidObserver::EventsController do
       expect(callbacks).to include(:require_persistence_mode)
     end
 
-    it "registers :set_event as a before_action only for show" do
-      callbacks = described_class._process_action_callbacks.select { |cb| cb.filter == :set_event }
-      expect(callbacks).not_to be_empty
-      expect(callbacks.first.kind).to eq(:before)
-    end
-
     it "defines PER_PAGE as 50" do
       expect(described_class::PER_PAGE).to eq(50)
     end
   end
 
-  describe "#set_filter_params" do
-    it "extracts event_type from params" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(event_type: "job_failed"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@event_type)).to eq("job_failed")
+  describe "#index" do
+    let(:from) { Date.new(2026, 1, 1) }
+    let(:to) { Date.new(2026, 1, 31) }
+    let(:filter) do
+      filter_values = {
+        page: 2,
+        event_type: "job_failed",
+        job_class: "MyJob",
+        queue_name: "default",
+        from: from,
+        to: to
+      }
+      instance_double(SolidObserver::Params::EventsFilter, **filter_values)
     end
-
-    it "extracts job_class from params" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(job_class: "MyJob"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@job_class)).to eq("MyJob")
-    end
-
-    it "extracts queue_name from params" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(queue_name: "default"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@queue_name)).to eq("default")
-    end
-
-    it "defaults @page to 1 when not given" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new({}))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@page)).to eq(1)
-    end
-
-    it "converts page to integer" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(page: "4"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@page)).to eq(4)
-    end
-
-    it "parses from date" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(from: "2026-01-01"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@from)).to eq(Date.new(2026, 1, 1))
-    end
-
-    it "parses to date" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(to: "2026-01-31"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@to)).to eq(Date.new(2026, 1, 31))
-    end
-  end
-
-  describe "#build_event_scope" do
-    let(:base_scope) { double("base_scope") }
+    let(:scope) { double("scope") }
+    let(:limited_scope) { double("limited_scope") }
+    let(:events) { [double("event")] }
+    let(:query) { instance_double(SolidObserver::Queries::EventsQuery, call: scope) }
 
     before do
-      allow(SolidObserver::QueueEvent).to receive(:order).with(recorded_at: :desc).and_return(base_scope)
-      controller.instance_variable_set(:@event_type, nil)
-      controller.instance_variable_set(:@job_class, nil)
-      controller.instance_variable_set(:@queue_name, nil)
-      controller.instance_variable_set(:@from, nil)
-      controller.instance_variable_set(:@to, nil)
+      allow(controller).to receive(:params).and_return(ActionController::Parameters.new({}))
+      allow(SolidObserver::Params::EventsFilter).to receive(:from_params).and_return(filter)
+      allow(SolidObserver::Queries::EventsQuery).to receive(:new).with(filter).and_return(query)
+      allow(controller).to receive(:paginate_scope).with(scope, per_page: described_class::PER_PAGE).and_return(50)
+      allow(scope).to receive(:limit).with(described_class::PER_PAGE).and_return(limited_scope)
+      allow(limited_scope).to receive(:offset).with(50).and_return(events)
+      allow(controller).to receive(:load_available_options).and_return({})
     end
 
-    it "returns base scope when no filters set" do
-      expect(controller.send(:build_event_scope)).to eq(base_scope)
+    it "assigns @events" do
+      controller.send(:index)
+      expect(controller.instance_variable_get(:@events)).to eq(events)
     end
 
-    it "applies event_type filter" do
-      controller.instance_variable_set(:@event_type, "job_failed")
-      filtered = double("filtered")
-      allow(base_scope).to receive(:by_event_type).with("job_failed").and_return(filtered)
-      expect(controller.send(:build_event_scope)).to eq(filtered)
-    end
-
-    it "applies job_class filter" do
-      controller.instance_variable_set(:@job_class, "MyJob")
-      filtered = double("filtered")
-      allow(base_scope).to receive(:by_job_class).with("MyJob").and_return(filtered)
-      expect(controller.send(:build_event_scope)).to eq(filtered)
-    end
-
-    it "applies queue_name filter" do
-      controller.instance_variable_set(:@queue_name, "default")
-      filtered = double("filtered")
-      allow(base_scope).to receive(:by_queue).with("default").and_return(filtered)
-      expect(controller.send(:build_event_scope)).to eq(filtered)
-    end
-
-    it "applies from date filter" do
-      date = Date.new(2026, 1, 1)
-      controller.instance_variable_set(:@from, date)
-      filtered = double("filtered")
-      allow(base_scope).to receive(:since).with(date.beginning_of_day).and_return(filtered)
-      expect(controller.send(:build_event_scope)).to eq(filtered)
-    end
-
-    it "applies to date filter" do
-      date = Date.new(2026, 1, 31)
-      controller.instance_variable_set(:@to, date)
-      filtered = double("filtered")
-      allow(base_scope).to receive(:before).with(date.end_of_day).and_return(filtered)
-      expect(controller.send(:build_event_scope)).to eq(filtered)
+    it "assigns legacy filter ivars" do
+      controller.send(:index)
+      expect(controller.instance_variable_get(:@event_type)).to eq("job_failed")
+      expect(controller.instance_variable_get(:@job_class)).to eq("MyJob")
+      expect(controller.instance_variable_get(:@queue_name)).to eq("default")
+      expect(controller.instance_variable_get(:@from)).to eq(from)
+      expect(controller.instance_variable_get(:@to)).to eq(to)
+      expect(controller.instance_variable_get(:@page)).to eq(2)
     end
   end
 
-  describe "#set_event" do
+  describe "#show" do
     context "when event exists" do
-      let(:event) { double("event") }
+      let(:event) { double("event", metadata: '{"key":"value"}') }
 
       before do
         allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "1"))
@@ -136,13 +77,13 @@ RSpec.describe SolidObserver::EventsController do
       end
 
       it "assigns @event" do
-        controller.send(:set_event)
+        controller.send(:show)
         expect(controller.instance_variable_get(:@event)).to eq(event)
       end
 
-      it "does not redirect" do
-        expect(controller).not_to receive(:redirect_to)
-        controller.send(:set_event)
+      it "assigns parsed metadata" do
+        controller.send(:show)
+        expect(controller.instance_variable_get(:@metadata)).to eq({"key" => "value"})
       end
     end
 
@@ -155,26 +96,8 @@ RSpec.describe SolidObserver::EventsController do
 
       it "redirects with an alert" do
         expect(controller).to receive(:redirect_to).with("/solid_observer/events", alert: "Event not found")
-        controller.send(:set_event)
+        controller.send(:show)
       end
-    end
-  end
-
-  describe "#parse_date" do
-    it "returns nil for blank string" do
-      expect(controller.send(:parse_date, "")).to be_nil
-    end
-
-    it "returns nil for nil" do
-      expect(controller.send(:parse_date, nil)).to be_nil
-    end
-
-    it "parses a valid date string" do
-      expect(controller.send(:parse_date, "2026-04-06")).to eq(Date.new(2026, 4, 6))
-    end
-
-    it "returns nil for invalid date" do
-      expect(controller.send(:parse_date, "not-a-date")).to be_nil
     end
   end
 
@@ -203,7 +126,7 @@ RSpec.describe SolidObserver::EventsController do
       allow(SolidObserver::QueueEvent).to receive(:distinct_queue_names).and_return(%w[default urgent])
     end
 
-    it "sets @available_event_types from EVENT_TYPES constant" do
+    it "assigns available event types from EVENT_TYPES constant" do
       controller.send(:load_available_options)
       expect(controller.instance_variable_get(:@available_event_types)).to eq(SolidObserver::QueueEvent::EVENT_TYPES)
     end
@@ -213,8 +136,10 @@ RSpec.describe SolidObserver::EventsController do
       expect(SolidObserver::QueueEvent).to receive(:distinct_queue_names).once.and_return(["q"])
 
       controller.send(:load_available_options)
-      controller.send(:load_available_options)
+      expect(controller.instance_variable_get(:@available_job_classes)).to eq(["A"])
+      expect(controller.instance_variable_get(:@available_queues)).to eq(["q"])
 
+      controller.send(:load_available_options)
       expect(controller.instance_variable_get(:@available_job_classes)).to eq(["A"])
       expect(controller.instance_variable_get(:@available_queues)).to eq(["q"])
     end

--- a/spec/solid_observer/jobs_controller_spec.rb
+++ b/spec/solid_observer/jobs_controller_spec.rb
@@ -31,273 +31,55 @@ RSpec.describe SolidObserver::JobsController do
     end
   end
 
-  describe "#set_filter_params" do
-    it "defaults @status to 'ready'" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new({}))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@status)).to eq("ready")
+  describe "#index" do
+    let(:filter) do
+      instance_double(
+        SolidObserver::Params::JobsFilter,
+        page: 2,
+        status: "ready",
+        queue_name: "default",
+        job_class: "MyJob"
+      )
     end
-
-    it "reads status from params" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(status: "failed"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@status)).to eq("failed")
-    end
-
-    it "reads queue_name from params" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(queue_name: "default"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@queue_name)).to eq("default")
-    end
-
-    it "reads job_class from params" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(job_class: "MyJob"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@job_class)).to eq("MyJob")
-    end
-
-    it "defaults @page to 1" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new({}))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@page)).to eq(1)
-    end
-
-    it "converts page param to integer" do
-      allow(controller).to receive(:params).and_return(ActionController::Parameters.new(page: "3"))
-      controller.send(:set_filter_params)
-      expect(controller.instance_variable_get(:@page)).to eq(3)
-    end
-  end
-
-  describe "#scope_for_status" do
-    it "returns ReadyExecution for 'ready'" do
-      ready_scope = double("ready_scope")
-      allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
-      expect(controller.send(:scope_for_status, "ready")).to eq(ready_scope)
-    end
-
-    it "returns ScheduledExecution for 'scheduled'" do
-      sched_scope = double("sched_scope")
-      allow(SolidQueue::ScheduledExecution).to receive(:all).and_return(sched_scope)
-      expect(controller.send(:scope_for_status, "scheduled")).to eq(sched_scope)
-    end
-
-    it "returns ClaimedExecution for 'claimed'" do
-      claimed_scope = double("claimed_scope")
-      allow(SolidQueue::ClaimedExecution).to receive(:all).and_return(claimed_scope)
-      expect(controller.send(:scope_for_status, "claimed")).to eq(claimed_scope)
-    end
-
-    it "returns FailedExecution for 'failed'" do
-      failed_scope = double("failed_scope")
-      allow(SolidQueue::FailedExecution).to receive(:all).and_return(failed_scope)
-      expect(controller.send(:scope_for_status, "failed")).to eq(failed_scope)
-    end
-
-    it "defaults to ReadyExecution for unknown status" do
-      ready_scope = double("ready_scope")
-      allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
-      expect(controller.send(:scope_for_status, "unknown_status")).to eq(ready_scope)
-    end
-  end
-
-  describe "#apply_queue_filter" do
     let(:scope) { double("scope") }
-
-    it "returns scope unchanged when queue_name is blank" do
-      expect(controller.send(:apply_queue_filter, scope, "ready", nil)).to eq(scope)
-    end
-
-    it "filters by queue_name directly for ready status" do
-      filtered = double("filtered")
-      allow(scope).to receive(:where).with(queue_name: "default").and_return(filtered)
-      expect(controller.send(:apply_queue_filter, scope, "ready", "default")).to eq(filtered)
-    end
-
-    it "joins through job table for failed status" do
-      joined = double("joined")
-      filtered = double("filtered")
-      allow(scope).to receive(:joins).with(:job).and_return(joined)
-      allow(joined).to receive(:where).with(solid_queue_jobs: {queue_name: "default"}).and_return(filtered)
-      expect(controller.send(:apply_queue_filter, scope, "failed", "default")).to eq(filtered)
-    end
-
-    it "joins through job table for claimed status" do
-      joined = double("joined")
-      filtered = double("filtered")
-      allow(scope).to receive(:joins).with(:job).and_return(joined)
-      allow(joined).to receive(:where).with(solid_queue_jobs: {queue_name: "urgent"}).and_return(filtered)
-      expect(controller.send(:apply_queue_filter, scope, "claimed", "urgent")).to eq(filtered)
-    end
-  end
-
-  describe "#apply_filters" do
-    let(:scope) { double("scope") }
+    let(:limited_scope) { double("limited_scope") }
+    let(:offset_scope) { double("offset_scope") }
+    let(:jobs) { [double("execution")] }
+    let(:query) { instance_double(SolidObserver::Queries::JobExecutionsQuery, call: scope) }
 
     before do
-      controller.instance_variable_set(:@queue_name, nil)
-      controller.instance_variable_set(:@job_class, nil)
-      controller.instance_variable_set(:@status, "ready")
+      allow(controller).to receive(:params).and_return(ActionController::Parameters.new({}))
+      allow(SolidObserver::Params::JobsFilter).to receive(:from_params).and_return(filter)
+      allow(SolidObserver::Queries::JobExecutionsQuery).to receive(:new).with(filter).and_return(query)
+      allow(controller).to receive(:paginate_scope).with(scope, per_page: described_class::PER_PAGE).and_return(25)
+      allow(scope).to receive(:limit).with(described_class::PER_PAGE).and_return(limited_scope)
+      allow(limited_scope).to receive(:offset).with(25).and_return(offset_scope)
+      allow(offset_scope).to receive(:includes).with(:job).and_return(jobs)
+      allow(controller).to receive(:fetch_available_queues).and_return(["default"])
+      allow(controller).to receive(:fetch_available_job_classes).and_return(["MyJob"])
     end
 
-    it "returns scope unchanged when no filters set" do
-      expect(controller.send(:apply_filters, scope)).to eq(scope)
+    it "assigns @jobs" do
+      controller.send(:index)
+      expect(controller.instance_variable_get(:@jobs)).to eq(jobs)
     end
 
-    it "joins job table and filters by class_name when job_class present" do
-      controller.instance_variable_set(:@job_class, "MyJob")
-      joined = double("joined")
-      filtered = double("filtered")
-      allow(scope).to receive(:joins).with(:job).and_return(joined)
-      allow(joined).to receive(:where).with(solid_queue_jobs: {class_name: "MyJob"}).and_return(filtered)
-      expect(controller.send(:apply_filters, scope)).to eq(filtered)
-    end
-  end
-
-  describe "#find_execution" do
-    it "returns ReadyExecution when found" do
-      exec = double("execution")
-      allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: "1").and_return(exec)
-      expect(controller.send(:find_execution, "1")).to eq(exec)
-    end
-
-    it "checks other types when ReadyExecution not found" do
-      allow(SolidQueue::ReadyExecution).to receive(:find_by).and_return(nil)
-      exec = double("execution")
-      allow(SolidQueue::ScheduledExecution).to receive(:find_by).with(id: "2").and_return(exec)
-      allow(SolidQueue::ClaimedExecution).to receive(:find_by).and_return(nil)
-      allow(SolidQueue::FailedExecution).to receive(:find_by).and_return(nil)
-      expect(controller.send(:find_execution, "2")).to eq(exec)
-    end
-
-    it "returns nil when not found in any execution type" do
-      allow(SolidQueue::ReadyExecution).to receive(:find_by).and_return(nil)
-      allow(SolidQueue::ScheduledExecution).to receive(:find_by).and_return(nil)
-      allow(SolidQueue::ClaimedExecution).to receive(:find_by).and_return(nil)
-      allow(SolidQueue::FailedExecution).to receive(:find_by).and_return(nil)
-      expect(controller.send(:find_execution, "999")).to be_nil
-    end
-  end
-
-  describe "#show" do
-    context "when execution is found" do
-      let(:execution) { double("execution", class: SolidQueue::ReadyExecution) }
-      let(:job) { double("job") }
-
-      before do
-        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "1"))
-        allow(controller).to receive(:find_execution).with("1").and_return(execution)
-        allow(execution).to receive(:job).and_return(job)
-        allow(execution).to receive(:class).and_return(SolidQueue::ReadyExecution)
-      end
-
-      it "assigns @execution" do
-        controller.send(:show)
-        expect(controller.instance_variable_get(:@execution)).to eq(execution)
-      end
-
-      it "assigns @job" do
-        controller.send(:show)
-        expect(controller.instance_variable_get(:@job)).to eq(job)
-      end
-
-      it "assigns @status via determine_status" do
-        controller.send(:show)
-        expect(controller.instance_variable_get(:@status)).to eq("ready")
-      end
-    end
-
-    context "when execution is not found" do
-      before do
-        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
-        allow(controller).to receive(:find_execution).with("999").and_return(nil)
-        controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
-      end
-
-      it "redirects with an alert" do
-        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", alert: "Job not found")
-        controller.send(:show)
-      end
-    end
-  end
-
-  describe "#retry" do
-    context "when failed execution exists" do
-      let(:execution) { double("execution") }
-
-      before do
-        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "5"))
-        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: "5").and_return(execution)
-        controller.define_singleton_method(:jobs_path) { |**| "/solid_observer/jobs" }
-      end
-
-      it "calls retry on the execution" do
-        allow(controller).to receive(:redirect_to)
-        expect(execution).to receive(:retry)
-        controller.send(:retry)
-      end
-
-      it "redirects with a notice" do
-        allow(execution).to receive(:retry)
-        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", notice: "Job 5 queued for retry")
-        controller.send(:retry)
-      end
-    end
-
-    context "when failed execution is not found" do
-      before do
-        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
-        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: "999").and_return(nil)
-        controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
-      end
-
-      it "redirects with an alert" do
-        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", alert: "Failed job not found")
-        controller.send(:retry)
-      end
-    end
-  end
-
-  describe "#discard" do
-    context "when failed execution exists" do
-      let(:execution) { double("execution") }
-
-      before do
-        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "7"))
-        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: "7").and_return(execution)
-        controller.define_singleton_method(:jobs_path) { |**| "/solid_observer/jobs" }
-      end
-
-      it "calls discard on the execution" do
-        allow(controller).to receive(:redirect_to)
-        expect(execution).to receive(:discard)
-        controller.send(:discard)
-      end
-
-      it "redirects with a notice" do
-        allow(execution).to receive(:discard)
-        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", notice: "Job 7 discarded")
-        controller.send(:discard)
-      end
-    end
-
-    context "when failed execution is not found" do
-      before do
-        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
-        allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: "999").and_return(nil)
-        controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
-      end
-
-      it "redirects with an alert" do
-        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", alert: "Failed job not found")
-        controller.send(:discard)
-      end
+    it "assigns legacy filter ivars" do
+      controller.send(:index)
+      expect(controller.instance_variable_get(:@status)).to eq("ready")
+      expect(controller.instance_variable_get(:@queue_name)).to eq("default")
+      expect(controller.instance_variable_get(:@job_class)).to eq("MyJob")
     end
   end
 
   describe "#fetch_available_queues" do
     context "when SolidQueue::Queue is defined" do
-      before { stub_const("SolidQueue::Queue", Class.new(ActiveRecord::Base)) }
+      before do
+        stub_const("SolidQueue::Queue", Class.new {
+          def self.all
+          end
+        })
+      end
 
       it "returns queue names" do
         q1 = double("q1", name: "default")
@@ -308,6 +90,8 @@ RSpec.describe SolidObserver::JobsController do
     end
 
     context "when SolidQueue::Queue is not defined" do
+      before { hide_const("SolidQueue::Queue") if defined?(SolidQueue::Queue) }
+
       it "returns empty array" do
         expect(controller.send(:fetch_available_queues)).to eq([])
       end
@@ -315,7 +99,10 @@ RSpec.describe SolidObserver::JobsController do
 
     context "on ActiveRecord error" do
       before do
-        stub_const("SolidQueue::Queue", Class.new(ActiveRecord::Base))
+        stub_const("SolidQueue::Queue", Class.new {
+          def self.all
+          end
+        })
         allow(SolidQueue::Queue).to receive(:all).and_raise(ActiveRecord::StatementInvalid)
       end
 
@@ -336,6 +123,122 @@ RSpec.describe SolidObserver::JobsController do
     it "returns empty array on ActiveRecord error" do
       allow(SolidQueue::Job).to receive(:distinct).and_raise(ActiveRecord::StatementInvalid)
       expect(controller.send(:fetch_available_job_classes)).to eq([])
+    end
+  end
+
+  describe "#show" do
+    context "when execution is found" do
+      let(:execution) { double("execution") }
+      let(:job) { double("job") }
+      let(:presenter) { instance_double(SolidObserver::ExecutionPresenter, job: job, status: "ready") }
+
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "1"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_any).with("1").and_return(execution)
+        allow(SolidObserver::ExecutionPresenter).to receive(:new).with(execution).and_return(presenter)
+      end
+
+      it "assigns @execution" do
+        controller.send(:show)
+        expect(controller.instance_variable_get(:@execution)).to eq(execution)
+      end
+
+      it "assigns @job" do
+        controller.send(:show)
+        expect(controller.instance_variable_get(:@job)).to eq(job)
+      end
+
+      it "assigns @status from presenter" do
+        controller.send(:show)
+        expect(controller.instance_variable_get(:@status)).to eq("ready")
+      end
+    end
+
+    context "when execution is not found" do
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_any).with("999").and_return(nil)
+        controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
+      end
+
+      it "redirects with an alert" do
+        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", alert: "Job not found")
+        controller.send(:show)
+      end
+    end
+  end
+
+  describe "#retry" do
+    context "when failed execution exists" do
+      let(:execution) { double("execution") }
+
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "5"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_failed).with("5").and_return(execution)
+        controller.define_singleton_method(:jobs_path) { |**| "/solid_observer/jobs" }
+      end
+
+      it "calls retry on the execution" do
+        allow(controller).to receive(:redirect_to)
+        expect(execution).to receive(:retry)
+        controller.send(:retry)
+      end
+
+      it "redirects with a notice" do
+        allow(execution).to receive(:retry)
+        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", notice: "Job 5 queued for retry")
+        controller.send(:retry)
+      end
+    end
+
+    context "when failed execution is not found" do
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_failed).with("999").and_return(nil)
+        controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
+      end
+
+      it "redirects with an alert" do
+        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", alert: "Failed job not found")
+        controller.send(:retry)
+      end
+    end
+  end
+
+  describe "#discard" do
+    context "when failed execution exists" do
+      let(:execution) { double("execution") }
+
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "7"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_failed).with("7").and_return(execution)
+        controller.define_singleton_method(:jobs_path) { |**| "/solid_observer/jobs" }
+      end
+
+      it "calls discard on the execution" do
+        allow(controller).to receive(:redirect_to)
+        expect(execution).to receive(:discard)
+        controller.send(:discard)
+      end
+
+      it "redirects with a notice" do
+        allow(execution).to receive(:discard)
+        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", notice: "Job 7 discarded")
+        controller.send(:discard)
+      end
+    end
+
+    context "when failed execution is not found" do
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_failed).with("999").and_return(nil)
+        controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
+      end
+
+      it "redirects with an alert" do
+        expect(controller).to receive(:redirect_to).with("/solid_observer/jobs", alert: "Failed job not found")
+        controller.send(:discard)
+      end
     end
   end
 end

--- a/spec/solid_observer/params/events_filter_spec.rb
+++ b/spec/solid_observer/params/events_filter_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Params::EventsFilter do
+  describe ".from_params" do
+    it "extracts event_type from params" do
+      filter = described_class.from_params(ActionController::Parameters.new(event_type: "job_failed"))
+      expect(filter.event_type).to eq("job_failed")
+    end
+
+    it "extracts job_class from params" do
+      filter = described_class.from_params(ActionController::Parameters.new(job_class: "MyJob"))
+      expect(filter.job_class).to eq("MyJob")
+    end
+
+    it "extracts queue_name from params" do
+      filter = described_class.from_params(ActionController::Parameters.new(queue_name: "default"))
+      expect(filter.queue_name).to eq("default")
+    end
+
+    it "defaults page to 1 when not given" do
+      filter = described_class.from_params(ActionController::Parameters.new({}))
+      expect(filter.page).to eq(1)
+    end
+
+    it "converts page to integer" do
+      filter = described_class.from_params(ActionController::Parameters.new(page: "4"))
+      expect(filter.page).to eq(4)
+    end
+
+    it "parses from date" do
+      filter = described_class.from_params(ActionController::Parameters.new(from: "2026-01-01"))
+      expect(filter.from).to eq(Date.new(2026, 1, 1))
+    end
+
+    it "parses to date" do
+      filter = described_class.from_params(ActionController::Parameters.new(to: "2026-01-31"))
+      expect(filter.to).to eq(Date.new(2026, 1, 31))
+    end
+
+    it "returns nil for blank date string" do
+      filter = described_class.from_params(ActionController::Parameters.new(from: ""))
+      expect(filter.from).to be_nil
+    end
+
+    it "returns nil for invalid date" do
+      filter = described_class.from_params(ActionController::Parameters.new(from: "not-a-date"))
+      expect(filter.from).to be_nil
+    end
+  end
+end

--- a/spec/solid_observer/params/jobs_filter_spec.rb
+++ b/spec/solid_observer/params/jobs_filter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Params::JobsFilter do
+  describe ".from_params" do
+    it "defaults status to ready" do
+      filter = described_class.from_params(ActionController::Parameters.new({}))
+      expect(filter.status).to eq("ready")
+    end
+
+    it "reads status from params" do
+      filter = described_class.from_params(ActionController::Parameters.new(status: "failed"))
+      expect(filter.status).to eq("failed")
+    end
+
+    it "reads queue_name from params" do
+      filter = described_class.from_params(ActionController::Parameters.new(queue_name: "default"))
+      expect(filter.queue_name).to eq("default")
+    end
+
+    it "reads job_class from params" do
+      filter = described_class.from_params(ActionController::Parameters.new(job_class: "MyJob"))
+      expect(filter.job_class).to eq("MyJob")
+    end
+
+    it "defaults page to 1" do
+      filter = described_class.from_params(ActionController::Parameters.new({}))
+      expect(filter.page).to eq(1)
+    end
+
+    it "converts page param to integer" do
+      filter = described_class.from_params(ActionController::Parameters.new(page: "3"))
+      expect(filter.page).to eq(3)
+    end
+
+    it "normalizes status case" do
+      filter = described_class.from_params(ActionController::Parameters.new(status: "FAILED"))
+      expect(filter.status).to eq("failed")
+    end
+
+    it "falls back to ready for unknown status" do
+      filter = described_class.from_params(ActionController::Parameters.new(status: "unknown_status"))
+      expect(filter.status).to eq("ready")
+    end
+  end
+end

--- a/spec/solid_observer/presenters/execution_presenter_spec.rb
+++ b/spec/solid_observer/presenters/execution_presenter_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::ExecutionPresenter do
+  before do
+    stub_const("SolidQueue::ReadyExecution", Class.new)
+    stub_const("SolidQueue::ScheduledExecution", Class.new)
+    stub_const("SolidQueue::ClaimedExecution", Class.new)
+    stub_const("SolidQueue::FailedExecution", Class.new)
+  end
+
+  describe "#status" do
+    it "returns ready for ReadyExecution" do
+      presenter = described_class.new(SolidQueue::ReadyExecution.new)
+      expect(presenter.status).to eq("ready")
+    end
+
+    it "returns scheduled for ScheduledExecution" do
+      presenter = described_class.new(SolidQueue::ScheduledExecution.new)
+      expect(presenter.status).to eq("scheduled")
+    end
+
+    it "returns claimed for ClaimedExecution" do
+      presenter = described_class.new(SolidQueue::ClaimedExecution.new)
+      expect(presenter.status).to eq("claimed")
+    end
+
+    it "returns failed for FailedExecution" do
+      presenter = described_class.new(SolidQueue::FailedExecution.new)
+      expect(presenter.status).to eq("failed")
+    end
+
+    it "returns unknown for unrecognized class" do
+      presenter = described_class.new(Object.new)
+      expect(presenter.status).to eq("unknown")
+    end
+  end
+
+  describe "#job" do
+    it "delegates to execution.job" do
+      job = double("job")
+      execution = double("execution", job: job)
+      presenter = described_class.new(execution)
+
+      expect(presenter.job).to eq(job)
+    end
+  end
+
+  describe "#to_model" do
+    it "returns the wrapped execution" do
+      execution = double("execution")
+      presenter = described_class.new(execution)
+
+      expect(presenter.to_model).to eq(execution)
+    end
+  end
+end

--- a/spec/solid_observer/queries/events_query_spec.rb
+++ b/spec/solid_observer/queries/events_query_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Queries::EventsQuery do
+  let(:filter_class) { Struct.new(:event_type, :job_class, :queue_name, :from, :to, keyword_init: true) }
+
+  def build_filter(event_type: nil, job_class: nil, queue_name: nil, from: nil, to: nil)
+    filter_class.new(event_type: event_type, job_class: job_class, queue_name: queue_name, from: from, to: to)
+  end
+
+  let(:base_scope) { double("base_scope") }
+
+  before do
+    allow(SolidObserver::QueueEvent).to receive(:order).with(recorded_at: :desc).and_return(base_scope)
+  end
+
+  it "returns base scope when no filters set" do
+    expect(described_class.new(build_filter).call).to eq(base_scope)
+  end
+
+  it "applies event_type filter" do
+    filtered_scope = double("filtered_scope")
+    allow(base_scope).to receive(:by_event_type).with("job_failed").and_return(filtered_scope)
+    expect(described_class.new(build_filter(event_type: "job_failed")).call).to eq(filtered_scope)
+  end
+
+  it "applies job_class filter" do
+    filtered_scope = double("filtered_scope")
+    allow(base_scope).to receive(:by_job_class).with("MyJob").and_return(filtered_scope)
+    expect(described_class.new(build_filter(job_class: "MyJob")).call).to eq(filtered_scope)
+  end
+
+  it "applies queue_name filter" do
+    filtered_scope = double("filtered_scope")
+    allow(base_scope).to receive(:by_queue).with("default").and_return(filtered_scope)
+    expect(described_class.new(build_filter(queue_name: "default")).call).to eq(filtered_scope)
+  end
+
+  it "applies from date filter" do
+    date = Date.new(2026, 1, 1)
+    filtered_scope = double("filtered_scope")
+    allow(base_scope).to receive(:since).with(date.beginning_of_day).and_return(filtered_scope)
+    expect(described_class.new(build_filter(from: date)).call).to eq(filtered_scope)
+  end
+
+  it "applies to date filter" do
+    date = Date.new(2026, 1, 31)
+    filtered_scope = double("filtered_scope")
+    allow(base_scope).to receive(:before).with(date.end_of_day).and_return(filtered_scope)
+    expect(described_class.new(build_filter(to: date)).call).to eq(filtered_scope)
+  end
+end

--- a/spec/solid_observer/queries/execution_finder_spec.rb
+++ b/spec/solid_observer/queries/execution_finder_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Queries::ExecutionFinder do
+  before do
+    stub_const("SolidQueue", Module.new)
+    stub_const("SolidQueue::ReadyExecution", Class.new {
+      def self.find_by(id:)
+      end
+    })
+    stub_const("SolidQueue::ScheduledExecution", Class.new {
+      def self.find_by(id:)
+      end
+    })
+    stub_const("SolidQueue::ClaimedExecution", Class.new {
+      def self.find_by(id:)
+      end
+    })
+    stub_const("SolidQueue::FailedExecution", Class.new {
+      def self.find_by(id:)
+      end
+    })
+  end
+
+  describe ".find_any" do
+    it "returns ReadyExecution when found" do
+      execution = double("execution")
+      allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: "1").and_return(execution)
+
+      expect(described_class.find_any("1")).to eq(execution)
+    end
+
+    it "checks other types when ReadyExecution not found" do
+      allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: "2").and_return(nil)
+      execution = double("execution")
+      allow(SolidQueue::ScheduledExecution).to receive(:find_by).with(id: "2").and_return(execution)
+
+      expect(described_class.find_any("2")).to eq(execution)
+    end
+
+    it "returns nil when not found in any execution type" do
+      allow(SolidQueue::ReadyExecution).to receive(:find_by).with(id: "999").and_return(nil)
+      allow(SolidQueue::ScheduledExecution).to receive(:find_by).with(id: "999").and_return(nil)
+      allow(SolidQueue::ClaimedExecution).to receive(:find_by).with(id: "999").and_return(nil)
+      allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: "999").and_return(nil)
+
+      expect(described_class.find_any("999")).to be_nil
+    end
+  end
+
+  describe ".find_failed" do
+    it "returns failed execution when found" do
+      execution = double("execution")
+      allow(SolidQueue::FailedExecution).to receive(:find_by).with(id: "5").and_return(execution)
+
+      expect(described_class.find_failed("5")).to eq(execution)
+    end
+
+    it "returns nil when FailedExecution constant is unavailable" do
+      hide_const("SolidQueue::FailedExecution")
+      expect(described_class.find_failed("5")).to be_nil
+    end
+  end
+end

--- a/spec/solid_observer/queries/job_executions_query_spec.rb
+++ b/spec/solid_observer/queries/job_executions_query_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Queries::JobExecutionsQuery do
+  before do
+    stub_const("SolidQueue", Module.new)
+    stub_const("SolidQueue::ReadyExecution", Class.new {
+      def self.all
+      end
+    })
+    stub_const("SolidQueue::ScheduledExecution", Class.new {
+      def self.all
+      end
+    })
+    stub_const("SolidQueue::ClaimedExecution", Class.new {
+      def self.all
+      end
+    })
+    stub_const("SolidQueue::FailedExecution", Class.new {
+      def self.all
+      end
+    })
+    stub_const("SolidQueue::Job", Class.new {
+      def self.distinct
+      end
+    })
+  end
+
+  let(:filter_class) { Struct.new(:status, :queue_name, :job_class, keyword_init: true) }
+
+  def build_filter(status: "ready", queue_name: nil, job_class: nil)
+    filter_class.new(status: status, queue_name: queue_name, job_class: job_class)
+  end
+
+  it "returns ReadyExecution for ready status" do
+    ready_scope = double("ready_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
+    allow(ready_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "ready")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "returns ScheduledExecution for scheduled status" do
+    scheduled_scope = double("scheduled_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ScheduledExecution).to receive(:all).and_return(scheduled_scope)
+    allow(scheduled_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "scheduled")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "returns ClaimedExecution for claimed status" do
+    claimed_scope = double("claimed_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ClaimedExecution).to receive(:all).and_return(claimed_scope)
+    allow(claimed_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "claimed")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "returns FailedExecution for failed status" do
+    failed_scope = double("failed_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::FailedExecution).to receive(:all).and_return(failed_scope)
+    allow(failed_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "failed")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "defaults to ReadyExecution for unknown status" do
+    ready_scope = double("ready_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
+    allow(ready_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "unknown_status")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "filters by queue_name directly for ready status" do
+    ready_scope = double("ready_scope")
+    filtered_scope = double("filtered_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
+    allow(ready_scope).to receive(:where).with(queue_name: "default").and_return(filtered_scope)
+    allow(filtered_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "ready", queue_name: "default")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "joins through job table for failed status queue filter" do
+    failed_scope = double("failed_scope")
+    joined_scope = double("joined_scope")
+    filtered_scope = double("filtered_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::FailedExecution).to receive(:all).and_return(failed_scope)
+    allow(failed_scope).to receive(:joins).with(:job).and_return(joined_scope)
+    allow(joined_scope).to receive(:where).with(solid_queue_jobs: {queue_name: "default"}).and_return(filtered_scope)
+    allow(filtered_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "failed", queue_name: "default")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "joins through job table for claimed status queue filter" do
+    claimed_scope = double("claimed_scope")
+    joined_scope = double("joined_scope")
+    filtered_scope = double("filtered_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ClaimedExecution).to receive(:all).and_return(claimed_scope)
+    allow(claimed_scope).to receive(:joins).with(:job).and_return(joined_scope)
+    allow(joined_scope).to receive(:where).with(solid_queue_jobs: {queue_name: "urgent"}).and_return(filtered_scope)
+    allow(filtered_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "claimed", queue_name: "urgent")).call
+    expect(result).to eq(ordered_scope)
+  end
+
+  it "joins job table and filters by class_name when job_class present" do
+    ready_scope = double("ready_scope")
+    joined_scope = double("joined_scope")
+    filtered_scope = double("filtered_scope")
+    ordered_scope = double("ordered_scope")
+    allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
+    allow(ready_scope).to receive(:joins).with(:job).and_return(joined_scope)
+    allow(joined_scope).to receive(:where).with(solid_queue_jobs: {class_name: "MyJob"}).and_return(filtered_scope)
+    allow(filtered_scope).to receive(:order).with(created_at: :desc).and_return(ordered_scope)
+
+    result = described_class.new(build_filter(status: "ready", job_class: "MyJob")).call
+    expect(result).to eq(ordered_scope)
+  end
+end

--- a/spec/solid_observer/services/cleanup_storage_spec.rb
+++ b/spec/solid_observer/services/cleanup_storage_spec.rb
@@ -149,17 +149,4 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
       end
     end
   end
-
-  describe "private methods" do
-    let(:service) { described_class.new }
-
-    describe "#format_bytes" do
-      it "formats bytes correctly" do
-        expect(service.send(:format_bytes, 0)).to eq("0 B")
-        expect(service.send(:format_bytes, 1024)).to eq("1.0 KB")
-        expect(service.send(:format_bytes, 1.megabyte)).to eq("1.0 MB")
-        expect(service.send(:format_bytes, 1.gigabyte)).to eq("1.0 GB")
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Summary of the changes:
- JobsController/EventsController: plain ivar assignments (no instance_variable_set loops)
- EventsQuery: inline filter access with locals (no delegator methods)
- EventsFilter: plain attr_reader (matching JobsFilter; no define_method loop)
- Move available_queues/available_job_classes back to JobsController privates
- Add execution_status helper for views (no inline presenter instantiation)
- ExecutionFinder.find_any: plain each loop
- Targeted reek suppressions for legitimate controller-form smells