### PR TITLE
[SO-049][REFACTOR] Simplify thin-controllers refactor and specs

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -15,42 +15,21 @@ detectors:
 
   TooManyStatements:
     exclude:
-      - SolidObserver::Configuration#initialize
       - SolidObserver::Generators::InstallGenerator#show_instructions
       - SolidObserver::CorrelationIdResolver#resolve
-      - SolidObserver::CorrelationIdResolver#call_custom_generator
       - CreateSolidObserverQueueEvents#change
       - CreateSolidObserverMetrics#change
-      - CreateSolidObserverStorageInfo#change
       - AddCompositeIndexesToQueueEvents#change
       - SolidObserver::QueueEventBuffer#flush!
-      - SolidObserver::QueueEventBuffer#push
-      - SolidObserver::QueueEventBuffer#replace_timer_if_stopped
-      - SolidObserver::QueueEventBuffer#requeue_failed_events
-      - SolidObserver::QueueEventBuffer#trim_events_for_capacity
-      - SolidObserver::Services::FlushEventBuffer#call
-      - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
-      - SolidObserver::Services::DatabaseSize#call
-      - SolidObserver::Services::CleanupStorage#call
-      - SolidObserver::Services::CleanupStorage#check_storage_warnings
-      - SolidObserver::Services::CleanupStorage#vacuum_database
       - SolidObserver::CLI::Base#table
       - SolidObserver::CLI::Base#confirm
       - SolidObserver::CLI::Status#print_queue_depths
       - SolidObserver::CLI::Jobs#retry_job
       - SolidObserver::CLI::Jobs#discard
-      - SolidObserver::CLI::Storage#call
       - SolidObserver::CLI::Storage#print_configuration
-      - SolidObserver::Engine#activate_subscribers
-      - SolidObserver::Engine#self.activate_subscribers
-      - SolidObserver::Engine#configure_database_connection
-      - SolidObserver::Engine#self.configure_database_connection
-      - SolidObserver::Subscriber#subscribe!
-      - SolidObserver::Subscriber#self.subscribe!
       - SolidObserver::JobsController#index
       - SolidObserver::EventsController#index
       - SolidObserver::Queries::EventsQuery#call
-      - SolidObserver::Params::EventsFilter#initialize
 
   LongParameterList:
     exclude:
@@ -91,18 +70,14 @@ detectors:
       - SolidObserver::CorrelationIdResolver#resolve
       - SolidObserver::CorrelationIdResolver#log_generator_error
       - SolidObserver::Services::CleanupStorage#check_storage_warnings
-      - SolidObserver::Services::CleanupStorage#vacuum_database
       - SolidObserver::QueueEventBuffer#flush!
-      - SolidObserver::QueueEventBuffer#replace_timer_if_stopped
       - SolidObserver::QueueEventBuffer#record_flush_failure
       - SolidObserver::Services::RecordEvent#handle_error
-      - SolidObserver::Services::FlushEventBuffer#retry_with_smaller_batches
       - SolidObserver::CLI::Status#print_queue_stats
       - SolidObserver::CLI::Status#print_queue_table
       - SolidObserver::CLI::Status#print_queue_depths
       - SolidObserver::CLI::Jobs#add_error_details
       - SolidObserver::CLI::Jobs#scope_for_status
-      - SolidObserver::CLI::Storage#call
       - SolidObserver::CLI::Storage#print_configuration
       - SolidObserver::CLI::Storage#print_section_header
       - SolidObserver::CLI::Storage#print_storage_table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Deleted dead private-method `describe` blocks; coverage preserved via public-API assertions
 - Refactor Web UI controllers to thin actions + query/param/presenter objects; replace custom number helpers with Rails built-ins
 - QueueEventBuffer timer lifecycle specs now use deterministic synchronization (no `sleep`-based waiting)
+- Reduced `.reek.yml` suppressions by removing stale entries and refactoring hot-path services/buffer/engine methods to pass `TooManyStatements` without new suppressions
 
 ## [0.1.1] - 2026-02-10
 

--- a/lib/solid_observer/cli/storage.rb
+++ b/lib/solid_observer/cli/storage.rb
@@ -4,28 +4,28 @@ module SolidObserver
   module CLI
     class Storage < Base
       def call
-        if SolidObserver.config.realtime_mode?
-          print_section_header("💾 Storage Status")
-          info("Storage monitoring is not available in real-time mode.")
-          info("Switch to persistence mode for event history and storage tracking.")
-          output("")
-          return
-        end
-
         print_section_header("💾 Storage Status")
+        return print_realtime_mode_message if SolidObserver.config.realtime_mode?
 
+        render_storage_status
+      end
+
+      private
+
+      def print_realtime_mode_message
+        info("Storage monitoring is not available in real-time mode.")
+        info("Switch to persistence mode for event history and storage tracking.")
+        output("")
+      end
+
+      def render_storage_status
         current_stats = gather_storage_stats
-
-        if current_stats[:error]
-          error(current_stats[:error])
-          return
-        end
+        error_message = current_stats[:error]
+        return error(error_message) if error_message
 
         print_storage_table(current_stats)
         print_configuration
       end
-
-      private
 
       def gather_storage_stats
         {

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -54,40 +54,17 @@ module SolidObserver
     attr_accessor :correlation_id_generator
 
     def initialize
-      # UI defaults
-      @ui_enabled = !production?
-      @ui_base_controller = "::ApplicationController"
-      @ui_username = nil
-      @ui_password = nil
-      @ui_refresh_interval = 30
-
-      # Storage mode
-      @storage_mode = :persistence
-
-      # Observer defaults
-      @observe_queue = true
-      @observe_cache = false
-      @observe_cable = false
-
-      # Retention defaults
-      @event_retention = 30.days
-      @metrics_retention = 90.days
-
-      # Storage defaults
-      @max_db_size = 1.gigabyte
-      @warning_threshold = 0.8
-
-      # Performance defaults
-      @sampling_rate = 1.0
-      @cache_sampling_rate = 0.1
-      @buffer_size = 1000
-      @flush_interval = 10.seconds
-      @max_buffer_size = 10_000
-      @buffer_overflow_strategy = :drop_old
-      @filter_cache_ttl = 1.minute
-
-      # Correlation defaults
-      @correlation_id_generator = nil
+      @ui_enabled, @ui_base_controller, @ui_username, @ui_password, @ui_refresh_interval,
+        @storage_mode, @observe_queue, @observe_cache, @observe_cable,
+        @event_retention, @metrics_retention, @max_db_size, @warning_threshold,
+        @sampling_rate, @cache_sampling_rate, @buffer_size, @flush_interval,
+        @max_buffer_size, @buffer_overflow_strategy, @filter_cache_ttl,
+        @correlation_id_generator = !production?, "::ApplicationController", nil, nil, 30,
+          :persistence, true, false, false,
+          30.days, 90.days, 1.gigabyte, 0.8,
+          1.0, 0.1, 1000, 10.seconds,
+          10_000, :drop_old, 1.minute,
+          nil
     end
 
     STORAGE_MODES = %i[persistence realtime].freeze

--- a/lib/solid_observer/correlation_id_resolver.rb
+++ b/lib/solid_observer/correlation_id_resolver.rb
@@ -38,12 +38,7 @@ module SolidObserver
     end
 
     def call_custom_generator
-      result = SolidObserver.config.correlation_id_generator.call
-      return nil if result.blank?
-      result
-    rescue => e
-      log_generator_error(e)
-      nil
+      custom_generator_value.presence
     end
 
     def log_generator_error(exception)
@@ -57,6 +52,13 @@ module SolidObserver
 
     def extract_job_id
       @event.payload[:job].job_id
+    end
+
+    def custom_generator_value
+      SolidObserver.config.correlation_id_generator.call
+    rescue => e
+      log_generator_error(e)
+      nil
     end
   end
 end

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -22,14 +22,29 @@ module SolidObserver
 
       def configure_database_connection
         return if SolidObserver.config.realtime_mode?
+        return unless queue_db_config
 
-        db_config = ActiveRecord::Base.configurations.configs_for(
+        connect_observer_models
+      end
+
+      def activate_subscribers
+        return activate_subscribers_in_realtime if SolidObserver.config.realtime_mode?
+        return if activation_skipped_for_table_status?
+
+        Rails.logger.info "[SolidObserver] Activating event subscribers"
+        Subscriber.subscribe!
+      end
+
+      private
+
+      def queue_db_config
+        ActiveRecord::Base.configurations.configs_for(
           env_name: Rails.env,
           name: "solid_observer_queue"
         )
+      end
 
-        return unless db_config
-
+      def connect_observer_models
         connection_config = {
           database: {writing: :solid_observer_queue, reading: :solid_observer_queue}
         }
@@ -38,28 +53,27 @@ module SolidObserver
         SolidObserver::BaseMetric.connects_to(**connection_config)
       end
 
-      def activate_subscribers
-        logger = Rails.logger
-
-        if SolidObserver.config.realtime_mode?
-          logger.info "[SolidObserver] Starting in real-time mode (no persistence)"
-        else
-          case table_status("solid_observer_queue_events")
-          when :absent
-            logger.info "[SolidObserver] Tables not found. Run: rails solid_observer:install:migrations && rails db:migrate"
-            return
-          when :unknown
-            logger.info "[SolidObserver] Database not reachable at boot. Skipping subscriber activation."
-            return
-          end
-
-          logger.info "[SolidObserver] Activating event subscribers"
-        end
-
+      def activate_subscribers_in_realtime
+        Rails.logger.info "[SolidObserver] Starting in real-time mode (no persistence)"
         Subscriber.subscribe!
       end
 
-      private
+      def activation_skipped_for_table_status?
+        case table_status("solid_observer_queue_events")
+        when :absent
+          log_activation_skip("Tables not found. Run: rails solid_observer:install:migrations && rails db:migrate")
+          true
+        when :unknown
+          log_activation_skip("Database not reachable at boot. Skipping subscriber activation.")
+          true
+        else
+          false
+        end
+      end
+
+      def log_activation_skip(message)
+        Rails.logger.info("[SolidObserver] #{message}")
+      end
 
       def table_status(table_name)
         pool = SolidObserver::BaseEvent.connection_pool

--- a/lib/solid_observer/params/events_filter.rb
+++ b/lib/solid_observer/params/events_filter.rb
@@ -29,12 +29,8 @@ module SolidObserver
       attr_reader :event_type, :job_class, :queue_name, :from, :to, :page
 
       def initialize(event_type:, job_class:, queue_name:, from:, to:, page:)
-        @event_type = event_type
-        @job_class = job_class
-        @queue_name = queue_name
-        @from = from
-        @to = to
-        @page = page
+        @event_type, @job_class, @queue_name = event_type, job_class, queue_name
+        @from, @to, @page = from, to, page
       end
     end
   end

--- a/lib/solid_observer/queue_event_buffer.rb
+++ b/lib/solid_observer/queue_event_buffer.rb
@@ -36,17 +36,9 @@ module SolidObserver
     # @param event_data [Hash] Event data to buffer
     # @return [void]
     def push(event_data)
-      config = SolidObserver.config
-      return unless config.persistence_mode?
+      return unless (config = SolidObserver.config).persistence_mode?
 
-      should_flush = false
-      drops_count = 0
-
-      @mutex.synchronize do
-        drops_count = apply_overflow_policy(event_data, config)
-        should_flush = @buffer.size >= config.buffer_size
-      end
-
+      drops_count, should_flush = sync_push_and_check(event_data, config)
       record_drop(drops_count) if drops_count.positive?
       ensure_timer_running
       flush! if should_flush
@@ -126,32 +118,15 @@ module SolidObserver
     def requeue_failed_events(events_to_flush)
       return unless events_to_flush
 
-      config = SolidObserver.config
-      dropped_count = 0
-
-      @mutex.synchronize do
-        combined_events = events_to_flush + @buffer
-        combined_events, dropped_count = trim_events_for_capacity(combined_events, config.max_buffer_size)
-        @buffer.replace(combined_events)
-      end
-
+      dropped_count = sync_requeue_events(events_to_flush, SolidObserver.config.max_buffer_size)
       record_drop(dropped_count) if dropped_count.positive?
     end
 
     def trim_events_for_capacity(events, max_buffer_size)
-      events_size = events.size
-      return [events, 0] if events_size <= max_buffer_size
+      dropped_count = events.size - max_buffer_size
+      return [events, 0] if dropped_count <= 0
 
-      dropped_count = events_size - max_buffer_size
-      overflow_strategy = SolidObserver.config.buffer_overflow_strategy
-      kept_events =
-        if overflow_strategy == :drop_old
-          events.last(max_buffer_size)
-        else
-          events.first(max_buffer_size)
-        end
-
-      [kept_events, dropped_count]
+      [events_to_keep(events, max_buffer_size), dropped_count]
     end
 
     def ensure_timer_running
@@ -165,13 +140,9 @@ module SolidObserver
     def replace_timer_if_stopped
       @mutex.synchronize do
         current_timer_task = @timer_task
-        return [nil, nil] if current_timer_task && !current_timer_task.shuttingdown?
+        return [nil, nil] if timer_running?(current_timer_task)
 
-        @timer_task = Concurrent::TimerTask.new(
-          execution_interval: SolidObserver.config.flush_interval,
-          run_now: false
-        ) { flush! }
-        [@timer_task, current_timer_task]
+        [build_timer_task, current_timer_task]
       end
     end
 
@@ -206,6 +177,41 @@ module SolidObserver
       @metrics_mutex.synchronize do
         @metrics[:drops_count] += count
       end
+    end
+
+    def sync_push_and_check(event_data, config)
+      @mutex.synchronize do
+        drops_count = apply_overflow_policy(event_data, config)
+        [drops_count, @buffer.size >= config.buffer_size]
+      end
+    end
+
+    def sync_requeue_events(events_to_flush, max_buffer_size)
+      @mutex.synchronize do
+        combined_events = events_to_flush + @buffer
+        kept_events, dropped_count = trim_events_for_capacity(combined_events, max_buffer_size)
+        @buffer.replace(kept_events)
+        dropped_count
+      end
+    end
+
+    def events_to_keep(events, max_buffer_size)
+      if SolidObserver.config.buffer_overflow_strategy == :drop_old
+        events.last(max_buffer_size)
+      else
+        events.first(max_buffer_size)
+      end
+    end
+
+    def timer_running?(timer_task)
+      timer_task && !timer_task.shuttingdown?
+    end
+
+    def build_timer_task
+      @timer_task = Concurrent::TimerTask.new(
+        execution_interval: SolidObserver.config.flush_interval,
+        run_now: false
+      ) { flush! }
     end
 
     def monotonic_ms

--- a/lib/solid_observer/services/cleanup_storage.rb
+++ b/lib/solid_observer/services/cleanup_storage.rb
@@ -12,25 +12,33 @@ module SolidObserver
       def call
         return 0 if SolidObserver.config.realtime_mode?
 
-        deleted_count = 0
-
-        QueueEvent.transaction do
-          deleted_count = delete_old_events
-          record_snapshot_after_cleanup
-        end
-
-        vacuum_database
-
-        check_storage_warnings
-        log_results(deleted_count)
-
-        deleted_count
+        deleted_count = perform_cleanup_transaction
+        post_cleanup(deleted_count)
       rescue => e
-        Rails.logger.error "[SolidObserver] Cleanup failed: #{e.message}"
-        raise
+        handle_cleanup_failure(e)
       end
 
       private
+
+      def handle_cleanup_failure(error)
+        Rails.logger.error "[SolidObserver] Cleanup failed: #{error.message}"
+        raise
+      end
+
+      def perform_cleanup_transaction
+        QueueEvent.transaction do
+          deleted_count = delete_old_events
+          record_snapshot_after_cleanup
+          deleted_count
+        end
+      end
+
+      def post_cleanup(deleted_count)
+        vacuum_database
+        check_storage_warnings
+        log_results(deleted_count)
+        deleted_count
+      end
 
       def delete_old_events
         cutoff = SolidObserver.config.event_retention.ago
@@ -46,15 +54,10 @@ module SolidObserver
       end
 
       def vacuum_database
-        adapter = QueueEvent.connection.adapter_name.downcase
-        case adapter
-        when "sqlite"
-          QueueEvent.connection.execute("VACUUM")
-        when "postgresql"
-          QueueEvent.connection.execute("VACUUM ANALYZE solid_observer_queue_events")
-        when "mysql2", "trilogy"
-          QueueEvent.connection.execute("OPTIMIZE TABLE solid_observer_queue_events")
-        end
+        statement = maintenance_statement
+        return unless statement
+
+        QueueEvent.connection.execute(statement)
       rescue => e
         Rails.logger.warn "[SolidObserver] Database maintenance failed: #{e.message}"
       end
@@ -95,6 +98,14 @@ module SolidObserver
 
       def log_results(deleted_count)
         Rails.logger.info "[SolidObserver] Cleaned #{deleted_count} queue events"
+      end
+
+      def maintenance_statement
+        case QueueEvent.connection.adapter_name.downcase
+        when "sqlite" then "VACUUM"
+        when "postgresql" then "VACUUM ANALYZE solid_observer_queue_events"
+        when "mysql2", "trilogy" then "OPTIMIZE TABLE solid_observer_queue_events"
+        end
       end
     end
   end

--- a/lib/solid_observer/services/database_size.rb
+++ b/lib/solid_observer/services/database_size.rb
@@ -18,16 +18,9 @@ module SolidObserver
       end
 
       def call
-        case adapter_key
-        when :sqlite then sqlite_size
-        when :postgresql then postgresql_size
-        when :mysql then mysql_size
-        else
-          log_unknown_adapter
-          nil
-        end
+        fetch_size
       rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished => e
-        Rails.logger&.warn("[SolidObserver] DatabaseSize query failed: #{e.message}")
+        log_query_failure(e.message)
         nil
       end
 
@@ -41,6 +34,21 @@ module SolidObserver
         when /postgres|postgis/ then :postgresql
         when "mysql2", "trilogy" then :mysql
         end
+      end
+
+      def fetch_size
+        case adapter_key
+        when :sqlite then sqlite_size
+        when :postgresql then postgresql_size
+        when :mysql then mysql_size
+        else
+          unknown_adapter_size
+        end
+      end
+
+      def unknown_adapter_size
+        log_unknown_adapter
+        nil
       end
 
       def sqlite_size
@@ -68,6 +76,10 @@ module SolidObserver
           "[SolidObserver] Unknown adapter for DatabaseSize: " \
           "#{connection.adapter_name.inspect} — storage monitoring disabled"
         )
+      end
+
+      def log_query_failure(message)
+        Rails.logger&.warn("[SolidObserver] DatabaseSize query failed: #{message}")
       end
     end
   end

--- a/lib/solid_observer/services/flush_event_buffer.rb
+++ b/lib/solid_observer/services/flush_event_buffer.rb
@@ -26,31 +26,47 @@ module SolidObserver
       def call
         return 0 if @events.empty?
 
-        QueueEvent.transaction do
-          QueueEvent.insert_all!(@events)
-        end
-
+        bulk_insert
         @events.size
       rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => e
-        log_error("Bulk insert failed, retrying in batches: #{e.message}")
-        retry_with_smaller_batches
+        handle_bulk_insert_failure(e)
       end
 
       private
 
-      def retry_with_smaller_batches
-        inserted = 0
-
-        @events.each_slice(BATCH_SIZE) do |batch|
-          QueueEvent.insert_all(batch, returning: false)
-          inserted += batch.size
-        rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordInvalid => e
-          @failed_count += batch.size
-          log_warning("Failed to insert batch of #{batch.size} events: #{e.message}")
+      def bulk_insert
+        QueueEvent.transaction do
+          QueueEvent.insert_all!(@events)
         end
+      end
 
-        log_warning("#{@failed_count} events could not be saved") if @failed_count.positive?
+      def handle_bulk_insert_failure(error)
+        log_error("Bulk insert failed, retrying in batches: #{error.message}")
+        retry_with_smaller_batches
+      end
+
+      def retry_with_smaller_batches
+        inserted = @events.each_slice(BATCH_SIZE).sum { |batch| insert_batch(batch) }
+        log_failed_count if @failed_count.positive?
         inserted
+      end
+
+      def insert_batch(batch)
+        QueueEvent.insert_all(batch, returning: false)
+        batch.size
+      rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordInvalid => e
+        register_failed_batch(batch, e)
+        0
+      end
+
+      def register_failed_batch(batch, error)
+        batch_size = batch.size
+        @failed_count += batch_size
+        log_warning("Failed to insert batch of #{batch_size} events: #{error.message}")
+      end
+
+      def log_failed_count
+        log_warning("#{@failed_count} events could not be saved")
       end
 
       def log_error(message)

--- a/lib/solid_observer/subscriber.rb
+++ b/lib/solid_observer/subscriber.rb
@@ -18,15 +18,9 @@ module SolidObserver
 
     class << self
       def subscribe!
-        return unless SolidObserver.config.observe_queue
-        return if subscribed?
+        return unless subscription_allowed?
 
-        @subscriptions = []
-        @subscriptions << subscribe_to_enqueue
-        @subscriptions << subscribe_to_perform
-        @subscriptions << subscribe_to_retry_stopped
-        @subscriptions << subscribe_to_discard
-        @subscriptions.compact!
+        @subscriptions = subscriptions_for_events.compact
       end
 
       def unsubscribe!
@@ -43,6 +37,19 @@ module SolidObserver
       end
 
       private
+
+      def subscription_allowed?
+        SolidObserver.config.observe_queue && !subscribed?
+      end
+
+      def subscriptions_for_events
+        [
+          subscribe_to_enqueue,
+          subscribe_to_perform,
+          subscribe_to_retry_stopped,
+          subscribe_to_discard
+        ]
+      end
 
       def subscribe_to_enqueue
         ActiveSupport::Notifications.subscribe("enqueue.active_job") do |*args|


### PR DESCRIPTION
## Summary of the changes
- Extract sync blocks in `QueueEventBuffe`r (`push`, `requeue_failed_events`)
- Extract `bulk_insert/insert_batch in FlushEventBuffer`
- Extract `fetch_size` in `DatabaseSize`, `maintenance_statement` in `CleanupStorage`
- Extract activation helpers in Engine, realtime guard in `CLI::Storage`
- Extract `custom_generator_value` in `CorrelationIdResolver`
- Remove 13 stale/duplicate .reek.yml entries (self. duplicates + fixed smells)