### PR TITLE
[SO-054][FEAT] Dashboard usability hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - `QueueEventBuffer#metrics` and `#shutdown` (graceful drain on app exit)
 - Configuration: `max_buffer_size` (default 10_000), `buffer_overflow_strategy` (`:drop_old` / `:drop_new`), `filter_cache_ttl`
 - `Services::DatabaseSize` for cross-adapter table-size measurement; composite indexes and `distinct_job_classes` / `distinct_queue_names` scopes
+- Dashboard now shows three throughput counters (Performed last hour, Failed last 24h, Enqueue rate last 5 min) sourced from the events table, alongside existing point-in-time counters. Throughput counters are persistence-mode only.
+- Stat counter subtitles ("queued" / "future runs" / "in progress" / "awaiting retry" / "active processes") clarify SolidQueue lifecycle terminology.
+- Conceptual hint banner on the dashboard explains the difference between Jobs tab (in-flight + failed) and Events tab (historical record).
+- Jobs tab now has an empty state with a hint pointing to Events tab for completed-job history.
 
 ### Fixed
 - Web UI now works on API-only Rails hosts. The engine ships its own Cookies / Session::CookieStore (`key: "_solid_observer_session"`) / Flash middleware stack, so requests routed to `/solid_observer/*` get the middleware they need regardless of whether the host app strips them via `config.api_only = true`. Previously, API-only hosts hit `NoMethodError: undefined method 'flash' for an instance of ActionDispatch::Request` rendering the dashboard layout.
@@ -34,6 +38,7 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - Web UI controllers refactored to thin actions + query/param/presenter objects; Rails built-in number helpers replace custom ones
 - Specs: `allow_any_instance_of` → `instance_double`; sleep-based timer specs use deterministic synchronisation; dead private-method `describe` blocks removed
 - `.reek.yml` suppressions trimmed; hot-path services/buffer/engine methods refactored to pass `TooManyStatements` without new suppressions
+- Jobs tab default filter changed from `status=ready` to `status=all_active` (ready + scheduled + claimed + failed).
 
 ## [0.1.1] - 2026-02-10
 

--- a/app/controllers/solid_observer/jobs_controller.rb
+++ b/app/controllers/solid_observer/jobs_controller.rb
@@ -15,20 +15,22 @@ module SolidObserver
       @queue_name = filter.queue_name
       @job_class = filter.job_class
       @page = filter.page
-      scope = Queries::JobExecutionsQuery.new(filter).call
-      offset = paginate_scope(scope, per_page: PER_PAGE)
-      @jobs = scope.limit(PER_PAGE).offset(offset).includes(:job).to_a
+      result = Queries::JobExecutionsQuery.new(filter).call
+      offset = paginate_scope(result, per_page: PER_PAGE)
+      @jobs = if result.is_a?(Array)
+        result.drop(offset).first(PER_PAGE)
+      else
+        result.limit(PER_PAGE).offset(offset).includes(:job).to_a
+      end
       @available_queues = fetch_available_queues
       @available_job_classes = fetch_available_job_classes
     end
 
     def show
-      @execution = Queries::ExecutionFinder.find_any(params[:id])
+      @execution = find_execution_for_show
       return redirect_to jobs_path, alert: "Job not found" unless @execution
 
-      presenter = ExecutionPresenter.new(@execution)
-      @job = presenter.job
-      @status = presenter.status
+      assign_show_presenter
     end
 
     def retry
@@ -50,6 +52,18 @@ module SolidObserver
     end
 
     private
+
+    def find_execution_for_show
+      id = params[:id]
+      Queries::ExecutionFinder.find_by_status(id, params[:status]) ||
+        Queries::ExecutionFinder.find_any(id)
+    end
+
+    def assign_show_presenter
+      presenter = ExecutionPresenter.new(@execution)
+      @job = presenter.job
+      @status = presenter.status
+    end
 
     def fetch_available_queues
       Rails.cache.fetch(CACHE_KEY_QUEUES, expires_in: SolidObserver.config.filter_cache_ttl) do

--- a/app/models/solid_observer/queue_event.rb
+++ b/app/models/solid_observer/queue_event.rb
@@ -38,5 +38,20 @@ module SolidObserver
         .pluck(:queue_name)
         .sort
     }
+
+    def self.performed_count_last(duration)
+      by_event_type("job_completed").since(duration.ago).count
+    end
+
+    def self.failed_count_last(duration)
+      by_event_type("job_failed").since(duration.ago).count
+    end
+
+    def self.enqueue_rate_per_minute(window: 5.minutes)
+      count = by_event_type("job_enqueued").since(window.ago).count
+      return 0.0 if count.zero?
+
+      (count.to_f / (window.to_f / 60.0)).round(1)
+    end
   end
 end

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -49,6 +49,7 @@
     .so-stat-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
     .so-card { background: var(--so-card-bg); border: 1px solid var(--so-border); border-radius: 8px; padding: 1.25rem; }
     .so-card__label { font-size: 0.8rem; color: var(--so-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .so-card__subtitle { font-size: 0.7rem; color: var(--so-text-muted); margin-top: 0.1rem; font-weight: 400; text-transform: none; letter-spacing: 0; }
     .so-card__value { font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; }
 
     .so-table { width: 100%; border-collapse: collapse; background: var(--so-card-bg); border: 1px solid var(--so-border); border-radius: 8px; overflow: hidden; }

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -5,14 +5,32 @@
   <h1>Dashboard</h1>
 </div>
 
+<% if persistence_mode? %>
+  <div class="so-card so-card--spaced" style="background: #f1f5f9; border: 1px solid var(--so-border);">
+    <p style="font-size: 0.85rem; color: var(--so-text-muted); margin: 0;">
+      <strong>Jobs tab</strong> shows currently in-flight jobs (ready, scheduled, claimed) and failed jobs awaiting retry.
+      Successfully completed jobs are not retained as execution rows by Solid Queue —
+      see <%= link_to "Events tab", events_path %> for the full historical record.
+    </p>
+  </div>
+<% end %>
+
 <% if @stats[:available] %>
   <div class="so-stat-cards">
-    <%= render "solid_observer/shared/stat_card", label: "Ready", value: @stats[:ready], color: "success" %>
-    <%= render "solid_observer/shared/stat_card", label: "Scheduled", value: @stats[:scheduled], color: "warning" %>
-    <%= render "solid_observer/shared/stat_card", label: "Claimed", value: @stats[:claimed], color: "info" %>
-    <%= render "solid_observer/shared/stat_card", label: "Failed", value: @stats[:failed], color: "danger" %>
-    <%= render "solid_observer/shared/stat_card", label: "Workers", value: @stats[:workers], color: "info" %>
+    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: @stats[:ready], color: "success" %>
+    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: @stats[:scheduled], color: "warning" %>
+    <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: @stats[:claimed], color: "info" %>
+    <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: @stats[:failed], color: "danger" %>
+    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: @stats[:workers], color: "info" %>
   </div>
+
+  <% if persistence_mode? %>
+    <div class="so-stat-cards">
+      <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "last hour", value: number_with_delimiter(@stats[:performed_last_hour]), color: "success" %>
+      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "last 24h", value: number_with_delimiter(@stats[:failed_last_24h]), color: "danger" %>
+      <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "last 5 min", value: "#{@stats[:enqueue_rate_per_min]} jobs/min", color: "info" %>
+    </div>
+  <% end %>
 
   <% if @stats[:queues].any? %>
     <div class="so-card" style="margin-bottom: 2rem;">
@@ -58,6 +76,11 @@
             <% end %>
           </tbody>
         </table>
+      </div>
+    <% else %>
+      <div class="so-card" style="border-left: 4px solid var(--so-success); margin-bottom: 2rem;">
+        <div class="so-card__label" style="color: var(--so-success);">Recent Failures</div>
+        <div style="margin-top: 0.5rem; font-size: 0.85rem; color: var(--so-text-muted);">No recent failures.</div>
       </div>
     <% end %>
 

--- a/app/views/solid_observer/jobs/index.html.erb
+++ b/app/views/solid_observer/jobs/index.html.erb
@@ -6,7 +6,7 @@
 
 <%= form_tag jobs_path, method: :get, class: "so-filters" do %>
   <%= select_tag :status,
-      options_for_select([["Ready", "ready"], ["Scheduled", "scheduled"], ["Claimed", "claimed"], ["Failed", "failed"]], @status),
+      options_for_select([["All Active", "all_active"], ["Ready", "ready"], ["Scheduled", "scheduled"], ["Claimed", "claimed"], ["Failed", "failed"]], @status),
       onchange: "this.form.submit()" %>
 
   <%= select_tag :queue_name,
@@ -33,14 +33,15 @@
     <tbody>
       <% @jobs.each do |execution| %>
         <% job = execution.job %>
+        <% status = execution_status(execution) %>
         <tr>
-          <td><%= link_to execution.id, job_path(execution.id) %></td>
+          <td><%= link_to execution.id, job_path(execution.id, status: status) %></td>
           <td><%= job&.class_name || "N/A" %></td>
           <td><%= job&.queue_name || execution&.queue_name || "N/A" %></td>
-          <td><%= status_badge(execution_status(execution)) %></td>
+          <td><%= status_badge(status) %></td>
           <td><%= time_ago_in_words(execution.created_at) %> ago</td>
           <td>
-            <%= link_to "View", job_path(execution.id), class: "so-btn" %>
+            <%= link_to "View", job_path(execution.id, status: status), class: "so-btn" %>
             <% if execution.is_a?(SolidQueue::FailedExecution) %>
               <%= button_to "Retry", retry_job_path(execution.id), method: :post, class: "so-btn so-btn--primary", form: { class: "so-form--inline" }, data: { confirm: "Retry job #{execution.id}?" } %>
               <%= button_to "Discard", discard_job_path(execution.id), method: :post, class: "so-btn so-btn--danger", form: { class: "so-form--inline" }, data: { confirm: "Discard job #{execution.id}? This cannot be undone." } %>
@@ -53,5 +54,8 @@
 
   <%= render "solid_observer/shared/pagination", page: @page, total_pages: @total_pages %>
 <% else %>
-  <%= render "solid_observer/shared/empty_state", message: "No jobs found matching the criteria" %>
+  <%= render "solid_observer/shared/empty_state",
+      message: persistence_mode? ?
+        "No jobs match this filter. Successfully completed jobs are not stored here — see #{link_to("Events tab", events_path)} for the full job history.".html_safe :
+        "No jobs match this filter." %>
 <% end %>

--- a/app/views/solid_observer/shared/_stat_card.html.erb
+++ b/app/views/solid_observer/shared/_stat_card.html.erb
@@ -1,6 +1,10 @@
 <% color = local_assigns[:color] %>
+<% subtitle = local_assigns[:subtitle] %>
 <div class="so-card">
   <div class="so-card__label"><%= label %></div>
+  <% if subtitle.present? %>
+    <div class="so-card__subtitle"><%= subtitle %></div>
+  <% end %>
   <div class="so-card__value"<% if color %> style="color: var(--so-<%= color %>)"<% end %>>
     <%= value || 0 %>
   </div>

--- a/lib/solid_observer/params/jobs_filter.rb
+++ b/lib/solid_observer/params/jobs_filter.rb
@@ -4,10 +4,11 @@ module SolidObserver
   module Params
     class JobsFilter
       ALLOWED_STATUSES = %w[ready scheduled claimed failed].freeze
+      PSEUDO_STATUSES = %w[all_active].freeze
 
       def self.from_params(params)
         new(
-          status: params[:status].presence || "ready",
+          status: params[:status].presence || "all_active",
           queue_name: params[:queue_name].presence,
           job_class: params[:job_class].presence,
           page: (params[:page].presence || 1).to_i
@@ -27,7 +28,7 @@ module SolidObserver
 
       def normalize_status(status)
         normalized = status.to_s.downcase
-        ALLOWED_STATUSES.include?(normalized) ? normalized : "ready"
+        (ALLOWED_STATUSES + PSEUDO_STATUSES).include?(normalized) ? normalized : "all_active"
       end
     end
   end

--- a/lib/solid_observer/queries/execution_finder.rb
+++ b/lib/solid_observer/queries/execution_finder.rb
@@ -10,12 +10,26 @@ module SolidObserver
         "SolidQueue::FailedExecution"
       ].freeze
 
+      STATUS_TO_EXECUTION_TYPE = {
+        "ready" => "SolidQueue::ReadyExecution",
+        "scheduled" => "SolidQueue::ScheduledExecution",
+        "claimed" => "SolidQueue::ClaimedExecution",
+        "failed" => "SolidQueue::FailedExecution"
+      }.freeze
+
       def self.find_any(id)
         EXECUTION_TYPES.each do |const_name|
           execution = const_name.safe_constantize&.find_by(id: id)
           return execution if execution
         end
         nil
+      end
+
+      def self.find_by_status(id, status)
+        const_name = STATUS_TO_EXECUTION_TYPE[status.to_s.downcase]
+        return nil unless const_name
+
+        const_name.safe_constantize&.find_by(id: id)
       end
 
       def self.find_failed(id)

--- a/lib/solid_observer/queries/job_executions_query.rb
+++ b/lib/solid_observer/queries/job_executions_query.rb
@@ -3,6 +3,8 @@
 module SolidObserver
   module Queries
     class JobExecutionsQuery
+      ALL_ACTIVE_STATUSES = %w[ready scheduled claimed failed].freeze
+
       STATUS_SCOPES = {
         "ready" => -> { SolidQueue::ReadyExecution.all },
         "scheduled" => -> { SolidQueue::ScheduledExecution.all },
@@ -16,13 +18,38 @@ module SolidObserver
 
       def call
         status = @filter.status
-        scope = STATUS_SCOPES.fetch(status, STATUS_SCOPES["ready"]).call
-        scope = apply_queue_filter(scope, status)
-        scope = apply_job_class_filter(scope)
-        scope.order(created_at: :desc)
+        return all_active_executions if status == "all_active"
+
+        filtered_scope(status).order(created_at: :desc)
       end
 
       private
+
+      def all_active_executions
+        records = all_active_records.sort_by(&:created_at).reverse
+        preload_jobs(records)
+      end
+
+      def all_active_records
+        ALL_ACTIVE_STATUSES.flat_map do |status|
+          filtered_scope(status).order(created_at: :desc).limit(50).to_a
+        end
+      end
+
+      def preload_jobs(records)
+        ActiveRecord::Associations::Preloader.new(records:, associations: :job).call
+        records
+      end
+
+      def filtered_scope(status)
+        scope = status_scope(status)
+        scope = apply_queue_filter(scope, status)
+        apply_job_class_filter(scope)
+      end
+
+      def status_scope(status)
+        STATUS_SCOPES.fetch(status, STATUS_SCOPES["ready"]).call
+      end
 
       def apply_job_class_filter(scope)
         job_class = @filter.job_class

--- a/lib/solid_observer/queue_stats.rb
+++ b/lib/solid_observer/queue_stats.rb
@@ -15,6 +15,21 @@ module SolidObserver
     def snapshot
       return unavailable_response unless self.class.solid_queue_available?
 
+      snapshot_for_mode
+    rescue => e
+      error_response(e)
+    end
+
+    private
+
+    def snapshot_for_mode
+      base = snapshot_base
+      return base unless SolidObserver.config.persistence_mode?
+
+      base.merge(throughput_stats)
+    end
+
+    def snapshot_base
       {
         ready: ready_count,
         scheduled: scheduled_count,
@@ -24,11 +39,15 @@ module SolidObserver
         queues: queue_depths,
         available: true
       }
-    rescue => e
-      error_response(e)
     end
 
-    private
+    def throughput_stats
+      {
+        performed_last_hour: QueueEvent.performed_count_last(1.hour),
+        failed_last_24h: QueueEvent.failed_count_last(24.hours),
+        enqueue_rate_per_min: QueueEvent.enqueue_rate_per_minute(window: 5.minutes)
+      }
+    end
 
     def unavailable_response
       {

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -22,6 +22,23 @@ RSpec.describe "Dashboard", type: :feature do
   end
 
   context "in persistence mode" do
+    before do
+      allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
+        ready: 10,
+        scheduled: 5,
+        claimed: 2,
+        failed: 1,
+        workers: 3,
+        queues: {},
+        available: true,
+        performed_last_hour: 1200,
+        failed_last_24h: 9,
+        enqueue_rate_per_min: 4.6
+      )
+      allow(SolidObserver::QueueEvent).to receive(:recent).and_return([])
+      allow(SolidObserver::QueueEvent).to receive(:recent_failures).and_return([])
+    end
+
     it "shows Events and Storage navigation links" do
       visit "/solid_observer"
       expect(page).to have_link("Events")
@@ -31,6 +48,26 @@ RSpec.describe "Dashboard", type: :feature do
     it "shows Persistence mode indicator" do
       visit "/solid_observer"
       expect(page).to have_content("Persistence")
+    end
+
+    it "shows conceptual hint and throughput cards" do
+      visit "/solid_observer"
+
+      expect(page).to have_link("Events tab")
+      expect(page).to have_content("Jobs tab")
+      expect(page).to have_content("Performed")
+      expect(page).to have_content("last hour")
+      expect(page).to have_content("Failed")
+      expect(page).to have_content("last 24h")
+      expect(page).to have_content("Enqueue rate")
+      expect(page).to have_content("4.6 jobs/min")
+    end
+
+    it "shows reassurance when there are no recent failures" do
+      visit "/solid_observer"
+
+      expect(page).to have_content("Recent Failures")
+      expect(page).to have_content("No recent failures.")
     end
   end
 
@@ -46,6 +83,24 @@ RSpec.describe "Dashboard", type: :feature do
     it "shows Real-time mode indicator" do
       visit "/solid_observer"
       expect(page).to have_content("Real-time")
+    end
+
+    it "does not show persistence-only hint and throughput cards" do
+      allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
+        ready: 1,
+        scheduled: 0,
+        claimed: 0,
+        failed: 0,
+        workers: 1,
+        queues: {},
+        available: true
+      )
+
+      visit "/solid_observer"
+
+      expect(page).not_to have_content("Jobs tab")
+      expect(page).not_to have_content("Performed")
+      expect(page).not_to have_content("Enqueue rate")
     end
   end
 

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -3,6 +3,87 @@
 require "feature_helper"
 
 RSpec.describe "Jobs", type: :feature do
+  def ensure_solid_queue_tables!
+    connection = ActiveRecord::Base.connection
+
+    unless connection.table_exists?(:solid_queue_jobs)
+      connection.create_table :solid_queue_jobs do |t|
+        t.string :queue_name, null: false
+        t.string :class_name, null: false
+        t.datetime :created_at, null: false
+        t.datetime :updated_at, null: false
+      end
+    end
+
+    unless connection.table_exists?(:solid_queue_ready_executions)
+      connection.create_table :solid_queue_ready_executions do |t|
+        t.bigint :job_id, null: false
+        t.string :queue_name, null: false
+        t.integer :priority, null: false, default: 0
+        t.datetime :created_at, null: false
+      end
+    end
+
+    unless connection.table_exists?(:solid_queue_scheduled_executions)
+      connection.create_table :solid_queue_scheduled_executions do |t|
+        t.bigint :job_id, null: false
+        t.string :queue_name, null: false
+        t.integer :priority, null: false, default: 0
+        t.datetime :scheduled_at, null: false
+        t.datetime :created_at, null: false
+      end
+    end
+
+    unless connection.table_exists?(:solid_queue_claimed_executions)
+      connection.create_table :solid_queue_claimed_executions do |t|
+        t.bigint :job_id, null: false
+        t.bigint :process_id
+        t.datetime :created_at, null: false
+      end
+    end
+
+    unless connection.table_exists?(:solid_queue_failed_executions)
+      connection.create_table :solid_queue_failed_executions do |t|
+        t.bigint :job_id, null: false
+        t.text :error
+        t.datetime :created_at, null: false
+      end
+    end
+  end
+
+  def stub_solid_queue_models!
+    stub_const("SolidQueue", Module.new)
+
+    job_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_queue_jobs"
+    end
+    stub_const("SolidQueue::Job", job_model)
+
+    ready_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_queue_ready_executions"
+      belongs_to :job, class_name: "SolidQueue::Job"
+    end
+    stub_const("SolidQueue::ReadyExecution", ready_model)
+
+    scheduled_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_queue_scheduled_executions"
+      belongs_to :job, class_name: "SolidQueue::Job"
+    end
+    stub_const("SolidQueue::ScheduledExecution", scheduled_model)
+
+    claimed_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_queue_claimed_executions"
+      belongs_to :job, class_name: "SolidQueue::Job"
+    end
+    stub_const("SolidQueue::ClaimedExecution", claimed_model)
+
+    failed_model = Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_queue_failed_executions"
+      belongs_to :job, class_name: "SolidQueue::Job"
+    end
+    stub_const("SolidQueue::FailedExecution", failed_model)
+  end
+
   context "when SolidQueue is not available" do
     it "redirects to dashboard with an alert" do
       visit "/solid_observer/jobs"
@@ -12,6 +93,102 @@ RSpec.describe "Jobs", type: :feature do
     it "displays the SolidQueue unavailable alert" do
       visit "/solid_observer/jobs"
       expect(page).to have_content("SolidQueue is not available")
+    end
+  end
+
+  context "when all_active filter is used" do
+    before do
+      ensure_solid_queue_tables!
+      stub_solid_queue_models!
+      SolidObserver.config.storage_mode = :persistence
+
+      SolidQueue::ReadyExecution.delete_all
+      SolidQueue::ScheduledExecution.delete_all
+      SolidQueue::ClaimedExecution.delete_all
+      SolidQueue::FailedExecution.delete_all
+      SolidQueue::Job.delete_all
+
+      now = Time.current
+      ready_job = SolidQueue::Job.create!(queue_name: "default", class_name: "ReadyJob", created_at: now - 5.minutes, updated_at: now - 5.minutes)
+      scheduled_job = SolidQueue::Job.create!(queue_name: "mailers", class_name: "ScheduledJob", created_at: now - 4.minutes, updated_at: now - 4.minutes)
+      claimed_job = SolidQueue::Job.create!(queue_name: "critical", class_name: "ClaimedJob", created_at: now - 3.minutes, updated_at: now - 3.minutes)
+      failed_job = SolidQueue::Job.create!(queue_name: "default", class_name: "FailedJob", created_at: now - 2.minutes, updated_at: now - 2.minutes)
+
+      SolidQueue::ReadyExecution.create!(job: ready_job, queue_name: "default", priority: 0, created_at: now - 5.minutes)
+      SolidQueue::ScheduledExecution.create!(job: scheduled_job, queue_name: "mailers", priority: 0, scheduled_at: now + 10.minutes, created_at: now - 4.minutes)
+      SolidQueue::ClaimedExecution.create!(job: claimed_job, process_id: 123, created_at: now - 3.minutes)
+      SolidQueue::FailedExecution.create!(job: failed_job, error: "failure", created_at: now - 2.minutes)
+    end
+
+    after do
+      SolidQueue::ReadyExecution.delete_all if defined?(SolidQueue::ReadyExecution)
+      SolidQueue::ScheduledExecution.delete_all if defined?(SolidQueue::ScheduledExecution)
+      SolidQueue::ClaimedExecution.delete_all if defined?(SolidQueue::ClaimedExecution)
+      SolidQueue::FailedExecution.delete_all if defined?(SolidQueue::FailedExecution)
+      SolidQueue::Job.delete_all if defined?(SolidQueue::Job)
+    end
+
+    it "renders jobs from all four execution tables" do
+      visit "/solid_observer/jobs?status=all_active"
+
+      expect(page).to have_content("ReadyJob")
+      expect(page).to have_content("ScheduledJob")
+      expect(page).to have_content("ClaimedJob")
+      expect(page).to have_content("FailedJob")
+      expect(page).to have_content("Ready")
+      expect(page).to have_content("Scheduled")
+      expect(page).to have_content("Claimed")
+      expect(page).to have_content("Failed")
+    end
+  end
+
+  context "when all_active has colliding execution ids across statuses" do
+    before do
+      ensure_solid_queue_tables!
+      stub_solid_queue_models!
+      SolidObserver.config.storage_mode = :persistence
+
+      SolidQueue::ReadyExecution.delete_all
+      SolidQueue::ScheduledExecution.delete_all
+      SolidQueue::ClaimedExecution.delete_all
+      SolidQueue::FailedExecution.delete_all
+      SolidQueue::Job.delete_all
+
+      now = Time.current
+      ready_job = SolidQueue::Job.create!(queue_name: "default", class_name: "ReadyCollisionJob", created_at: now - 2.minutes, updated_at: now - 2.minutes)
+      claimed_job = SolidQueue::Job.create!(queue_name: "critical", class_name: "ClaimedCollisionJob", created_at: now - 1.minute, updated_at: now - 1.minute)
+
+      SolidQueue::ReadyExecution.create!(id: 77, job: ready_job, queue_name: "default", priority: 0, created_at: now - 2.minutes)
+      SolidQueue::ClaimedExecution.create!(id: 77, job: claimed_job, process_id: 321, created_at: now - 1.minute)
+    end
+
+    after do
+      SolidQueue::ReadyExecution.delete_all if defined?(SolidQueue::ReadyExecution)
+      SolidQueue::ScheduledExecution.delete_all if defined?(SolidQueue::ScheduledExecution)
+      SolidQueue::ClaimedExecution.delete_all if defined?(SolidQueue::ClaimedExecution)
+      SolidQueue::FailedExecution.delete_all if defined?(SolidQueue::FailedExecution)
+      SolidQueue::Job.delete_all if defined?(SolidQueue::Job)
+    end
+
+    it "renders distinct status-aware links when ids collide" do
+      visit "/solid_observer/jobs?status=all_active"
+
+      ready_href = nil
+      claimed_href = nil
+
+      within("tr", text: "ReadyCollisionJob") do
+        ready_href = find_link("View")[:href]
+      end
+
+      within("tr", text: "ClaimedCollisionJob") do
+        claimed_href = find_link("View")[:href]
+      end
+
+      expect(ready_href).to include("/solid_observer/jobs/77")
+      expect(ready_href).to include("status=ready")
+      expect(claimed_href).to include("/solid_observer/jobs/77")
+      expect(claimed_href).to include("status=claimed")
+      expect(ready_href).not_to eq(claimed_href)
     end
   end
 end

--- a/spec/models/solid_observer/queue_event_spec.rb
+++ b/spec/models/solid_observer/queue_event_spec.rb
@@ -93,4 +93,63 @@ RSpec.describe "SolidObserver::QueueEvent" do
       expect(SolidObserver::QueueEvent.distinct_queue_names.count).to eq(3)
     end
   end
+
+  describe "throughput counters" do
+    before(:all) do
+      connection = SolidObserver::QueueEvent.connection
+      next if connection.table_exists?(:solid_observer_queue_events)
+
+      connection.create_table :solid_observer_queue_events do |t|
+        t.string :event_type, null: false, limit: 50
+        t.string :job_class, limit: 100
+        t.string :queue_name, limit: 50
+        t.datetime :recorded_at, null: false
+      end
+    end
+
+    before { SolidObserver::QueueEvent.delete_all }
+
+    describe ".performed_count_last" do
+      it "counts completed events within the provided window" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", recorded_at: 20.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", recorded_at: 2.hours.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_failed", recorded_at: 10.minutes.ago)
+
+          expect(SolidObserver::QueueEvent.performed_count_last(1.hour)).to eq(1)
+        end
+      end
+    end
+
+    describe ".failed_count_last" do
+      it "counts failed events within the provided window" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_failed", recorded_at: 6.hours.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_failed", recorded_at: 30.hours.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_discarded", recorded_at: 2.hours.ago)
+
+          expect(SolidObserver::QueueEvent.failed_count_last(24.hours)).to eq(1)
+        end
+      end
+    end
+
+    describe ".enqueue_rate_per_minute" do
+      it "returns jobs per minute rounded to one decimal place" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          12.times { SolidObserver::QueueEvent.create!(event_type: "job_enqueued", recorded_at: 2.minutes.ago) }
+          SolidObserver::QueueEvent.create!(event_type: "job_enqueued", recorded_at: 10.minutes.ago)
+
+          expect(SolidObserver::QueueEvent.enqueue_rate_per_minute(window: 5.minutes)).to eq(2.4)
+        end
+      end
+
+      it "returns 0.0 when there are no enqueues in the window" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_enqueued", recorded_at: 10.minutes.ago)
+
+          expect(SolidObserver::QueueEvent.enqueue_rate_per_minute(window: 5.minutes)).to eq(0.0)
+        end
+      end
+    end
+  end
 end

--- a/spec/solid_observer/jobs_controller_spec.rb
+++ b/spec/solid_observer/jobs_controller_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe SolidObserver::JobsController do
 
       before do
         allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "1"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_by_status).with("1", nil).and_return(nil)
         allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_any).with("1").and_return(execution)
         allow(SolidObserver::ExecutionPresenter).to receive(:new).with(execution).and_return(presenter)
       end
@@ -190,9 +191,28 @@ RSpec.describe SolidObserver::JobsController do
       end
     end
 
+    context "when status is provided" do
+      let(:execution) { double("execution") }
+      let(:job) { double("job") }
+      let(:presenter) { instance_double(SolidObserver::ExecutionPresenter, job: job, status: "claimed") }
+
+      before do
+        allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "1", status: "claimed"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_by_status).with("1", "claimed").and_return(execution)
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_any)
+        allow(SolidObserver::ExecutionPresenter).to receive(:new).with(execution).and_return(presenter)
+      end
+
+      it "uses status-aware lookup and does not fallback to find_any" do
+        expect(SolidObserver::Queries::ExecutionFinder).not_to receive(:find_any)
+        controller.send(:show)
+      end
+    end
+
     context "when execution is not found" do
       before do
         allow(controller).to receive(:params).and_return(ActionController::Parameters.new(id: "999"))
+        allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_by_status).with("999", nil).and_return(nil)
         allow(SolidObserver::Queries::ExecutionFinder).to receive(:find_any).with("999").and_return(nil)
         controller.define_singleton_method(:jobs_path) { "/solid_observer/jobs" }
       end

--- a/spec/solid_observer/params/jobs_filter_spec.rb
+++ b/spec/solid_observer/params/jobs_filter_spec.rb
@@ -4,9 +4,9 @@ require "spec_helper"
 
 RSpec.describe SolidObserver::Params::JobsFilter do
   describe ".from_params" do
-    it "defaults status to ready" do
+    it "defaults status to all_active" do
       filter = described_class.from_params(ActionController::Parameters.new({}))
-      expect(filter.status).to eq("ready")
+      expect(filter.status).to eq("all_active")
     end
 
     it "reads status from params" do
@@ -39,8 +39,18 @@ RSpec.describe SolidObserver::Params::JobsFilter do
       expect(filter.status).to eq("failed")
     end
 
-    it "falls back to ready for unknown status" do
+    it "falls back to all_active for unknown status" do
       filter = described_class.from_params(ActionController::Parameters.new(status: "unknown_status"))
+      expect(filter.status).to eq("all_active")
+    end
+
+    it "accepts all_active pseudo-status" do
+      filter = described_class.from_params(ActionController::Parameters.new(status: "all_active"))
+      expect(filter.status).to eq("all_active")
+    end
+
+    it "still accepts ready status" do
+      filter = described_class.from_params(ActionController::Parameters.new(status: "ready"))
       expect(filter.status).to eq("ready")
     end
   end

--- a/spec/solid_observer/queries/execution_finder_spec.rb
+++ b/spec/solid_observer/queries/execution_finder_spec.rb
@@ -62,4 +62,23 @@ RSpec.describe SolidObserver::Queries::ExecutionFinder do
       expect(described_class.find_failed("5")).to be_nil
     end
   end
+
+  describe ".find_by_status" do
+    it "finds by the mapped execution class for status" do
+      execution = double("execution")
+      allow(SolidQueue::ClaimedExecution).to receive(:find_by).with(id: "10").and_return(execution)
+
+      expect(described_class.find_by_status("10", "claimed")).to eq(execution)
+    end
+
+    it "returns nil for unknown status" do
+      expect(described_class.find_by_status("10", "unknown")).to be_nil
+    end
+
+    it "returns nil when mapped constant is unavailable" do
+      hide_const("SolidQueue::ReadyExecution")
+
+      expect(described_class.find_by_status("10", "ready")).to be_nil
+    end
+  end
 end

--- a/spec/solid_observer/queries/job_executions_query_spec.rb
+++ b/spec/solid_observer/queries/job_executions_query_spec.rb
@@ -136,4 +136,55 @@ RSpec.describe SolidObserver::Queries::JobExecutionsQuery do
     result = described_class.new(build_filter(status: "ready", job_class: "MyJob")).call
     expect(result).to eq(ordered_scope)
   end
+
+  it "returns a merged array for all_active sorted by created_at desc and preloads jobs" do
+    ready_scope = double("ready_scope")
+    ready_ordered = double("ready_ordered")
+    ready_limited = double("ready_limited")
+    scheduled_scope = double("scheduled_scope")
+    scheduled_ordered = double("scheduled_ordered")
+    scheduled_limited = double("scheduled_limited")
+    claimed_scope = double("claimed_scope")
+    claimed_ordered = double("claimed_ordered")
+    claimed_limited = double("claimed_limited")
+    failed_scope = double("failed_scope")
+    failed_ordered = double("failed_ordered")
+    failed_limited = double("failed_limited")
+
+    ready_record = double("ready_record", created_at: 4.minutes.ago)
+    scheduled_record = double("scheduled_record", created_at: 2.minutes.ago)
+    claimed_record = double("claimed_record", created_at: 1.minute.ago)
+    failed_record = double("failed_record", created_at: 3.minutes.ago)
+
+    allow(SolidQueue::ReadyExecution).to receive(:all).and_return(ready_scope)
+    allow(ready_scope).to receive(:order).with(created_at: :desc).and_return(ready_ordered)
+    allow(ready_ordered).to receive(:limit).with(50).and_return(ready_limited)
+    allow(ready_limited).to receive(:to_a).and_return([ready_record])
+
+    allow(SolidQueue::ScheduledExecution).to receive(:all).and_return(scheduled_scope)
+    allow(scheduled_scope).to receive(:order).with(created_at: :desc).and_return(scheduled_ordered)
+    allow(scheduled_ordered).to receive(:limit).with(50).and_return(scheduled_limited)
+    allow(scheduled_limited).to receive(:to_a).and_return([scheduled_record])
+
+    allow(SolidQueue::ClaimedExecution).to receive(:all).and_return(claimed_scope)
+    allow(claimed_scope).to receive(:order).with(created_at: :desc).and_return(claimed_ordered)
+    allow(claimed_ordered).to receive(:limit).with(50).and_return(claimed_limited)
+    allow(claimed_limited).to receive(:to_a).and_return([claimed_record])
+
+    allow(SolidQueue::FailedExecution).to receive(:all).and_return(failed_scope)
+    allow(failed_scope).to receive(:order).with(created_at: :desc).and_return(failed_ordered)
+    allow(failed_ordered).to receive(:limit).with(50).and_return(failed_limited)
+    allow(failed_limited).to receive(:to_a).and_return([failed_record])
+
+    expected = [claimed_record, scheduled_record, failed_record, ready_record]
+    preloader = instance_double(ActiveRecord::Associations::Preloader, call: true)
+    expect(ActiveRecord::Associations::Preloader).to receive(:new)
+      .with(records: expected, associations: :job)
+      .and_return(preloader)
+
+    result = described_class.new(build_filter(status: "all_active")).call
+
+    expect(result).to be_a(Array)
+    expect(result).to eq(expected)
+  end
 end

--- a/spec/solid_observer/queue_stats_spec.rb
+++ b/spec/solid_observer/queue_stats_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe SolidObserver::QueueStats do
+  after { SolidObserver.reset_configuration! }
+
   describe ".solid_queue_available?" do
     context "when SolidQueue is defined" do
       it "returns true" do
@@ -82,7 +84,7 @@ RSpec.describe SolidObserver::QueueStats do
         allow(described_class).to receive(:solid_queue_available?).and_return(true)
       end
 
-      it "returns snapshot with all statistics" do
+      before do
         allow(ready_execution).to receive(:count).and_return(10)
         allow(scheduled_execution).to receive(:count).and_return(5)
         allow(claimed_execution).to receive(:count).and_return(3)
@@ -92,22 +94,61 @@ RSpec.describe SolidObserver::QueueStats do
         group_double = double
         allow(ready_execution).to receive(:group).with(:queue_name).and_return(group_double)
         allow(group_double).to receive(:count).and_return({"default" => 8, "mailers" => 2})
+      end
 
-        result = queue_stats.snapshot
+      context "when persistence_mode? is true" do
+        before do
+          SolidObserver.config.storage_mode = :persistence
+          allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(1.hour).and_return(120)
+          allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
+          allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 5.minutes).and_return(14.2)
+        end
 
-        expect(result).to eq(
-          ready: 10,
-          scheduled: 5,
-          claimed: 3,
-          failed: 2,
-          workers: 4,
-          queues: {"default" => 8, "mailers" => 2},
-          available: true
-        )
+        it "returns snapshot with throughput statistics" do
+          result = queue_stats.snapshot
+
+          expect(result).to eq(
+            ready: 10,
+            scheduled: 5,
+            claimed: 3,
+            failed: 2,
+            workers: 4,
+            queues: {"default" => 8, "mailers" => 2},
+            available: true,
+            performed_last_hour: 120,
+            failed_last_24h: 7,
+            enqueue_rate_per_min: 14.2
+          )
+        end
+      end
+
+      context "when persistence_mode? is false (realtime)" do
+        before do
+          SolidObserver.config.storage_mode = :realtime
+        end
+
+        it "does not include throughput statistics" do
+          expect(SolidObserver::QueueEvent).not_to receive(:performed_count_last)
+          expect(SolidObserver::QueueEvent).not_to receive(:failed_count_last)
+          expect(SolidObserver::QueueEvent).not_to receive(:enqueue_rate_per_minute)
+
+          result = queue_stats.snapshot
+
+          expect(result).to eq(
+            ready: 10,
+            scheduled: 5,
+            claimed: 3,
+            failed: 2,
+            workers: 4,
+            queues: {"default" => 8, "mailers" => 2},
+            available: true
+          )
+        end
       end
 
       it "returns 0 workers when Process model is not defined" do
         hide_const("SolidQueue::Process")
+        SolidObserver.config.storage_mode = :realtime
 
         allow(ready_execution).to receive(:count).and_return(10)
         allow(scheduled_execution).to receive(:count).and_return(5)
@@ -125,7 +166,7 @@ RSpec.describe SolidObserver::QueueStats do
 
       it "returns empty hash for queues when ReadyExecution is not defined" do
         hide_const("SolidQueue::ReadyExecution")
-        stub_const("SolidQueue::ReadyExecution", nil)
+        SolidObserver.config.storage_mode = :realtime
 
         allow(queue_stats).to receive(:ready_count).and_return(0)
         allow(scheduled_execution).to receive(:count).and_return(5)


### PR DESCRIPTION
## Summary of the changes
Fast jobs (~10ms typical) made point-in-time counters read 0 between executions, the Jobs tab defaulted to an empty 'ready' filter, and SolidQueue lifecycle terms required external docs — making healthy production systems look dead. Surface throughput from the events table, subtitle the lifecycle counters, switch the Jobs default to a merged 'all_active' view, and fill in missing empty-state reassurance.