### PR TITLE
[SO-048][REFACTORING] Replace sleep-based timer specs with deterministic synchronisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Removed `allow_any_instance_of` anti-pattern from specs; replaced with `instance_double` stubs
 - Deleted dead private-method `describe` blocks; coverage preserved via public-API assertions
 - Refactor Web UI controllers to thin actions + query/param/presenter objects; replace custom number helpers with Rails built-ins
+- QueueEventBuffer timer lifecycle specs now use deterministic synchronization (no `sleep`-based waiting)
 
 ## [0.1.1] - 2026-02-10
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.1.1-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.2%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-95.12%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---

--- a/spec/solid_observer/queue_event_buffer_spec.rb
+++ b/spec/solid_observer/queue_event_buffer_spec.rb
@@ -162,14 +162,8 @@ RSpec.describe SolidObserver::QueueEventBuffer do
     it "handles concurrent push and flush safely" do
       allow(SolidObserver::Services::FlushEventBuffer).to receive(:call)
 
-      push_thread = Thread.new do
-        20.times { buffer.push(event_data) }
-      end
-
-      flush_thread = Thread.new do
-        sleep(0.01)
-        buffer.flush!
-      end
+      push_thread = Thread.new { 20.times { buffer.push(event_data) } }
+      flush_thread = Thread.new { buffer.flush! }
 
       push_thread.join
       flush_thread.join
@@ -399,7 +393,7 @@ RSpec.describe SolidObserver::QueueEventBuffer do
       timer_task = buffer.instance_variable_get(:@timer_task)
 
       10.times do
-        sleep(0.03)
+        buffer.flush!
         buffer.push(event_data)
         expect(buffer.instance_variable_get(:@timer_task)).to be(timer_task)
       end


### PR DESCRIPTION
## Summary of the changes
- "handles concurrent push and flush safely": remove sleep(0.01), both threads start immediately with no delay
- "uses one persistent timer across flush cycles": replace sleep(0.03) with direct buffer.flush! per iteration — tests @timer_task identity without waiting for real timer ticks,