### PR TITLE
[SO-046][SECURITY][FIX] Fix RecordEvent metadata extraction + remove arguments PII

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -30,7 +30,6 @@ detectors:
       - SolidObserver::QueueEventBuffer#trim_events_for_capacity
       - SolidObserver::Services::FlushEventBuffer#call
       - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
-      - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::DatabaseSize#call
       - SolidObserver::Services::CleanupStorage#call
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
@@ -73,7 +72,6 @@ detectors:
       - CreateSolidObserverQueueEvents#change
       - CreateSolidObserverMetrics#change
       - CreateSolidObserverStorageInfo#change
-      - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::CLI::Base#confirm
       - SolidObserver::CLI::Status#print_queue_stats
       - SolidObserver::CLI::Status#print_queue_table
@@ -97,7 +95,6 @@ detectors:
       - SolidObserver::QueueEventBuffer#flush!
       - SolidObserver::QueueEventBuffer#replace_timer_if_stopped
       - SolidObserver::QueueEventBuffer#record_flush_failure
-      - SolidObserver::Services::RecordEvent#extract_metadata
       - SolidObserver::Services::RecordEvent#handle_error
       - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
       - SolidObserver::CLI::Status#print_queue_stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - QueueEventBuffer uses a single persistent `Concurrent::TimerTask` for scheduled flushes instead of spawning a new thread every cycle
 - Storage monitoring now uses adapter-native size queries (SQLite/PostgreSQL/MySQL/Trilogy) instead of filesystem path checks, fixing `0 MB` false readings on non-SQLite deployments
 - EventsController filter dropdowns were full-table scans on every request
+- JobsController filter dropdown queries are now cached using `filter_cache_ttl` (queues and job classes)
 - `RecordEvent` metadata extraction now supports real `ActiveJob::Base` notification payload objects (with hash fallback)
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - QueueEventBuffer uses a single persistent `Concurrent::TimerTask` for scheduled flushes instead of spawning a new thread every cycle
 - Storage monitoring now uses adapter-native size queries (SQLite/PostgreSQL/MySQL/Trilogy) instead of filesystem path checks, fixing `0 MB` false readings on non-SQLite deployments
 - EventsController filter dropdowns were full-table scans on every request
+- `RecordEvent` metadata extraction now supports real `ActiveJob::Base` notification payload objects (with hash fallback)
+
+### Security
+- Removed job arguments from persisted event metadata and from the jobs detail view to reduce PII exposure risk
 
 ### Added
 - `SolidObserver::QueueEventBuffer#metrics` — exposes flush latency, failure count, drops count, and last-error for observability

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.53%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.2%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---

--- a/app/controllers/solid_observer/jobs_controller.rb
+++ b/app/controllers/solid_observer/jobs_controller.rb
@@ -6,6 +6,8 @@ module SolidObserver
     include RequireSolidQueue
 
     PER_PAGE = 25
+    CACHE_KEY_QUEUES = "solid_observer/jobs/available_queues"
+    CACHE_KEY_JOB_CLASSES = "solid_observer/jobs/available_job_classes"
 
     def index
       filter = Params::JobsFilter.from_params(params)
@@ -50,15 +52,18 @@ module SolidObserver
     private
 
     def fetch_available_queues
-      return [] unless defined?(SolidQueue::Queue)
-
-      SolidQueue::Queue.all.map(&:name)
+      Rails.cache.fetch(CACHE_KEY_QUEUES, expires_in: SolidObserver.config.filter_cache_ttl) do
+        next [] unless defined?(SolidQueue::Queue)
+        SolidQueue::Queue.all.map(&:name)
+      end
     rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished
       []
     end
 
     def fetch_available_job_classes
-      SolidQueue::Job.distinct.pluck(:class_name).compact.sort
+      Rails.cache.fetch(CACHE_KEY_JOB_CLASSES, expires_in: SolidObserver.config.filter_cache_ttl) do
+        SolidQueue::Job.distinct.pluck(:class_name).compact.sort
+      end
     rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished
       []
     end

--- a/app/views/solid_observer/jobs/show.html.erb
+++ b/app/views/solid_observer/jobs/show.html.erb
@@ -45,13 +45,6 @@
   </table>
 </div>
 
-<% if @job&.arguments %>
-  <div class="so-card so-card--spaced">
-    <div class="so-card__label">Arguments</div>
-    <pre class="so-pre"><code><%= JSON.pretty_generate(@job.arguments) rescue @job.arguments.to_s %></code></pre>
-  </div>
-<% end %>
-
 <% if @execution.is_a?(SolidQueue::FailedExecution) && @execution.error %>
   <div class="so-card so-card--error">
     <div class="so-card__label so-card__label--danger">Error Details</div>

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -11,6 +11,15 @@ module SolidObserver
         Rails.logger.warn "[SolidObserver] SolidQueue not detected. Queue observability features will be limited."
       end
 
+      def check_ui_authentication
+        config = SolidObserver.config
+        return unless config.ui_enabled
+        return if config.ui_username.present?
+
+        Rails.logger.warn "[SolidObserver] WARNING: UI is enabled with no authentication configured. " \
+          "Set config.ui_username and config.ui_password."
+      end
+
       def configure_database_connection
         return if SolidObserver.config.realtime_mode?
 
@@ -92,6 +101,7 @@ module SolidObserver
     config.after_initialize do
       Engine.configure_database_connection
       Engine.activate_subscribers
+      Engine.check_ui_authentication
     end
   end
 end

--- a/lib/solid_observer/services/record_event.rb
+++ b/lib/solid_observer/services/record_event.rb
@@ -62,22 +62,55 @@ module SolidObserver
 
       def extract_metadata
         payload = @event.payload || {}
-        exception_obj = payload[:exception_object]
-
-        {
-          job_id: payload.dig(:job, :job_id),
-          job_class: payload.dig(:job, :class_name) || payload.dig(:job, :job_class),
-          queue_name: payload.dig(:job, :queue_name),
-          arguments: payload.dig(:job, :arguments),
-          executions: payload.dig(:job, :executions),
-          exception_class: exception_obj&.class&.name || payload[:exception]&.first,
-          exception_message: exception_obj&.message || payload[:exception]&.last,
-          enqueued_at: payload.dig(:job, :enqueued_at),
-          priority: payload.dig(:job, :priority)
-        }.compact
+        metadata_from(payload, payload[:job]).compact
       rescue => e
         Rails.logger.warn "[SolidObserver] Failed to extract metadata: #{e.message}" if defined?(Rails)
         {}
+      end
+
+      def metadata_from(payload, job)
+        {
+          job_id: read_job_attr(job, :job_id),
+          job_class: read_job_class(job),
+          queue_name: read_job_attr(job, :queue_name),
+          executions: read_job_attr(job, :executions),
+          exception_class: exception_class(payload),
+          exception_message: exception_message(payload),
+          enqueued_at: read_job_attr(job, :enqueued_at),
+          priority: read_job_attr(job, :priority)
+        }
+      end
+
+      def read_job_attr(job, attr)
+        return nil unless job
+
+        if job.is_a?(Hash)
+          job[attr]
+        else
+          job.public_send(attr)
+        end
+      rescue NoMethodError
+        nil
+      end
+
+      def read_job_class(job)
+        return nil unless job
+
+        if job.is_a?(Hash)
+          job[:class_name] || job[:job_class]
+        else
+          job.class.name
+        end
+      end
+
+      def exception_class(payload)
+        exception_obj = payload[:exception_object]
+        exception_obj&.class&.name || payload[:exception]&.first
+      end
+
+      def exception_message(payload)
+        exception_obj = payload[:exception_object]
+        exception_obj&.message || payload[:exception]&.last
       end
 
       def increment_metric

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -35,6 +35,49 @@ RSpec.describe SolidObserver::Engine do
     end
   end
 
+  describe ".check_ui_authentication" do
+    after { SolidObserver.reset_configuration! }
+
+    it "is a public class method" do
+      expect(described_class.public_methods).to include(:check_ui_authentication)
+    end
+
+    context "when UI is disabled" do
+      before { SolidObserver.config.ui_enabled = false }
+
+      it "does not log a warning" do
+        expect(logger).not_to receive(:warn).with(/authentication/)
+        described_class.check_ui_authentication
+      end
+    end
+
+    context "when UI is enabled and username is set" do
+      before do
+        SolidObserver.config.ui_enabled = true
+        SolidObserver.config.ui_username = "admin"
+      end
+
+      it "does not log a warning" do
+        expect(logger).not_to receive(:warn).with(/authentication/)
+        described_class.check_ui_authentication
+      end
+    end
+
+    context "when UI is enabled but no username configured" do
+      before do
+        SolidObserver.config.ui_enabled = true
+        SolidObserver.config.ui_username = nil
+      end
+
+      it "logs a warning" do
+        expect(logger).to receive(:warn).with(
+          /WARNING: UI is enabled with no authentication/
+        )
+        described_class.check_ui_authentication
+      end
+    end
+  end
+
   describe ".activate_subscribers" do
     let(:pool) { instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool) }
     let(:cache) { instance_double(ActiveRecord::ConnectionAdapters::SchemaCache) }

--- a/spec/solid_observer/jobs_controller_spec.rb
+++ b/spec/solid_observer/jobs_controller_spec.rb
@@ -126,6 +126,42 @@ RSpec.describe SolidObserver::JobsController do
     end
   end
 
+  describe "#index filter option caching" do
+    before do
+      SolidObserver.config.filter_cache_ttl = 1.minute
+      stub_const("SolidQueue::Queue", Class.new {
+        def self.all = []
+      })
+      allow(SolidQueue::Queue).to receive(:all).and_return([double("q", name: "default")])
+      allow(SolidQueue::Job).to receive(:distinct).and_return(
+        double("distinct", pluck: ["MyJob"])
+      )
+    end
+
+    it "calls source once on cold cache" do
+      expect(SolidQueue::Queue).to receive(:all).once.and_return([double("q", name: "default")])
+      controller.send(:fetch_available_queues)
+      controller.send(:fetch_available_queues)
+    end
+
+    it "calls job class source once on cold cache" do
+      distinct = double("distinct", pluck: ["MyJob"])
+      expect(SolidQueue::Job).to receive(:distinct).once.and_return(distinct)
+      controller.send(:fetch_available_job_classes)
+      controller.send(:fetch_available_job_classes)
+    end
+
+    it "re-fetches after TTL expiry" do
+      distinct = double("distinct", pluck: ["MyJob"])
+      expect(SolidQueue::Job).to receive(:distinct).twice.and_return(distinct)
+
+      controller.send(:fetch_available_job_classes)
+      travel_to(2.minutes.from_now) do
+        controller.send(:fetch_available_job_classes)
+      end
+    end
+  end
+
   describe "#show" do
     context "when execution is found" do
       let(:execution) { double("execution") }

--- a/spec/solid_observer/services/record_event_spec.rb
+++ b/spec/solid_observer/services/record_event_spec.rb
@@ -3,19 +3,18 @@
 require "spec_helper"
 
 RSpec.describe SolidObserver::Services::RecordEvent do
-  let(:event_payload) do
-    {
-      job: {
-        job_id: "test-job-123",
-        class_name: "TestJob",
-        queue_name: "default",
-        arguments: [1, 2, 3],
-        executions: 1,
-        enqueued_at: Time.current,
-        priority: 10
-      }
-    }
+  let(:job_obj) do
+    double(
+      "active_job_instance",
+      job_id: "test-job-123",
+      class: double("job_class", name: "TestJob"),
+      queue_name: "default",
+      executions: 1,
+      enqueued_at: Time.current,
+      priority: 10
+    )
   end
+  let(:event_payload) { {job: job_obj} }
 
   let(:event) do
     double(
@@ -72,13 +71,27 @@ RSpec.describe SolidObserver::Services::RecordEvent do
         ))
       end
 
-      it "includes metadata as JSON with job fields" do
+      it "includes job fields in metadata as JSON" do
         service.call
 
         expect(buffer).to have_received(:push).with(hash_including(
           job_class: "TestJob",
           queue_name: "default",
-          metadata: satisfy { |m| JSON.parse(m).slice("job_id", "arguments", "executions", "priority") == {"job_id" => "test-job-123", "arguments" => [1, 2, 3], "executions" => 1, "priority" => 10} }
+          metadata: satisfy { |m|
+            JSON.parse(m).slice("job_id", "executions", "priority") == {
+              "job_id" => "test-job-123",
+              "executions" => 1,
+              "priority" => 10
+            }
+          }
+        ))
+      end
+
+      it "does not store job arguments in metadata" do
+        service.call
+
+        expect(buffer).to have_received(:push).with(hash_including(
+          metadata: satisfy { |m| !JSON.parse(m).key?("arguments") }
         ))
       end
 
@@ -96,9 +109,20 @@ RSpec.describe SolidObserver::Services::RecordEvent do
     end
 
     context "with exception data in payload" do
+      let(:exception_job) do
+        double(
+          "active_job_instance",
+          job_id: "test-job-123",
+          class: double("job_class", name: "TestJob"),
+          queue_name: "default",
+          executions: 1,
+          enqueued_at: nil,
+          priority: nil
+        )
+      end
       let(:event_payload) do
         {
-          job: {job_id: "test-job-123", class_name: "TestJob", queue_name: "default"},
+          job: exception_job,
           exception_object: StandardError.new("Something went wrong")
         }
       end
@@ -116,6 +140,43 @@ RSpec.describe SolidObserver::Services::RecordEvent do
             parsed = JSON.parse(m)
             parsed["exception_class"] == "StandardError" && parsed["exception_message"] == "Something went wrong"
           }
+        ))
+      end
+    end
+
+    context "with hash-shaped payload[:job] (adapter fallback)" do
+      let(:event_payload) do
+        {
+          job: {
+            job_id: "hash-job-456",
+            class_name: "HashJob",
+            queue_name: "batch",
+            executions: 2,
+            enqueued_at: nil,
+            priority: nil
+          }
+        }
+      end
+
+      before do
+        allow(service).to receive(:rand).and_return(0.5)
+        allow(SolidObserver.config).to receive(:sampling_rate).and_return(1.0)
+      end
+
+      it "extracts job_class and queue_name from hash keys" do
+        service.call
+
+        expect(buffer).to have_received(:push).with(hash_including(
+          job_class: "HashJob",
+          queue_name: "batch"
+        ))
+      end
+
+      it "does not store arguments" do
+        service.call
+
+        expect(buffer).to have_received(:push).with(hash_including(
+          metadata: satisfy { |m| !JSON.parse(m).key?("arguments") }
         ))
       end
     end


### PR DESCRIPTION
## Summary of the changes
- Fix extract_metadata to handle real `ActiveJob::Base` objects via `read_job_attr/read_job_class` helpers; hash-shaped payloads still work as fallback - metadata was silently empty on every production event
- Remove arguments from persisted metadata (PII)
- Remove job arguments block from jobs detail view (PII)
- Add `Engine.check_ui_authentication` boot warning when UI is enabled with no credentials configured
- Rewrite `record_event_spec` with object-shaped payload doubles; add hash-fallback context and explicit arguments-not-stored assertion