### PR TITLE
[SO-061][FEAT] Minimalist UI refresh + dashboard stability indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - `.reek.yml` suppressions trimmed; hot-path services/buffer/engine methods refactored to pass `TooManyStatements` without new suppressions
 - Jobs tab default filter changed from `status=ready` to `status=all_active` (ready + scheduled + claimed + failed).
 - Duration values on the Events index and detail pages now use per-event-type semantic context via `<abbr title="...">` tooltips so operators can distinguish enqueue call latency (`job_enqueued`) from perform-time duration (`job_completed` / `job_failed` / `job_discarded`).
+- Refreshed the engine UI to a minimalist visual language: light surfaces, near-black text, restrained semantic colour accents reserved for badges/state, hairline separators, consistent rounding. Sidebar moves from dark slate to a light surface. No external CSS dependencies, no JS, no dark mode (single light theme).
+- Dashboard: replaced the multi-line "Recent Failures" panel with a single-line **Stability** indicator (pill badge + summary + "View failures" link). Three states based on rolling failure counts: **Stable** (no failures in last 24h), **Degraded** (failures in last 24h but none in last hour), **Critical** (any failure in the last hour). Click-through targets the Events page filtered to `job_failed`.
+- Dashboard: removed the "Jobs tab / Events tab" orientation banner. The distinction is discoverable via navigation; the dashboard is reserved for signal.
 
 ## [0.1.1] - 2026-02-10
 

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -5,10 +5,7 @@ module SolidObserver
     def index
       @stats = QueueStats.snapshot
 
-      if persistence_mode?
-        @recent_events = QueueEvent.recent(10)
-        @recent_failures = QueueEvent.recent_failures(5)
-      end
+      @recent_events = QueueEvent.recent(10) if persistence_mode?
     end
   end
 end

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -18,6 +18,11 @@ module SolidObserver
       "job_failed" => "Time spent performing the job before the exception was raised",
       "job_discarded" => "Time before discard decision was made"
     }.freeze
+    STABILITY_STATES = {
+      stable: {label: "Stable", tone: "success"},
+      degraded: {label: "Degraded", tone: "warning"},
+      critical: {label: "Critical", tone: "danger"}
+    }.freeze
 
     def execution_status(execution)
       ExecutionPresenter.new(execution).status
@@ -49,6 +54,33 @@ module SolidObserver
       config = SolidObserver.config
       color = config.persistence_mode? ? "info" : "warning"
       content_tag(:span, config.storage_mode.to_s.capitalize, class: "so-badge so-badge--#{color}")
+    end
+
+    def stability_state(stats)
+      return :critical if stats[:failed_last_hour].to_i.positive?
+      return :degraded if stats[:failed_last_24h].to_i.positive?
+
+      :stable
+    end
+
+    def stability_badge(stats)
+      meta = STABILITY_STATES.fetch(stability_state(stats))
+      dot = tag.svg(tag.circle(r: 3, cx: 3, cy: 3),
+        class: "so-badge__dot", viewBox: "0 0 6 6", "aria-hidden": "true")
+      tag.span(class: "so-badge so-badge--pill so-badge--#{meta[:tone]}") do
+        safe_join([dot, meta[:label]], " ")
+      end
+    end
+
+    def stability_detail(stats)
+      failures_24h = stats[:failed_last_24h].to_i
+      return "No failures in the last 24h" if failures_24h.zero?
+
+      "#{pluralize(failures_24h, "failure")} in the last 24h, latest #{latest_failure_phrase(stats[:latest_failure_at])}"
+    end
+
+    def latest_failure_phrase(timestamp)
+      timestamp ? "#{time_ago_in_words(timestamp)} ago" : "unknown"
     end
   end
 end

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -10,24 +10,43 @@
   <% end %>
   <style>
     :root {
-      --so-sidebar-width: 240px;
-      --so-sidebar-bg: #1e293b;
-      --so-sidebar-text: #e2e8f0;
-      --so-sidebar-active: #00DBCC;
-      --so-bg: #f8fafc;
+      /* surfaces */
+      --so-bg: #fafafa;
       --so-card-bg: #ffffff;
-      --so-text: #1e293b;
-      --so-text-muted: #64748b;
-      --so-border: #e2e8f0;
-      --so-success: #22c55e;
-      --so-warning: #f59e0b;
-      --so-danger: #ef4444;
-      --so-info: #3b82f6;
+      --so-surface-muted: #f5f5f5;
+
+      /* text */
+      --so-text: #171717;
+      --so-text-muted: #737373;
+      --so-text-subtle: #a3a3a3;
+
+      /* lines */
+      --so-border: #e5e5e5;
+      --so-border-strong: #d4d4d4;
+
+      /* sidebar (now light) */
+      --so-sidebar-width: 220px;
+      --so-sidebar-bg: #ffffff;
+      --so-sidebar-text: #525252;
+      --so-sidebar-active-bg: #f5f5f5;
+      --so-sidebar-active-text: #171717;
+
+      /* semantic accents — used ONLY for badges / pills / state markers */
+      --so-success: #16a34a;
+      --so-warning: #d97706;
+      --so-danger: #dc2626;
+      --so-info: #2563eb;
+
+      /* radii & motion */
+      --so-radius: 6px;
+      --so-radius-lg: 8px;
+
+      /* type */
+      --so-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-           color: var(--so-text); background: var(--so-bg); }
+    body { font-family: var(--so-font); color: var(--so-text); background: var(--so-bg); }
 
     .so-layout {
       display: grid;
@@ -35,80 +54,280 @@
       min-height: 100vh;
     }
 
-    .so-sidebar { background: var(--so-sidebar-bg); color: var(--so-sidebar-text); padding: 1.5rem 0; display: flex; flex-direction: column; }
-    .so-sidebar__logo { padding: 1rem 1.25rem 1.5rem; font-size: 1.1rem; font-weight: 700; color: var(--so-sidebar-active); letter-spacing: 0.01em; }
-    .so-sidebar__nav a { display: block; padding: 0.6rem 1.25rem; color: var(--so-sidebar-text); text-decoration: none; font-size: 0.9rem; }
-    .so-sidebar__nav a:hover { background: rgba(255,255,255,0.08); }
-    .so-sidebar__nav a.active { background: var(--so-sidebar-active); color: #fff; border-radius: 0 4px 4px 0; margin-right: 8px; }
-    .so-sidebar__mode { padding: 1rem 1.25rem; font-size: 0.75rem; color: var(--so-text-muted); border-top: 1px solid rgba(255,255,255,0.1); margin-top: auto; }
+    .so-sidebar {
+      background: var(--so-sidebar-bg);
+      color: var(--so-sidebar-text);
+      border-right: 1px solid var(--so-border);
+      padding: 1.5rem 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .so-sidebar__logo {
+      padding: 1rem 1.25rem 1.5rem;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--so-text);
+      letter-spacing: 0;
+    }
+
+    .so-sidebar__nav a {
+      display: block;
+      padding: 0.6rem 0.75rem;
+      margin: 0 0.75rem;
+      border-radius: var(--so-radius);
+      color: var(--so-sidebar-text);
+      text-decoration: none;
+      font-size: 0.9rem;
+      font-weight: 500;
+    }
+
+    .so-sidebar__nav a:hover {
+      background: var(--so-sidebar-active-bg);
+      color: var(--so-sidebar-active-text);
+    }
+
+    .so-sidebar__nav a.active {
+      background: var(--so-sidebar-active-bg);
+      color: var(--so-sidebar-active-text);
+    }
+
+    .so-sidebar__mode {
+      padding: 1rem 1.25rem;
+      font-size: 0.75rem;
+      color: var(--so-text-muted);
+      border-top: 1px solid var(--so-border);
+      margin-top: auto;
+    }
 
     .so-content { padding: 2rem; overflow-y: auto; }
     .so-content__header { margin-bottom: 1.5rem; }
-    .so-content__header h1 { font-size: 1.5rem; font-weight: 600; }
+    .so-content__header h1 { font-size: 1.375rem; font-weight: 500; }
 
     .so-stat-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
-    .so-card { background: var(--so-card-bg); border: 1px solid var(--so-border); border-radius: 8px; padding: 1.25rem; }
-    .so-card__label { font-size: 0.8rem; color: var(--so-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-    .so-card__subtitle { font-size: 0.7rem; color: var(--so-text-muted); margin-top: 0.1rem; font-weight: 400; text-transform: none; letter-spacing: 0; }
-    .so-card__value { font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; }
+    .so-card {
+      background: var(--so-card-bg);
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius-lg);
+      padding: 1.25rem;
+    }
 
-    .so-table { width: 100%; border-collapse: collapse; background: var(--so-card-bg); border: 1px solid var(--so-border); border-radius: 8px; overflow: hidden; }
-    .so-table th { text-align: left; padding: 0.75rem 1rem; background: #f1f5f9; font-size: 0.8rem; color: var(--so-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-    .so-table td { padding: 0.75rem 1rem; border-top: 1px solid var(--so-border); font-size: 0.9rem; }
-    .so-table tr:hover td { background: #f8fafc; }
+    .so-card__label {
+      font-size: 0.75rem;
+      color: var(--so-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 500;
+    }
 
-    .so-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
+    .so-card__subtitle {
+      font-size: 0.7rem;
+      color: var(--so-text-subtle);
+      margin-top: 0.15rem;
+    }
+
+    .so-card__value {
+      font-size: 1.625rem;
+      font-weight: 600;
+      margin-top: 0.4rem;
+      color: var(--so-text);
+    }
+
+    .so-card--accent-danger { border-left: 3px solid var(--so-danger); }
+    .so-card--accent-success { border-left: 3px solid var(--so-success); }
+    .so-card--muted { background: var(--so-surface-muted); }
+    .so-card--section { margin-bottom: 2rem; }
+
+    .so-table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--so-card-bg);
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius);
+      overflow: hidden;
+    }
+
+    .so-table th {
+      text-align: left;
+      padding: 0.625rem 0.875rem;
+      background: var(--so-surface-muted);
+      font-size: 0.7rem;
+      font-weight: 500;
+      color: var(--so-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .so-table td {
+      padding: 0.7rem 0.875rem;
+      border-top: 1px solid var(--so-border);
+      font-size: 0.875rem;
+    }
+
+    .so-table tr:hover td { background: var(--so-surface-muted); }
+
+    .so-badge {
+      display: inline-block;
+      padding: 0.15rem 0.45rem;
+      border-radius: var(--so-radius);
+      font-size: 0.7rem;
+      font-weight: 600;
+    }
     .so-badge--success { background: #dcfce7; color: #166534; }
     .so-badge--warning { background: #fef3c7; color: #92400e; }
     .so-badge--danger { background: #fee2e2; color: #991b1b; }
     .so-badge--info { background: #dbeafe; color: #1e40af; }
-    .so-badge--default { background: #f1f5f9; color: #475569; }
+    .so-badge--default { background: var(--so-surface-muted); color: var(--so-text-muted); }
 
-    .so-flash { padding: 0.75rem 1rem; border-radius: 6px; margin-bottom: 1rem; font-size: 0.9rem; }
-    .so-flash--notice { background: #dbeafe; color: #1e40af; }
-    .so-flash--alert { background: #fee2e2; color: #991b1b; }
+    .so-badge--pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.25rem 0.55rem;
+      border-radius: 9999px;
+      font-weight: 500;
+    }
+    .so-badge__dot { width: 0.375rem; height: 0.375rem; flex-shrink: 0; }
+    .so-badge--pill.so-badge--success .so-badge__dot { fill: var(--so-success); }
+    .so-badge--pill.so-badge--warning .so-badge__dot { fill: var(--so-warning); }
+    .so-badge--pill.so-badge--danger  .so-badge__dot { fill: var(--so-danger); }
 
-    .so-btn { display: inline-block; padding: 0.4rem 0.75rem; border-radius: 4px; font-size: 0.85rem; font-weight: 500; text-decoration: none; cursor: pointer; border: 1px solid var(--so-border); background: var(--so-card-bg); color: var(--so-text); }
-    .so-btn:hover { background: #f1f5f9; }
-    .so-btn--primary { background: var(--so-info); color: #fff; border-color: var(--so-info); }
-    .so-btn--primary:hover { background: #2563eb; }
+    .so-stability {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      padding: 0.75rem 0;
+      margin-bottom: 2rem;
+      border-top: 1px solid var(--so-border);
+      border-bottom: 1px solid var(--so-border);
+      font-size: 0.85rem;
+    }
+    .so-stability__label {
+      font-size: 0.7rem;
+      color: var(--so-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 500;
+    }
+    .so-stability__detail { color: var(--so-text-muted); }
+    .so-stability__link { margin-left: auto; color: var(--so-text-muted); text-decoration: none; font-size: 0.8rem; }
+    .so-stability__link:hover { color: var(--so-text); }
+
+    .so-flash {
+      padding: 0.75rem 1rem;
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius);
+      margin-bottom: 1rem;
+      font-size: 0.9rem;
+    }
+
+    .so-flash--notice {
+      background: var(--so-surface-muted);
+      color: var(--so-text);
+      border-left: 3px solid var(--so-info);
+    }
+
+    .so-flash--alert {
+      background: var(--so-surface-muted);
+      color: var(--so-text);
+      border-left: 3px solid var(--so-danger);
+    }
+
+    .so-btn {
+      display: inline-block;
+      padding: 0.4rem 0.75rem;
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius);
+      font-size: 0.85rem;
+      font-weight: 500;
+      text-decoration: none;
+      cursor: pointer;
+      background: var(--so-card-bg);
+      color: var(--so-text);
+    }
+
+    .so-btn:hover { background: var(--so-surface-muted); }
+    .so-btn--primary { background: var(--so-text); color: var(--so-card-bg); border-color: var(--so-text); }
+    .so-btn--primary:hover { background: #000; }
     .so-btn--danger { background: var(--so-danger); color: #fff; border-color: var(--so-danger); }
-    .so-btn--danger:hover { background: #dc2626; }
+    .so-btn--danger:hover { background: #b91c1c; }
 
     .so-pagination { display: flex; gap: 0.5rem; margin-top: 1rem; justify-content: center; }
+    .so-pagination__status { cursor: default; }
 
     .so-filters { display: flex; gap: 0.75rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
-    .so-filters select, .so-filters input { padding: 0.4rem 0.6rem; border: 1px solid var(--so-border); border-radius: 4px; font-size: 0.85rem; }
+    .so-filters select, .so-filters input {
+      padding: 0.4rem 0.6rem;
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius);
+      font-size: 0.85rem;
+      background: var(--so-card-bg);
+      color: var(--so-text);
+    }
 
     .so-empty { text-align: center; padding: 3rem 1rem; color: var(--so-text-muted); }
     .so-empty__icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .so-empty__message { font-size: 0.9rem; }
 
-    .so-usage-bar { height: 8px; background: var(--so-border); border-radius: 4px; overflow: hidden; }
-    .so-usage-bar__fill { height: 100%; border-radius: 4px; transition: width 0.3s ease; }
+    .so-usage-bar { height: 8px; background: var(--so-border); border-radius: var(--so-radius); overflow: hidden; }
+    .so-usage-bar__fill { height: 100%; border-radius: var(--so-radius); transition: width 0.3s ease; }
     .so-usage-bar__fill--ok { background: var(--so-success); }
     .so-usage-bar__fill--warning { background: var(--so-warning); }
     .so-usage-bar__fill--critical { background: var(--so-danger); }
 
     .so-back-link { margin-bottom: 1rem; }
     .so-card--spaced { margin-bottom: 1.5rem; }
-    .so-card--error { border-left: 4px solid var(--so-danger); }
+    .so-card--error { border-left: 3px solid var(--so-danger); }
     .so-card__label--danger { color: var(--so-danger); }
+    .so-card__label--success { color: var(--so-success); }
     .so-details td:first-child { width: 150px; font-weight: 600; }
-    .so-pre { margin-top: 1rem; padding: 1rem; background: #f8fafc; border-radius: 4px; overflow-x: auto; }
-    .so-pre--error { margin-top: 0.5rem; background: #fee2e2; font-size: 0.8rem; }
+    .so-pre {
+      margin-top: 1rem;
+      padding: 1rem;
+      background: var(--so-surface-muted);
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius);
+      overflow-x: auto;
+      font-size: 0.85rem;
+    }
+
+    .so-pre--error {
+      margin-top: 0.5rem;
+      background: #fef2f2;
+      border-color: #fecaca;
+      color: #7f1d1d;
+      font-size: 0.8rem;
+    }
+
     .so-actions { margin-top: 1.5rem; }
     .so-form--inline { display: inline; }
     .so-btn--disabled { opacity: 0.4; cursor: default; }
     .so-btn--static { cursor: default; }
-    .so-table--card { margin: 1rem 0; }
+    .so-table--card { margin-top: 1rem; }
+    .so-table--listing th:last-child,
+    .so-table--listing td:last-child { white-space: nowrap; }
+
+    .so-card h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
+
+    .so-card ol {
+      margin-left: 1rem;
+      color: var(--so-text-muted);
+      line-height: 1.5;
+    }
+
+    .so-card li + li { margin-top: 0.45rem; }
 
     @media (max-width: 768px) {
       .so-layout { grid-template-columns: 1fr; }
-      .so-sidebar { position: relative; padding: 0.75rem 0; }
+      .so-sidebar { position: relative; padding: 0.75rem 0; border-right: none; border-bottom: 1px solid var(--so-border); }
       .so-sidebar__logo { display: inline-block; padding: 0.5rem 1rem; }
       .so-sidebar__nav { display: flex; flex-wrap: wrap; gap: 0.25rem; padding: 0 0.75rem; }
-      .so-sidebar__nav a { padding: 0.4rem 0.75rem; border-radius: 4px; margin-right: 0; }
-      .so-sidebar__nav a.active { margin-right: 0; border-radius: 4px; }
+      .so-sidebar__nav a { padding: 0.4rem 0.75rem; margin: 0; }
       .so-sidebar__mode { display: inline-block; padding: 0.5rem 1rem; border-top: none; margin-top: 0; font-size: 0.7rem; }
       .so-content { padding: 1rem; }
       .so-stat-cards { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -5,37 +5,27 @@
   <h1>Dashboard</h1>
 </div>
 
-<% if persistence_mode? %>
-  <div class="so-card so-card--spaced" style="background: #f1f5f9; border: 1px solid var(--so-border);">
-    <p style="font-size: 0.85rem; color: var(--so-text-muted); margin: 0;">
-      <strong>Jobs tab</strong> shows currently in-flight jobs (ready, scheduled, claimed) and failed jobs awaiting retry.
-      Successfully completed jobs are not retained as execution rows by Solid Queue —
-      see <%= link_to "Events tab", events_path %> for the full historical record.
-    </p>
-  </div>
-<% end %>
-
 <% if @stats[:available] %>
   <div class="so-stat-cards">
-    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: @stats[:ready], color: "success" %>
-    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: @stats[:scheduled], color: "warning" %>
-    <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: @stats[:claimed], color: "info" %>
-    <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: @stats[:failed], color: "danger" %>
-    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: @stats[:workers], color: "info" %>
+    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: @stats[:ready] %>
+    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: @stats[:scheduled] %>
+    <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: @stats[:claimed] %>
+    <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: @stats[:failed] %>
+    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: @stats[:workers] %>
   </div>
 
   <% if persistence_mode? %>
     <div class="so-stat-cards">
-      <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "last hour", value: number_with_delimiter(@stats[:performed_last_hour]), color: "success" %>
-      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "last 24h", value: number_with_delimiter(@stats[:failed_last_24h]), color: "danger" %>
-      <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "last 5 min", value: "#{@stats[:enqueue_rate_per_min]} jobs/min", color: "info" %>
+      <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "last hour", value: number_with_delimiter(@stats[:performed_last_hour]) %>
+      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "last 24h", value: number_with_delimiter(@stats[:failed_last_24h]) %>
+      <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "last 5 min", value: "#{@stats[:enqueue_rate_per_min]} jobs/min" %>
     </div>
   <% end %>
 
   <% if @stats[:queues].any? %>
-    <div class="so-card" style="margin-bottom: 2rem;">
+    <div class="so-card so-card--section">
       <div class="so-card__label">Queue Depths</div>
-      <table class="so-table" style="margin-top: 1rem;">
+      <table class="so-table so-table--card">
         <thead>
           <tr>
             <th>Queue</th>
@@ -55,39 +45,17 @@
   <% end %>
 
   <% if persistence_mode? %>
-    <% if @recent_failures.any? %>
-      <div class="so-card" style="border-left: 4px solid var(--so-danger); margin-bottom: 2rem;">
-        <div class="so-card__label" style="color: var(--so-danger);">Recent Failures</div>
-        <table class="so-table" style="margin-top: 1rem;">
-          <thead>
-            <tr>
-              <th>Job Class</th>
-              <th>Queue</th>
-              <th>Time</th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @recent_failures.each do |event| %>
-              <tr>
-                <td><%= event.job_class %></td>
-                <td><%= event.queue_name %></td>
-                <td><%= time_ago_in_words(event.recorded_at) %> ago</td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    <% else %>
-      <div class="so-card" style="border-left: 4px solid var(--so-success); margin-bottom: 2rem;">
-        <div class="so-card__label" style="color: var(--so-success);">Recent Failures</div>
-        <div style="margin-top: 0.5rem; font-size: 0.85rem; color: var(--so-text-muted);">No recent failures.</div>
-      </div>
-    <% end %>
+    <section class="so-stability">
+      <span class="so-stability__label">Stability</span>
+      <%= stability_badge(@stats) %>
+      <span class="so-stability__detail"><%= stability_detail(@stats) %></span>
+      <%= link_to "View failures →", events_path(event_type: "job_failed"), class: "so-stability__link" %>
+    </section>
 
     <% if @recent_events.any? %>
       <div class="so-card">
         <div class="so-card__label">Recent Events</div>
-        <table class="so-table" style="margin-top: 1rem;">
+        <table class="so-table so-table--card">
           <thead>
             <tr>
               <th>Event</th>

--- a/app/views/solid_observer/errors/storage_unavailable.html.erb
+++ b/app/views/solid_observer/errors/storage_unavailable.html.erb
@@ -4,7 +4,7 @@
   <h1>SolidObserver storage is not reachable</h1>
 </div>
 
-<div class="so-card so-card--spaced so-card--error">
+<div class="so-card so-card--spaced so-card--accent-danger">
   <p class="so-card__label so-card__label--danger">
     <strong><%= @error_class %></strong>
   </p>

--- a/app/views/solid_observer/events/index.html.erb
+++ b/app/views/solid_observer/events/index.html.erb
@@ -24,7 +24,7 @@
 <% end %>
 
 <% if @events.any? %>
-  <table class="so-table">
+  <table class="so-table so-table--listing">
     <thead>
       <tr>
         <th>Event</th>

--- a/app/views/solid_observer/events/show.html.erb
+++ b/app/views/solid_observer/events/show.html.erb
@@ -40,7 +40,7 @@
 </div>
 
 <% if @metadata %>
-  <div class="so-card">
+  <div class="so-card so-card--spaced">
     <div class="so-card__label">Metadata</div>
     <pre class="so-pre"><code><%= JSON.pretty_generate(@metadata) %></code></pre>
   </div>

--- a/app/views/solid_observer/jobs/index.html.erb
+++ b/app/views/solid_observer/jobs/index.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 
 <% if @jobs.any? %>
-  <table class="so-table">
+  <table class="so-table so-table--listing">
     <thead>
       <tr>
         <th>ID</th>

--- a/app/views/solid_observer/jobs/show.html.erb
+++ b/app/views/solid_observer/jobs/show.html.erb
@@ -46,7 +46,7 @@
 </div>
 
 <% if @execution.is_a?(SolidQueue::FailedExecution) && @execution.error %>
-  <div class="so-card so-card--error">
+  <div class="so-card so-card--accent-danger">
     <div class="so-card__label so-card__label--danger">Error Details</div>
     <table class="so-table so-details so-table--card">
       <tbody>

--- a/app/views/solid_observer/shared/_empty_state.html.erb
+++ b/app/views/solid_observer/shared/_empty_state.html.erb
@@ -1,5 +1,5 @@
 <% local_assigns[:message] ||= "No data available" %>
 <div class="so-empty">
   <div class="so-empty__icon">📭</div>
-  <div><%= message %></div>
+  <div class="so-empty__message"><%= message %></div>
 </div>

--- a/app/views/solid_observer/shared/_pagination.html.erb
+++ b/app/views/solid_observer/shared/_pagination.html.erb
@@ -3,15 +3,15 @@
     <% if page > 1 %>
       <%= link_to "Previous", url_for(request.query_parameters.merge(page: page - 1)), class: "so-btn" %>
     <% else %>
-      <span class="so-btn so-btn--disabled">Previous</span>
+      <span class="so-btn so-btn--disabled" aria-disabled="true">Previous</span>
     <% end %>
 
-    <span class="so-btn so-btn--static">Page <%= page %> of <%= total_pages %></span>
+    <span class="so-btn so-btn--static so-pagination__status">Page <%= page %> of <%= total_pages %></span>
 
     <% if page < total_pages %>
       <%= link_to "Next", url_for(request.query_parameters.merge(page: page + 1)), class: "so-btn" %>
     <% else %>
-      <span class="so-btn so-btn--disabled">Next</span>
+      <span class="so-btn so-btn--disabled" aria-disabled="true">Next</span>
     <% end %>
   </div>
 <% end %>

--- a/app/views/solid_observer/shared/_stat_card.html.erb
+++ b/app/views/solid_observer/shared/_stat_card.html.erb
@@ -1,11 +1,8 @@
-<% color = local_assigns[:color] %>
 <% subtitle = local_assigns[:subtitle] %>
 <div class="so-card">
   <div class="so-card__label"><%= label %></div>
   <% if subtitle.present? %>
     <div class="so-card__subtitle"><%= subtitle %></div>
   <% end %>
-  <div class="so-card__value"<% if color %> style="color: var(--so-<%= color %>)"<% end %>>
-    <%= value || 0 %>
-  </div>
+  <div class="so-card__value"><%= value || 0 %></div>
 </div>

--- a/app/views/solid_observer/storages/show.html.erb
+++ b/app/views/solid_observer/storages/show.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <% if @storage_history.any? %>
-    <div class="so-card">
+    <div class="so-card so-card--section">
       <div class="so-card__label">Recent Snapshots</div>
       <table class="so-table so-table--card">
         <thead>

--- a/lib/solid_observer/queue_stats.rb
+++ b/lib/solid_observer/queue_stats.rb
@@ -42,9 +42,12 @@ module SolidObserver
     end
 
     def throughput_stats
+      one_hour = 1.hour
       {
-        performed_last_hour: QueueEvent.performed_count_last(1.hour),
+        performed_last_hour: QueueEvent.performed_count_last(one_hour),
         failed_last_24h: QueueEvent.failed_count_last(24.hours),
+        failed_last_hour: QueueEvent.failed_count_last(one_hour),
+        latest_failure_at: QueueEvent.recent_failures(1).first&.recorded_at,
         enqueue_rate_per_min: QueueEvent.enqueue_rate_per_minute(window: 5.minutes)
       }
     end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -33,10 +33,11 @@ RSpec.describe "Dashboard", type: :feature do
         available: true,
         performed_last_hour: 1200,
         failed_last_24h: 9,
+        failed_last_hour: 0,
+        latest_failure_at: nil,
         enqueue_rate_per_min: 4.6
       )
       allow(SolidObserver::QueueEvent).to receive(:recent).and_return([])
-      allow(SolidObserver::QueueEvent).to receive(:recent_failures).and_return([])
     end
 
     it "shows Events and Storage navigation links" do
@@ -50,11 +51,9 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("Persistence")
     end
 
-    it "shows conceptual hint and throughput cards" do
+    it "shows throughput cards" do
       visit "/solid_observer"
 
-      expect(page).to have_link("Events tab")
-      expect(page).to have_content("Jobs tab")
       expect(page).to have_content("Performed")
       expect(page).to have_content("last hour")
       expect(page).to have_content("Failed")
@@ -63,11 +62,11 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("4.6 jobs/min")
     end
 
-    it "shows reassurance when there are no recent failures" do
+    it "shows the Stability indicator with a click-through to failures" do
       visit "/solid_observer"
 
-      expect(page).to have_content("Recent Failures")
-      expect(page).to have_content("No recent failures.")
+      expect(page).to have_content("Stability")
+      expect(page).to have_link("View failures", href: "/solid_observer/events?event_type=job_failed")
     end
   end
 
@@ -98,9 +97,9 @@ RSpec.describe "Dashboard", type: :feature do
 
       visit "/solid_observer"
 
-      expect(page).not_to have_content("Jobs tab")
       expect(page).not_to have_content("Performed")
       expect(page).not_to have_content("Enqueue rate")
+      expect(page).not_to have_content("Stability")
     end
   end
 

--- a/spec/solid_observer/application_helper_spec.rb
+++ b/spec/solid_observer/application_helper_spec.rb
@@ -138,4 +138,78 @@ RSpec.describe SolidObserver::ApplicationHelper do
       end
     end
   end
+
+  describe "#stability_state" do
+    it "returns :stable when both windows are zero" do
+      expect(stability_state(failed_last_hour: 0, failed_last_24h: 0)).to eq(:stable)
+    end
+
+    it "returns :degraded when 24h has failures but last hour is clean" do
+      expect(stability_state(failed_last_hour: 0, failed_last_24h: 3)).to eq(:degraded)
+    end
+
+    it "returns :critical when there is any failure in the last hour" do
+      expect(stability_state(failed_last_hour: 1, failed_last_24h: 5)).to eq(:critical)
+    end
+
+    it "treats nil counts as zero" do
+      expect(stability_state(failed_last_hour: nil, failed_last_24h: nil)).to eq(:stable)
+    end
+  end
+
+  describe "#stability_badge" do
+    include ActionView::Helpers::UrlHelper
+
+    it "renders a green pill labelled Stable when stable" do
+      result = stability_badge(failed_last_hour: 0, failed_last_24h: 0)
+
+      expect(result).to include("so-badge--pill")
+      expect(result).to include("so-badge--success")
+      expect(result).to include("Stable")
+      expect(result).to include("<svg")
+      expect(result).to include('viewBox="0 0 6 6"')
+    end
+
+    it "renders an amber pill labelled Degraded for 24h failures only" do
+      result = stability_badge(failed_last_hour: 0, failed_last_24h: 4)
+
+      expect(result).to include("so-badge--warning")
+      expect(result).to include("Degraded")
+    end
+
+    it "renders a red pill labelled Critical when there is any failure in the last hour" do
+      result = stability_badge(failed_last_hour: 2, failed_last_24h: 9)
+
+      expect(result).to include("so-badge--danger")
+      expect(result).to include("Critical")
+    end
+  end
+
+  describe "#stability_detail" do
+    include ActionView::Helpers::DateHelper
+    include ActionView::Helpers::TextHelper
+
+    it "states the stable case explicitly" do
+      expect(stability_detail(failed_last_24h: 0, latest_failure_at: nil))
+        .to eq("No failures in the last 24h")
+    end
+
+    it "pluralises and includes latest-failure age" do
+      latest = 17.minutes.ago
+      result = stability_detail(failed_last_24h: 3, latest_failure_at: latest)
+
+      expect(result).to start_with("3 failures in the last 24h, latest ")
+      expect(result).to include("ago")
+    end
+
+    it "uses singular form for one failure" do
+      result = stability_detail(failed_last_24h: 1, latest_failure_at: 5.minutes.ago)
+      expect(result).to start_with("1 failure in the last 24h")
+    end
+
+    it "falls back to 'unknown' when latest timestamp is missing" do
+      result = stability_detail(failed_last_24h: 2, latest_failure_at: nil)
+      expect(result).to include("latest unknown")
+    end
+  end
 end

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -30,21 +30,14 @@ RSpec.describe SolidObserver::DashboardController do
       before { SolidObserver.config.storage_mode = :persistence }
 
       let(:events_scope) { double("events_scope") }
-      let(:failures_scope) { double("failures_scope") }
 
       before do
         allow(SolidObserver::QueueEvent).to receive(:recent).with(10).and_return(events_scope)
-        allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(5).and_return(failures_scope)
       end
 
       it "assigns @recent_events" do
         controller.send(:index)
         expect(controller.instance_variable_get(:@recent_events)).to eq(events_scope)
-      end
-
-      it "assigns @recent_failures" do
-        controller.send(:index)
-        expect(controller.instance_variable_get(:@recent_failures)).to eq(failures_scope)
       end
     end
 
@@ -54,11 +47,6 @@ RSpec.describe SolidObserver::DashboardController do
       it "does not assign @recent_events" do
         controller.send(:index)
         expect(controller.instance_variable_get(:@recent_events)).to be_nil
-      end
-
-      it "does not assign @recent_failures" do
-        controller.send(:index)
-        expect(controller.instance_variable_get(:@recent_failures)).to be_nil
       end
     end
   end

--- a/spec/solid_observer/queue_stats_spec.rb
+++ b/spec/solid_observer/queue_stats_spec.rb
@@ -101,7 +101,9 @@ RSpec.describe SolidObserver::QueueStats do
           SolidObserver.config.storage_mode = :persistence
           allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(1.hour).and_return(120)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
+          allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(1.hour).and_return(0)
           allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 5.minutes).and_return(14.2)
+          allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(1).and_return([])
         end
 
         it "returns snapshot with throughput statistics" do
@@ -117,6 +119,8 @@ RSpec.describe SolidObserver::QueueStats do
             available: true,
             performed_last_hour: 120,
             failed_last_24h: 7,
+            failed_last_hour: 0,
+            latest_failure_at: nil,
             enqueue_rate_per_min: 14.2
           )
         end
@@ -131,6 +135,7 @@ RSpec.describe SolidObserver::QueueStats do
           expect(SolidObserver::QueueEvent).not_to receive(:performed_count_last)
           expect(SolidObserver::QueueEvent).not_to receive(:failed_count_last)
           expect(SolidObserver::QueueEvent).not_to receive(:enqueue_rate_per_minute)
+          expect(SolidObserver::QueueEvent).not_to receive(:recent_failures)
 
           result = queue_stats.snapshot
 


### PR DESCRIPTION
## Summary of the changes
- Engine-wide minimalist UI refresh: light surfaces, near-black text, hairline separators, restrained semantic accents (badges/state only — no card tints, no shadows, no coloured value digits).
- New Dashboard **Stability** indicator: single-line pill badge with three states (Stable / Degraded / Critical) replacing the multi-line Recent Failures card. Click-through to events filtered by `job_failed`.
- Removed the "Jobs tab / Events tab" orientation banner — discoverable via navigation; dashboard reserved for signal.
- `QueueStats#throughput_stats` extended with `failed_last_hour` and `latest_failure_at` to drive the indicator.