### PR TITLE
[SO-059][FEAT] Time-Range scoped dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 ### Added
 - Web UI dashboard at `/solid_observer` — queue stats, jobs browser, events log, storage info; auto-refresh, responsive layout, optional HTTP Basic Auth
 - Web UI config: `ui_enabled`, `ui_username`, `ui_password`, `ui_base_controller`, `ui_refresh_interval`
+- Dashboard now supports a Time-Range selector (`15m`, `30m`, `1h`, `7h`, `1d`, `7d`, `14d`, default `1h`) that scopes the new "Last <range>" card region (Performed / Failed / Enqueue rate). The "Right Now" region (Ready / Scheduled / Claimed / Failed-awaiting-retry / Workers) is unaffected by the range and reflects current SolidQueue state.
 - Retry / discard actions with confirmation dialogs and CSRF protection
 - `QueueEventBuffer#metrics` and `#shutdown` (graceful drain on app exit)
 - Configuration: `max_buffer_size` (default 10_000), `buffer_overflow_strategy` (`:drop_old` / `:drop_new`), `filter_cache_ttl`
@@ -40,6 +41,7 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - Web UI controllers refactored to thin actions + query/param/presenter objects; Rails built-in number helpers replace custom ones
 - Specs: `allow_any_instance_of` → `instance_double`; sleep-based timer specs use deterministic synchronisation; dead private-method `describe` blocks removed
 - `.reek.yml` suppressions trimmed; hot-path services/buffer/engine methods refactored to pass `TooManyStatements` without new suppressions
+- The legacy implicit dashboard auto-refresh (driven by `SolidObserver.config.ui_refresh_interval`) is no longer enabled on the dashboard view. Explicit Live Mode replaces it in SO-060 within the same release.
 - Jobs tab default filter changed from `status=ready` to `status=all_active` (ready + scheduled + claimed + failed).
 - Duration values on the Events index and detail pages now use per-event-type semantic context via `<abbr title="...">` tooltips so operators can distinguish enqueue call latency (`job_enqueued`) from perform-time duration (`job_completed` / `job_failed` / `job_discarded`).
 - Refreshed the engine UI to a minimalist visual language: light surfaces, near-black text, restrained semantic colour accents reserved for badges/state, hairline separators, consistent rounding. Sidebar moves from dark slate to a light surface. No external CSS dependencies, no JS, no dark mode (single light theme).

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -3,9 +3,25 @@
 module SolidObserver
   class DashboardController < ApplicationController
     def index
-      @stats = QueueStats.snapshot
+      assign_range_and_stats
+      load_persistence_data if persistence_mode?
+    end
 
-      @recent_events = QueueEvent.recent(10) if persistence_mode?
+    private
+
+    def assign_range_and_stats
+      range = QueueStats.parse_range(request_range_param)
+      @range = range
+      @stats = QueueStats.snapshot(range: range)
+    end
+
+    def load_persistence_data
+      @recent_events = QueueEvent.recent(10)
+      @recent_failures = QueueEvent.recent_failures(5)
+    end
+
+    def request_range_param
+      request&.query_parameters&.[]("range") || request&.query_parameters&.[](:range)
     end
   end
 end

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -56,6 +56,15 @@ module SolidObserver
       content_tag(:span, config.storage_mode.to_s.capitalize, class: "so-badge so-badge--#{color}")
     end
 
+    def turbo_frame_tag(id, **options, &block)
+      return super if defined?(super)
+
+      content = options.delete(:content)
+      body = block_given? ? capture(&block) : content
+
+      content_tag(:"turbo-frame", body, **options.merge(id: id).compact)
+    end
+
     def stability_state(stats)
       return :critical if stats[:failed_last_hour].to_i.positive?
       return :degraded if stats[:failed_last_24h].to_i.positive?

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -105,6 +105,15 @@
     .so-content__header h1 { font-size: 1.375rem; font-weight: 500; }
 
     .so-stat-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
+    .so-cards-section { margin-bottom: 2rem; }
+    .so-cards-section__title {
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--so-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-bottom: 0.75rem;
+    }
     .so-card {
       background: var(--so-card-bg);
       border: 1px solid var(--so-border);
@@ -257,6 +266,7 @@
     .so-pagination__status { cursor: default; }
 
     .so-filters { display: flex; gap: 0.75rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
+    .so-filters__label { align-self: center; }
     .so-filters select, .so-filters input {
       padding: 0.4rem 0.6rem;
       border: 1px solid var(--so-border);

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -1,25 +1,44 @@
-<% content_for :auto_refresh, true %>
 <% content_for :title, "Dashboard" %>
 
 <div class="so-content__header">
   <h1>Dashboard</h1>
 </div>
 
+<form method="get" action="<%= root_path %>" class="so-filters" data-turbo-frame="_top">
+  <label for="so-range" class="so-card__label so-filters__label">Range</label>
+  <select id="so-range" name="range" onchange="this.form.requestSubmit()">
+    <% SolidObserver::QueueStats::RANGES.each_key do |key| %>
+      <option value="<%= key %>" <%= "selected" if key == @range %>><%= key %></option>
+    <% end %>
+  </select>
+  <noscript><button type="submit" class="so-btn">Apply</button></noscript>
+</form>
+
 <% if @stats[:available] %>
-  <div class="so-stat-cards">
-    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: @stats[:ready] %>
-    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: @stats[:scheduled] %>
-    <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: @stats[:claimed] %>
-    <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: @stats[:failed] %>
-    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: @stats[:workers] %>
-  </div>
+  <%= turbo_frame_tag "so_right_now" do %>
+    <section class="so-cards-section">
+      <h2 class="so-cards-section__title">Right Now</h2>
+      <div class="so-stat-cards">
+        <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: @stats[:ready] %>
+        <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: @stats[:scheduled] %>
+        <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: @stats[:claimed] %>
+        <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: @stats[:workers] %>
+        <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: @stats[:failed] %>
+      </div>
+    </section>
+  <% end %>
 
   <% if persistence_mode? %>
-    <div class="so-stat-cards">
-      <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "last hour", value: number_with_delimiter(@stats[:performed_last_hour]) %>
-      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "last 24h", value: number_with_delimiter(@stats[:failed_last_24h]) %>
-      <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "last 5 min", value: "#{@stats[:enqueue_rate_per_min]} jobs/min" %>
-    </div>
+    <%= turbo_frame_tag "so_scoped" do %>
+      <section class="so-cards-section">
+        <h2 class="so-cards-section__title">Last <%= @range %></h2>
+        <div class="so-stat-cards">
+          <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "in range", value: number_with_delimiter(@stats[:performed_in_range]) %>
+          <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "in range", value: number_with_delimiter(@stats[:failed_in_range]) %>
+          <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "per min", value: "#{@stats[:enqueue_rate_per_min]} jobs/min" %>
+        </div>
+      </section>
+    <% end %>
   <% end %>
 
   <% if @stats[:queues].any? %>

--- a/lib/solid_observer/queue_stats.rb
+++ b/lib/solid_observer/queue_stats.rb
@@ -2,31 +2,52 @@
 
 module SolidObserver
   class QueueStats
+    RANGES = {
+      "15m" => 15.minutes,
+      "30m" => 30.minutes,
+      "1h" => 1.hour,
+      "7h" => 7.hours,
+      "1d" => 1.day,
+      "7d" => 7.days,
+      "14d" => 14.days
+    }.freeze
+    DEFAULT_RANGE = "1h"
+
     class << self
-      def snapshot
-        new.snapshot
+      def snapshot(range: DEFAULT_RANGE)
+        new.snapshot(range)
       end
 
       def solid_queue_available?
         !!(defined?(SolidQueue) && defined?(SolidQueue::Job))
       end
+
+      def parse_range(value)
+        range_key = value.to_s
+        RANGES.key?(range_key) ? range_key : DEFAULT_RANGE
+      end
+
+      def range_duration(value)
+        RANGES.fetch(parse_range(value))
+      end
     end
 
-    def snapshot
-      return unavailable_response unless self.class.solid_queue_available?
+    def snapshot(range = DEFAULT_RANGE)
+      klass = self.class
+      return error_response("SolidQueue not available") unless klass.solid_queue_available?
 
-      snapshot_for_mode
+      snapshot_for_mode(klass.parse_range(range))
     rescue => e
-      error_response(e)
+      error_response(e.message)
     end
 
     private
 
-    def snapshot_for_mode
+    def snapshot_for_mode(range_key)
       base = snapshot_base
       return base unless SolidObserver.config.persistence_mode?
 
-      base.merge(throughput_stats)
+      base.merge(throughput_stats(range_key)).merge(range: range_key)
     end
 
     def snapshot_base
@@ -41,18 +62,20 @@ module SolidObserver
       }
     end
 
-    def throughput_stats
-      one_hour = 1.hour
+    def throughput_stats(range_key)
+      duration = self.class.range_duration(range_key)
       {
-        performed_last_hour: QueueEvent.performed_count_last(one_hour),
+        performed_in_range: QueueEvent.performed_count_last(duration),
+        failed_in_range: QueueEvent.failed_count_last(duration),
+        # Stability indicator still uses dedicated rolling windows independent of selected range.
         failed_last_24h: QueueEvent.failed_count_last(24.hours),
-        failed_last_hour: QueueEvent.failed_count_last(one_hour),
+        failed_last_hour: QueueEvent.failed_count_last(1.hour),
         latest_failure_at: QueueEvent.recent_failures(1).first&.recorded_at,
-        enqueue_rate_per_min: QueueEvent.enqueue_rate_per_minute(window: 5.minutes)
+        enqueue_rate_per_min: QueueEvent.enqueue_rate_per_minute(window: duration)
       }
     end
 
-    def unavailable_response
+    def error_response(message)
       {
         ready: 0,
         scheduled: 0,
@@ -61,20 +84,8 @@ module SolidObserver
         workers: 0,
         queues: {},
         available: false,
-        error: "SolidQueue not available"
-      }
-    end
-
-    def error_response(exception)
-      {
-        ready: 0,
-        scheduled: 0,
-        claimed: 0,
-        failed: 0,
-        workers: 0,
-        queues: {},
-        available: false,
-        error: exception.message
+        range: DEFAULT_RANGE,
+        error: message
       }
     end
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -31,13 +31,16 @@ RSpec.describe "Dashboard", type: :feature do
         workers: 3,
         queues: {},
         available: true,
-        performed_last_hour: 1200,
+        range: "1h",
+        performed_in_range: 1200,
+        failed_in_range: 9,
         failed_last_24h: 9,
         failed_last_hour: 0,
         latest_failure_at: nil,
         enqueue_rate_per_min: 4.6
       )
       allow(SolidObserver::QueueEvent).to receive(:recent).and_return([])
+      allow(SolidObserver::QueueEvent).to receive(:recent_failures).and_return([])
     end
 
     it "shows Events and Storage navigation links" do
@@ -54,12 +57,33 @@ RSpec.describe "Dashboard", type: :feature do
     it "shows throughput cards" do
       visit "/solid_observer"
 
+      expect(page).to have_content("Last 1h")
       expect(page).to have_content("Performed")
-      expect(page).to have_content("last hour")
       expect(page).to have_content("Failed")
-      expect(page).to have_content("last 24h")
+      expect(page).to have_content("in range")
       expect(page).to have_content("Enqueue rate")
       expect(page).to have_content("4.6 jobs/min")
+    end
+
+    it "renders both dashboard turbo frames" do
+      visit "/solid_observer"
+
+      expect(page).to have_css("turbo-frame#so_right_now")
+      expect(page).to have_css("turbo-frame#so_scoped")
+    end
+
+    it "keeps selected range for a valid range param" do
+      visit "/solid_observer?range=15m"
+
+      expect(page).to have_select("Range", selected: "15m")
+      expect(page).to have_content("Last 15m")
+    end
+
+    it "falls back selected range for an invalid range param" do
+      visit "/solid_observer?range=bogus"
+
+      expect(page).to have_select("Range", selected: "1h")
+      expect(page).to have_content("Last 1h")
     end
 
     it "shows the Stability indicator with a click-through to failures" do
@@ -92,7 +116,8 @@ RSpec.describe "Dashboard", type: :feature do
         failed: 0,
         workers: 1,
         queues: {},
-        available: true
+        available: true,
+        range: "15m"
       )
 
       visit "/solid_observer"
@@ -100,6 +125,25 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).not_to have_content("Performed")
       expect(page).not_to have_content("Enqueue rate")
       expect(page).not_to have_content("Stability")
+    end
+
+    it "renders only the right-now turbo frame" do
+      allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
+        ready: 1,
+        scheduled: 0,
+        claimed: 0,
+        failed: 0,
+        workers: 1,
+        queues: {},
+        available: true,
+        range: "15m"
+      )
+
+      visit "/solid_observer?range=15m"
+
+      expect(page).to have_css("turbo-frame#so_right_now")
+      expect(page).not_to have_css("turbo-frame#so_scoped")
+      expect(page).to have_select("Range", selected: "15m")
     end
   end
 

--- a/spec/solid_observer/application_helper_spec.rb
+++ b/spec/solid_observer/application_helper_spec.rb
@@ -139,6 +139,26 @@ RSpec.describe SolidObserver::ApplicationHelper do
     end
   end
 
+  describe "#turbo_frame_tag" do
+    it "renders a turbo frame with block content" do
+      result = turbo_frame_tag("so_right_now") { "Right now content" }
+
+      expect(result).to include("<turbo-frame")
+      expect(result).to include('id="so_right_now"')
+      expect(result).to include("Right now content")
+      expect(result).to include("</turbo-frame>")
+    end
+
+    it "renders a turbo frame with src in non-block form" do
+      result = turbo_frame_tag("so_lazy", src: "/solid_observer/scoped")
+
+      expect(result).to include("<turbo-frame")
+      expect(result).to include('id="so_lazy"')
+      expect(result).to include('src="/solid_observer/scoped"')
+      expect(result).to include("</turbo-frame>")
+    end
+  end
+
   describe "#stability_state" do
     it "returns :stable when both windows are zero" do
       expect(stability_state(failed_last_hour: 0, failed_last_24h: 0)).to eq(:stable)

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -14,39 +14,126 @@ RSpec.describe SolidObserver::DashboardController do
   end
 
   describe "#index" do
-    let(:stats) { {ready: 3, scheduled: 1, claimed: 0, failed: 2, workers: 1, queues: {}, available: true} }
+    let(:params_hash) { {} }
+    let(:stats) do
+      {
+        ready: 3,
+        scheduled: 1,
+        claimed: 0,
+        failed: 2,
+        workers: 1,
+        queues: {},
+        available: true,
+        range: "1h"
+      }
+    end
+    let(:request_double) do
+      instance_double(
+        ActionDispatch::Request,
+        query_parameters: params_hash.transform_keys(&:to_s)
+      )
+    end
 
     before do
+      allow(controller).to receive(:request).and_return(request_double)
       allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
     end
 
-    it "assigns @stats from QueueStats.snapshot" do
+    it "assigns @stats from QueueStats.snapshot and exposes available ranges" do
       SolidObserver.config.storage_mode = :realtime
-      controller.send(:index)
+      controller.index
+
+      expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "1h")
       expect(controller.instance_variable_get(:@stats)).to eq(stats)
+      expect(controller.instance_variable_get(:@range)).to eq("1h")
+    end
+
+    describe "GET #index with range param" do
+      context "with a valid range" do
+        let(:params_hash) { {range: "15m"} }
+        let(:stats) { super().merge(range: "15m") }
+
+        it "uses the provided range" do
+          SolidObserver.config.storage_mode = :realtime
+          controller.index
+
+          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "15m")
+          expect(controller.instance_variable_get(:@range)).to eq("15m")
+          expect(controller.instance_variable_get(:@stats)[:range]).to eq("15m")
+        end
+      end
+
+      context "with an invalid range" do
+        let(:params_hash) { {range: "999d"} }
+
+        it "falls back to the default range" do
+          SolidObserver.config.storage_mode = :realtime
+          controller.index
+
+          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "1h")
+          expect(controller.instance_variable_get(:@range)).to eq("1h")
+          expect(controller.instance_variable_get(:@stats)[:range]).to eq("1h")
+        end
+      end
+
+      context "with no range" do
+        it "falls back to the default range" do
+          SolidObserver.config.storage_mode = :realtime
+          controller.index
+
+          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "1h")
+          expect(controller.instance_variable_get(:@range)).to eq("1h")
+          expect(controller.instance_variable_get(:@stats)[:range]).to eq("1h")
+        end
+      end
     end
 
     context "in persistence mode" do
       before { SolidObserver.config.storage_mode = :persistence }
 
       let(:events_scope) { double("events_scope") }
+      let(:failures_scope) { double("failures_scope") }
+      let(:stats) do
+        super().merge(
+          performed_in_range: 22,
+          failed_in_range: 4,
+          enqueue_rate_per_min: 1.8
+        )
+      end
 
       before do
         allow(SolidObserver::QueueEvent).to receive(:recent).with(10).and_return(events_scope)
+        allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(5).and_return(failures_scope)
       end
 
-      it "assigns @recent_events" do
-        controller.send(:index)
+      it "assigns persistence-only data and scoped stats" do
+        controller.index
+
         expect(controller.instance_variable_get(:@recent_events)).to eq(events_scope)
+        expect(controller.instance_variable_get(:@recent_failures)).to eq(failures_scope)
+        expect(controller.instance_variable_get(:@stats)).to include(
+          :performed_in_range,
+          :failed_in_range,
+          :enqueue_rate_per_min
+        )
       end
     end
 
     context "in realtime mode" do
       before { SolidObserver.config.storage_mode = :realtime }
 
-      it "does not assign @recent_events" do
-        controller.send(:index)
+      let(:stats) { super().except(:performed_in_range, :failed_in_range, :enqueue_rate_per_min) }
+
+      it "does not assign persistence-only data or scoped keys" do
+        controller.index
+
         expect(controller.instance_variable_get(:@recent_events)).to be_nil
+        expect(controller.instance_variable_get(:@recent_failures)).to be_nil
+        expect(controller.instance_variable_get(:@stats)).not_to include(
+          :performed_in_range,
+          :failed_in_range,
+          :enqueue_rate_per_min
+        )
       end
     end
   end

--- a/spec/solid_observer/queue_stats_spec.rb
+++ b/spec/solid_observer/queue_stats_spec.rb
@@ -37,7 +37,27 @@ RSpec.describe SolidObserver::QueueStats do
       instance = instance_double(described_class, snapshot: {ready: 0})
       allow(described_class).to receive(:new).and_return(instance)
 
-      expect(described_class.snapshot).to eq({ready: 0})
+      expect(described_class.snapshot(range: "15m")).to eq({ready: 0})
+      expect(instance).to have_received(:snapshot).with("15m")
+    end
+  end
+
+  describe ".parse_range" do
+    it "returns allowlisted range keys unchanged" do
+      described_class::RANGES.keys.each do |range_key|
+        expect(described_class.parse_range(range_key)).to eq(range_key)
+      end
+    end
+
+    it "falls back to the default for unknown values" do
+      expect(described_class.parse_range("999d")).to eq("1h")
+      expect(described_class.parse_range(nil)).to eq("1h")
+    end
+  end
+
+  describe ".range_duration" do
+    it "returns configured duration for known keys" do
+      expect(described_class.range_duration("15m")).to eq(15.minutes)
     end
   end
 
@@ -60,6 +80,7 @@ RSpec.describe SolidObserver::QueueStats do
           workers: 0,
           queues: {},
           available: false,
+          range: "1h",
           error: "SolidQueue not available"
         )
       end
@@ -100,13 +121,16 @@ RSpec.describe SolidObserver::QueueStats do
         before do
           SolidObserver.config.storage_mode = :persistence
           allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(1.hour).and_return(120)
-          allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
+          allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(15.minutes).and_return(34)
+          allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(15.minutes).and_return(2)
+          allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 15.minutes).and_return(9.1)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(1.hour).and_return(0)
-          allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 5.minutes).and_return(14.2)
+          allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
+          allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 1.hour).and_return(14.2)
           allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(1).and_return([])
         end
 
-        it "returns snapshot with throughput statistics" do
+        it "returns snapshot with throughput statistics for the default range" do
           result = queue_stats.snapshot
 
           expect(result).to eq(
@@ -117,12 +141,28 @@ RSpec.describe SolidObserver::QueueStats do
             workers: 4,
             queues: {"default" => 8, "mailers" => 2},
             available: true,
-            performed_last_hour: 120,
+            performed_in_range: 120,
+            failed_in_range: 0,
             failed_last_24h: 7,
             failed_last_hour: 0,
             latest_failure_at: nil,
-            enqueue_rate_per_min: 14.2
+            enqueue_rate_per_min: 14.2,
+            range: "1h"
           )
+        end
+
+        it "uses a requested range window for scoped throughput values" do
+          result = queue_stats.snapshot("15m")
+
+          expect(result).to include(
+            performed_in_range: 34,
+            failed_in_range: 2,
+            enqueue_rate_per_min: 9.1,
+            range: "15m"
+          )
+          expect(SolidObserver::QueueEvent).to have_received(:performed_count_last).with(15.minutes)
+          expect(SolidObserver::QueueEvent).to have_received(:failed_count_last).with(15.minutes)
+          expect(SolidObserver::QueueEvent).to have_received(:enqueue_rate_per_minute).with(window: 15.minutes)
         end
       end
 
@@ -202,6 +242,7 @@ RSpec.describe SolidObserver::QueueStats do
           workers: 0,
           queues: {},
           available: false,
+          range: "1h",
           error: "Database connection failed"
         )
       end


### PR DESCRIPTION
## Summary
- Splits the dashboard into "Right Now" (point-in-time SolidQueue counts) and "Last <range>" (QueueEvent aggregates) regions, each wrapped in its own `turbo_frame_tag` to seam SO-060 Live Mode.
- Adds a range selector at the top of the dashboard with allowlist `15m / 30m / 1h / 7h / 1d / 7d / 14d` (default `1h`); invalid input falls back to default with no exception.
- Disables the legacy implicit dashboard auto-refresh driven by `ui_refresh_interval`; SO-060 lands the explicit Live Mode replacement in the same release.