### PR TITLE
[SO-051][FIX] Install:migrations respects migrations_paths from database.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Web UI now works on API-only Rails hosts. The engine ships its own Cookies / Session::CookieStore (`key: "_solid_observer_session"`) / Flash middleware stack, so requests routed to `/solid_observer/*` get the middleware they need regardless of whether the host app strips them via `config.api_only = true`. Previously, API-only hosts hit `NoMethodError: undefined method 'flash' for an instance of ActionDispatch::Request` rendering the dashboard layout.
+- `bin/rails solid_observer:install:migrations` now respects `migrations_paths` from the `solid_observer_queue` connection in `config/database.yml`. When the host configures a dedicated migration folder (e.g. `db/solid_observer_migrate`), the install task copies migrations directly there instead of `db/migrate/`. Previously, operators in multi-database setups had to manually move the files after install to prevent cross-database migration contamination.
 
 ## [0.3.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
-## [Unreleased]
-
-### Fixed
-- Web UI now works on API-only Rails hosts. The engine ships its own Cookies / Session::CookieStore (`key: "_solid_observer_session"`) / Flash middleware stack, so requests routed to `/solid_observer/*` get the middleware they need regardless of whether the host app strips them via `config.api_only = true`. Previously, API-only hosts hit `NoMethodError: undefined method 'flash' for an instance of ActionDispatch::Request` rendering the dashboard layout.
-- `bin/rails solid_observer:install:migrations` now respects `migrations_paths` from the `solid_observer_queue` connection in `config/database.yml`. When the host configures a dedicated migration folder (e.g. `db/solid_observer_migrate`), the install task copies migrations directly there instead of `db/migrate/`. Previously, operators in multi-database setups had to manually move the files after install to prevent cross-database migration contamination.
-
-## [0.3.0] - 2026-04-27
+## [0.3.0] - [unreleased]
 
 > Note: there is no separate `0.2.0` gem release — work originally scoped for v0.2.0 (stability + refactoring, SO-040 through SO-049) was folded into this release.
 
@@ -19,6 +13,8 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - `Services::DatabaseSize` for cross-adapter table-size measurement; composite indexes and `distinct_job_classes` / `distinct_queue_names` scopes
 
 ### Fixed
+- Web UI now works on API-only Rails hosts. The engine ships its own Cookies / Session::CookieStore (`key: "_solid_observer_session"`) / Flash middleware stack, so requests routed to `/solid_observer/*` get the middleware they need regardless of whether the host app strips them via `config.api_only = true`. Previously, API-only hosts hit `NoMethodError: undefined method 'flash' for an instance of ActionDispatch::Request` rendering the dashboard layout.
+- `bin/rails solid_observer:install:migrations` now respects `migrations_paths` from the `solid_observer_queue` connection in `config/database.yml`. When the host configures a dedicated migration folder (e.g. `db/solid_observer_migrate`), the install task copies migrations directly there instead of `db/migrate/`. Previously, operators in multi-database setups had to manually move the files after install to prevent cross-database migration contamination.
 - Engine boot no longer requires a live DB (Docker/CI/K8s safe); table check uses `BaseEvent.connection_pool` (multi-DB safe); broader rescue covering adapter-specific connection errors
 - `QueueEventBuffer` hard-caps at `max_buffer_size` with overflow strategy; uses a single persistent `Concurrent::TimerTask` instead of spawning a thread per flush
 - Storage monitoring uses adapter-native size queries (SQLite / PostgreSQL / MySQL / Trilogy) — fixes `0 MB` readings off SQLite

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/bart-oz/solid_observer/releases"><img src="https://img.shields.io/badge/version-0.3.0-blue.svg" alt="Version"></a>
   <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/tests-passing-brightgreen.svg" alt="Tests"></a>
-  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-96.43%25-brightgreen.svg" alt="Coverage"></a>
+  <a href="https://github.com/bart-oz/solid_observer/actions"><img src="https://img.shields.io/badge/coverage-96.65%25-brightgreen.svg" alt="Coverage"></a>
 </p>
 
 ---
@@ -360,6 +360,8 @@ solid_observer_queue:
 
 > **Note:** SQLite is the generator default, not a requirement. The `solid_observer_queue` database can use any Rails-supported adapter for record persistence. Adapter-native **storage-size monitoring** is currently implemented for SQLite, PostgreSQL/PostGIS, MySQL, and Trilogy. On other adapters, the size query returns `nil` and the engine logs a single `[SolidObserver] Unknown adapter for DatabaseSize: …` warning — record persistence still works, but the size column on the dashboard will be empty until adapter support is added.
 
+> **Multi-database isolation:** if your `solid_observer_queue` connection declares `migrations_paths` in `config/database.yml`, `bin/rails solid_observer:install:migrations` copies migrations to that path automatically (no manual `mv` required). This prevents Rails from running SolidObserver's migrations against your other databases.
+
 ## Roadmap
 
 SolidObserver is actively developed. Here's what's coming:
@@ -444,6 +446,7 @@ development:
   solid_observer_queue:
     adapter: sqlite3
     database: storage/development_solid_observer_queue.sqlite3
+    migrations_paths: db/solid_observer_migrate
 ```
 
 ## Contributing

--- a/lib/solid_observer/services/install_migrations.rb
+++ b/lib/solid_observer/services/install_migrations.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    class InstallMigrations
+      def self.call(rails_env: Rails.env)
+        new(rails_env).call
+      end
+
+      def initialize(rails_env)
+        @rails_env = rails_env
+      end
+
+      def call
+        destination = resolve_destination
+        copied = ActiveRecord::Migration.copy(
+          destination,
+          "solid_observer" => SolidObserver::Engine.paths["db/migrate"].existent.first
+        )
+
+        {
+          destination: destination,
+          copied: copied
+        }
+      end
+
+      private
+
+      def resolve_destination
+        path = configured_path
+        return path if path
+
+        ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first || "db/migrate"
+      end
+
+      def configured_path
+        config = ActiveRecord::Base.configurations.configs_for(
+          env_name: @rails_env,
+          name: "solid_observer_queue"
+        )
+        path = Array(config&.migrations_paths).first
+        return if path.blank?
+
+        FileUtils.mkdir_p(path) unless Dir.exist?(path)
+        path
+      end
+    end
+  end
+end

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../solid_observer/services/install_migrations"
+
 namespace :solid_observer do
   desc "Display SolidObserver version"
   task :version do
@@ -11,8 +13,14 @@ namespace :solid_observer do
   namespace :install do
     desc "Copy SolidObserver migrations to your application"
     task migrations: :environment do
-      Rake::Task["railties:install:migrations"].reenable
-      Rake::Task["railties:install:migrations"].invoke
+      result = SolidObserver::Services::InstallMigrations.call
+
+      if result[:copied].any?
+        suffix = (result[:copied].size == 1) ? "" : "s"
+        puts "Copied #{result[:copied].size} SolidObserver migration#{suffix} to #{result[:destination]}/"
+      else
+        puts "No new SolidObserver migrations to copy (all already present in #{result[:destination]}/)"
+      end
     end
   end
 

--- a/spec/solid_observer/services/install_migrations_spec.rb
+++ b/spec/solid_observer/services/install_migrations_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/solid_observer/services/install_migrations"
+
+RSpec.describe SolidObserver::Services::InstallMigrations do
+  let(:configurations) { instance_double(ActiveRecord::DatabaseConfigurations) }
+  let(:source_paths) { double("source_paths", existent: ["/gem/solid_observer/db/migrate"]) }
+  let(:migration_class) do
+    Class.new do
+      def self.copy(*)
+      end
+    end
+  end
+
+  before do
+    stub_const("ActiveRecord::Migration", migration_class)
+    allow(ActiveRecord::Base).to receive(:configurations).and_return(configurations)
+    allow(SolidObserver::Engine.paths).to receive(:[]).with("db/migrate").and_return(source_paths)
+  end
+
+  describe ".call" do
+    context "when solid_observer_queue config has migrations_paths" do
+      let(:db_config) { double("db_config", migrations_paths: "db/solid_observer_migrate") }
+
+      before do
+        allow(configurations).to receive(:configs_for)
+          .with(env_name: "test", name: "solid_observer_queue")
+          .and_return(db_config)
+        allow(Dir).to receive(:exist?).with("db/solid_observer_migrate").and_return(false)
+        allow(FileUtils).to receive(:mkdir_p)
+        allow(ActiveRecord::Migration).to receive(:copy).and_return(["20260115000001"])
+      end
+
+      it "copies migrations to the configured destination" do
+        result = described_class.call(rails_env: "test")
+
+        expect(ActiveRecord::Migration).to have_received(:copy).with(
+          "db/solid_observer_migrate",
+          "solid_observer" => "/gem/solid_observer/db/migrate"
+        )
+        expect(result).to eq(
+          destination: "db/solid_observer_migrate",
+          copied: ["20260115000001"]
+        )
+      end
+
+      it "creates the destination directory when missing" do
+        described_class.call(rails_env: "test")
+
+        expect(FileUtils).to have_received(:mkdir_p).with("db/solid_observer_migrate")
+      end
+    end
+
+    context "when solid_observer_queue config has no migrations_paths" do
+      let(:db_config) { double("db_config", migrations_paths: nil) }
+
+      before do
+        allow(configurations).to receive(:configs_for)
+          .with(env_name: "test", name: "solid_observer_queue")
+          .and_return(db_config)
+        allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:migrations_paths).and_return(["db/default_migrate"])
+        allow(ActiveRecord::Migration).to receive(:copy).and_return([])
+      end
+
+      it "falls back to ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first" do
+        result = described_class.call(rails_env: "test")
+
+        expect(ActiveRecord::Migration).to have_received(:copy).with(
+          "db/default_migrate",
+          "solid_observer" => "/gem/solid_observer/db/migrate"
+        )
+        expect(result).to eq(
+          destination: "db/default_migrate",
+          copied: []
+        )
+      end
+    end
+
+    context "when solid_observer_queue config is absent" do
+      before do
+        allow(configurations).to receive(:configs_for)
+          .with(env_name: "test", name: "solid_observer_queue")
+          .and_return(nil)
+        allow(ActiveRecord::Tasks::DatabaseTasks).to receive(:migrations_paths).and_return(["db/fallback_migrate"])
+        allow(ActiveRecord::Migration).to receive(:copy).and_return(["20260115000001", "20260115000002"])
+      end
+
+      it "uses the default Rails migrations path fallback" do
+        result = described_class.call(rails_env: "test")
+
+        expect(ActiveRecord::Migration).to have_received(:copy).with(
+          "db/fallback_migrate",
+          "solid_observer" => "/gem/solid_observer/db/migrate"
+        )
+        expect(result).to eq(
+          destination: "db/fallback_migrate",
+          copied: ["20260115000001", "20260115000002"]
+        )
+      end
+    end
+  end
+end

--- a/spec/tasks/solid_observer_rake_spec.rb
+++ b/spec/tasks/solid_observer_rake_spec.rb
@@ -111,6 +111,52 @@ RSpec.describe "solid_observer rake tasks" do
       end
     end
 
+    describe "solid_observer:install:migrations" do
+      before do
+        install_migrations_service = Class.new do
+          def self.call
+          end
+        end
+
+        stub_const("SolidObserver::Services::InstallMigrations", install_migrations_service)
+        allow(SolidObserver::Services::InstallMigrations).to receive(:call)
+      end
+
+      it "prints singular copy output when one migration is copied" do
+        allow(SolidObserver::Services::InstallMigrations).to receive(:call).and_return(
+          {destination: "db/solid_observer_migrate", copied: ["20260115000001"]}
+        )
+
+        expect {
+          Rake::Task["solid_observer:install:migrations"].invoke
+        }.to output("Copied 1 SolidObserver migration to db/solid_observer_migrate/\n").to_stdout
+
+        expect(SolidObserver::Services::InstallMigrations).to have_received(:call)
+      end
+
+      it "prints plural copy output when multiple migrations are copied" do
+        allow(SolidObserver::Services::InstallMigrations).to receive(:call).and_return(
+          {destination: "db/solid_observer_migrate", copied: %w[20260115000001 20260115000002]}
+        )
+
+        expect {
+          Rake::Task["solid_observer:install:migrations"].invoke
+        }.to output("Copied 2 SolidObserver migrations to db/solid_observer_migrate/\n").to_stdout
+      end
+
+      it "prints no-op output when all migrations are already present" do
+        allow(SolidObserver::Services::InstallMigrations).to receive(:call).and_return(
+          {destination: "db/solid_observer_migrate", copied: []}
+        )
+
+        expect {
+          Rake::Task["solid_observer:install:migrations"].invoke
+        }.to output(
+          "No new SolidObserver migrations to copy (all already present in db/solid_observer_migrate/)\n"
+        ).to_stdout
+      end
+    end
+
     describe "solid_observer:jobs:list" do
       it "invokes CLI::Jobs#list with arguments" do
         jobs_instance = instance_double(SolidObserver::CLI::Jobs)


### PR DESCRIPTION
## Summary
- `bin/rails solid_observer:install:migrations` now copies to the path declared by `migrations_paths` on the `solid_observer_queue` connection in `database.yml`
- Falls back to `ActiveRecord::Tasks::DatabaseTasks.migrations_paths.first || "db/migrate"` (matches `railties:install:migrations`) when not configured
- Logic extracted to `SolidObserver::Services::InstallMigrations.call` (no `.send` to private internals)

## Why
Discovered during install in a real PostgreSQL host (`nua-healthcare`) using SQLite for the observer DB. Without isolated `migrations_paths`, Rails ran SolidObserver migrations against the primary PG too. With it, operators previously had to manually `mv` files post-install. This automates that step.

## Test plan
- [x] `bundle exec rspec` — 592 examples, 0 failures, 96.65% coverage
- [x] `bundle exec standardrb` — clean
- [x] `bundle exec reek lib/ app/ db/` — clean
- [x] `bundle exec appraisal rails-8.0 rspec` — green
- [x] `bundle exec appraisal rails-8.1 rspec` — green
- [x] Service spec covers 3 destination branches + asserts `ActiveRecord::Migration.copy` invocation
- [x] Rake task spec exercises `Rake::Task[].invoke` and asserts stdout for copied 1 / many / none
- [x] Manual smoke in a fresh host with `migrations_paths: db/solid_observer_migrate` declared — verify files land in custom path
