### PR TITLE
[SO-057][FEAT] Clarify Duration semantics per event type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - Specs: `allow_any_instance_of` → `instance_double`; sleep-based timer specs use deterministic synchronisation; dead private-method `describe` blocks removed
 - `.reek.yml` suppressions trimmed; hot-path services/buffer/engine methods refactored to pass `TooManyStatements` without new suppressions
 - Jobs tab default filter changed from `status=ready` to `status=all_active` (ready + scheduled + claimed + failed).
+- Duration values on the Events index and detail pages now use per-event-type semantic context via `<abbr title="...">` tooltips so operators can distinguish enqueue call latency (`job_enqueued`) from perform-time duration (`job_completed` / `job_failed` / `job_discarded`).
 
 ## [0.1.1] - 2026-02-10
 

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -12,6 +12,12 @@ module SolidObserver
       "enqueued" => "info",
       "discarded" => "info"
     }.freeze
+    DURATION_SEMANTICS = {
+      "job_enqueued" => "Time spent in the ActiveJob enqueue call (Rails internal; typically sub-millisecond to single-digit ms)",
+      "job_completed" => "Time spent performing the job",
+      "job_failed" => "Time spent performing the job before the exception was raised",
+      "job_discarded" => "Time before discard decision was made"
+    }.freeze
 
     def execution_status(execution)
       ExecutionPresenter.new(execution).status
@@ -31,6 +37,12 @@ module SolidObserver
       status_str = status.to_s
       color = STATUS_COLORS.fetch(status_str, "default")
       content_tag(:span, status_str.humanize, class: "so-badge so-badge--#{color}")
+    end
+
+    def duration_with_semantic(value, event_type)
+      return content_tag(:span, "—", class: "so-text-muted") unless value
+
+      content_tag(:abbr, format_duration(value), title: DURATION_SEMANTICS.fetch(event_type.to_s))
     end
 
     def mode_badge

--- a/app/views/solid_observer/events/index.html.erb
+++ b/app/views/solid_observer/events/index.html.erb
@@ -40,7 +40,7 @@
           <td><%= link_to event.event_type.humanize, event_path(event.id) %></td>
           <td><%= event.job_class %></td>
           <td><%= event.queue_name %></td>
-          <td><%= event.duration ? format_duration(event.duration) : "—" %></td>
+          <td><%= duration_with_semantic(event.duration, event.event_type) %></td>
           <td><%= time_ago_in_words(event.recorded_at) %> ago</td>
         </tr>
       <% end %>

--- a/app/views/solid_observer/events/show.html.erb
+++ b/app/views/solid_observer/events/show.html.erb
@@ -29,7 +29,7 @@
       </tr>
       <tr>
         <td>Duration</td>
-        <td><%= @event.duration ? format_duration(@event.duration) : "N/A" %></td>
+        <td><%= duration_with_semantic(@event.duration, @event.event_type) %></td>
       </tr>
       <tr>
         <td>Recorded At</td>

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -27,11 +27,12 @@ RSpec.describe "Events", type: :feature do
     end
 
     context "when events exist" do
-      before do
+      let!(:event) do
         SolidObserver::QueueEvent.create!(
           event_type: "job_completed",
           job_class: "MyJob",
           queue_name: "default",
+          duration: 0.011,
           recorded_at: Time.now
         )
       end
@@ -45,6 +46,22 @@ RSpec.describe "Events", type: :feature do
       it "links to the event show page" do
         visit "/solid_observer/events"
         expect(page).to have_link("Job completed")
+      end
+
+      it "renders duration with semantic tooltip on the index page" do
+        visit "/solid_observer/events"
+        expect(page).to have_css(
+          "abbr[title='Time spent performing the job']",
+          text: "11ms"
+        )
+      end
+
+      it "renders duration with semantic tooltip on the show page" do
+        visit "/solid_observer/events/#{event.id}"
+        expect(page).to have_css(
+          "abbr[title='Time spent performing the job']",
+          text: "11ms"
+        )
       end
     end
   end

--- a/spec/solid_observer/application_helper_spec.rb
+++ b/spec/solid_observer/application_helper_spec.rb
@@ -31,6 +31,44 @@ RSpec.describe SolidObserver::ApplicationHelper do
     end
   end
 
+  describe "#duration_with_semantic" do
+    it "wraps duration in an abbr tag with perform text for job_completed" do
+      result = duration_with_semantic(0.011, "job_completed")
+
+      expect(result).to include("<abbr")
+      expect(result).to include("11ms")
+      expect(result).to include("Time spent performing the job")
+    end
+
+    it "uses enqueue-specific text for job_enqueued" do
+      result = duration_with_semantic(0.005, "job_enqueued")
+      expect(result).to include("ActiveJob enqueue call")
+    end
+
+    it "uses failed-specific text for job_failed" do
+      result = duration_with_semantic(1.5, "job_failed")
+      expect(result).to include("before the exception was raised")
+    end
+
+    it "uses discarded-specific text for job_discarded" do
+      result = duration_with_semantic(0.2, "job_discarded")
+      expect(result).to include("discard decision was made")
+    end
+
+    it "renders an em-dash for nil duration" do
+      result = duration_with_semantic(nil, "job_completed")
+
+      expect(result).to include("—")
+      expect(result).to include("so-text-muted")
+    end
+
+    it "raises KeyError for unknown event type" do
+      expect {
+        duration_with_semantic(0.011, "job_unknown")
+      }.to raise_error(KeyError)
+    end
+  end
+
   describe "#status_badge" do
     it "uses success for completed" do
       expect(status_badge(:completed)).to include("so-badge--success")


### PR DESCRIPTION
## Summary
- Wraps Duration values on the Events index and Event show pages in `<abbr title="...">` tooltips so operators can hover to see what "Duration" means for each event type (enqueue call latency vs. job perform time vs. time-before-failure/discard).
- Adds `DURATION_SEMANTICS` frozen-hash constant + single `duration_with_semantic(value, event_type)` helper in `ApplicationHelper`. Uses `fetch` without default — `KeyError` fail-fast surfaces any future event-type drift instead of silently masking it.
- Zero new dependencies, no JS, header text unchanged. Resolves the post-SO-056 ambiguity where four semantically different durations shared a uniform "Duration" column.
