### PR TITLE
[SO-063][FEAT] Frontend rewrite: JSON polling + sparkline rendering

### DIFF
--- a/app/assets/javascripts/solid_observer/live_poll.js
+++ b/app/assets/javascripts/solid_observer/live_poll.js
@@ -1,60 +1,66 @@
 (function () {
   "use strict";
 
-  function init(root) {
-    var wrapper = root.querySelector("[data-so-live]");
+  var MAX_POINTS = 60;
+  var SVG_W = 120,
+    SVG_H = 32;
+
+  function init() {
+    var wrapper = document.querySelector("[data-so-live]");
     if (!wrapper) return;
 
-    var intervalSec = parseInt(wrapper.getAttribute("data-so-live-interval"), 10);
-    var frameId = wrapper.getAttribute("data-so-live-frame");
-    if (!intervalSec || !frameId || intervalSec <= 0) return;
+    var intervalSec = parseInt(
+      wrapper.getAttribute("data-so-live-interval"),
+      10,
+    );
+    if (!intervalSec || intervalSec <= 0) return;
 
     var checkbox = wrapper.querySelector("input[type=checkbox][name=live]");
     if (!checkbox) return;
 
-    var timerId = null;
-    var inFlight = false;
+    var sparks = collectSparks();
+    var url = "/solid_observer/poll_data";
+    var inFlight = false,
+      timerId = null;
 
-    function swapFrameContent(frame, html) {
-      var doc = new DOMParser().parseFromString(html, "text/html");
-      var freshFrame = doc.querySelector("turbo-frame#" + frameId);
-      if (!freshFrame) return;
-
-      frame.replaceChildren();
-      while (freshFrame.firstChild) {
-        frame.appendChild(freshFrame.firstChild);
-      }
-    }
-
-    function poll() {
+    function tick() {
       if (inFlight) return;
-
-      var frame = document.getElementById(frameId);
-      if (!frame) return;
-
-      var src = frame.getAttribute("src");
-      if (!src) return;
-
       inFlight = true;
-      fetch(src, {headers: {Accept: "text/html"}, credentials: "same-origin"})
-        .then(function (response) {
-          if (!response.ok) return null;
-          return response.text();
+      var rangeParam = readRangeFromUrl();
+      fetch(
+        url + (rangeParam ? "?range=" + encodeURIComponent(rangeParam) : ""),
+        { headers: { Accept: "application/json" }, credentials: "same-origin" },
+      )
+        .then(function (r) {
+          return r.ok ? r.json() : null;
         })
-        .then(function (html) {
-          if (!html) return;
-          swapFrameContent(frame, html);
+        .then(function (data) {
+          if (data) applyUpdate(data);
         })
         .catch(function () {
+          /* drop tick silently */
         })
         .finally(function () {
           inFlight = false;
         });
     }
 
+    function applyUpdate(data) {
+      var snapshot = data.snapshot || {};
+      Object.keys(snapshot).forEach(function (key) {
+        var el = document.querySelector('[data-so-card-value="' + key + '"]');
+        if (el) el.textContent = formatValue(snapshot[key]);
+      });
+      var chart = data.chart || {};
+      Object.keys(sparks).forEach(function (key) {
+        var series = chart[key];
+        if (Array.isArray(series)) sparks[key].render(series);
+      });
+    }
+
     function start() {
       stop();
-      timerId = window.setInterval(poll, intervalSec * 1000);
+      timerId = window.setInterval(tick, intervalSec * 1000);
     }
 
     function stop() {
@@ -89,11 +95,58 @@
     window.addEventListener("beforeunload", stop);
   }
 
+  function collectSparks() {
+    var sparks = {};
+    var figures = document.querySelectorAll("[data-so-spark]");
+    for (var i = 0; i < figures.length; i++) {
+      var key = figures[i].getAttribute("data-so-spark");
+      sparks[key] = new Sparkline(figures[i]);
+    }
+    return sparks;
+  }
+
+  function Sparkline(figureEl) {
+    this.line = figureEl.querySelector(".so-spark__line");
+    this.valueEl = figureEl.querySelector("[data-so-spark-value]");
+  }
+
+  Sparkline.prototype.render = function (series) {
+    if (!this.line || !series.length) return;
+    var tMin = series[0].t,
+      tMax = series[series.length - 1].t;
+    var vMax = 1;
+    for (var i = 0; i < series.length; i++) {
+      if (series[i].v > vMax) vMax = series[i].v;
+    }
+    var points = [];
+    for (var i = 0; i < series.length; i++) {
+      var x =
+        tMin === tMax
+          ? SVG_W / 2
+          : ((series[i].t - tMin) / (tMax - tMin)) * (SVG_W - 2) + 1;
+      var y = SVG_H - 1 - (series[i].v / vMax) * (SVG_H - 2);
+      points.push(x.toFixed(1) + "," + y.toFixed(1));
+    }
+    this.line.setAttribute("points", points.join(" "));
+    if (this.valueEl) {
+      this.valueEl.textContent = formatValue(series[series.length - 1].v);
+    }
+  };
+
+  function formatValue(v) {
+    if (v === null || v === undefined) return "\u2014";
+    if (Number.isInteger(v))
+      return v.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return parseFloat(v).toFixed(1);
+  }
+
+  function readRangeFromUrl() {
+    return new URL(window.location.href).searchParams.get("range");
+  }
+
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", function () {
-      init(document);
-    });
+    document.addEventListener("DOMContentLoaded", init);
   } else {
-    init(document);
+    init();
   }
 })();

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -102,6 +102,14 @@
     .so-content__header h1 { font-size: 1.375rem; font-weight: 500; }
 
     .so-stat-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
+    .so-chart-strip { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+    .so-chart-strip:has(> .so-spark:only-child) { grid-template-columns: minmax(0, 340px); }
+    .so-spark { display: flex; flex-direction: column; gap: 0.25rem; padding: 0.75rem; border: 1px solid var(--so-border); border-radius: var(--so-radius); background: var(--so-card-bg); color: var(--so-text-muted); }
+    .so-spark__svg { width: 100%; height: 32px; }
+    .so-spark__baseline { stroke: var(--so-border); }
+    .so-spark__line { fill: none; stroke: currentColor; stroke-width: 1.25; stroke-linejoin: round; stroke-linecap: round; }
+    .so-spark__label { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; }
+    .so-spark__value { font-size: 0.95rem; font-weight: 600; color: var(--so-text); align-self: flex-end; }
     .so-cards-section { margin-bottom: 2rem; }
     .so-cards-section__title {
       font-size: 0.75rem;

--- a/app/views/solid_observer/dashboard/_chart.html.erb
+++ b/app/views/solid_observer/dashboard/_chart.html.erb
@@ -1,0 +1,28 @@
+<div class="so-chart-strip" data-so-chart>
+  <% if SolidObserver.config.persistence_mode? %>
+    <figure class="so-spark" data-so-spark="performed">
+      <figcaption class="so-spark__label">Performed/min</figcaption>
+      <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+        <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+        <polyline class="so-spark__line" points=""/>
+      </svg>
+      <span class="so-spark__value" data-so-spark-value>—</span>
+    </figure>
+    <figure class="so-spark" data-so-spark="failed">
+      <figcaption class="so-spark__label">Failed/min</figcaption>
+      <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+        <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+        <polyline class="so-spark__line" points=""/>
+      </svg>
+      <span class="so-spark__value" data-so-spark-value>—</span>
+    </figure>
+  <% end %>
+  <figure class="so-spark" data-so-spark="ready">
+    <figcaption class="so-spark__label">Ready depth</figcaption>
+    <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+      <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+      <polyline class="so-spark__line" points=""/>
+    </svg>
+    <span class="so-spark__value" data-so-spark-value>—</span>
+  </figure>
+</div>

--- a/app/views/solid_observer/dashboard/_right_now.html.erb
+++ b/app/views/solid_observer/dashboard/_right_now.html.erb
@@ -2,11 +2,11 @@
   <section class="so-cards-section">
     <h2 class="so-cards-section__title">Right Now</h2>
     <div class="so-stat-cards">
-      <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: stats[:ready] %>
-      <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: stats[:scheduled] %>
-      <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: stats[:claimed] %>
-      <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: stats[:workers] %>
-      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: stats[:failed] %>
+      <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: stats[:ready], data_key: "ready" %>
+      <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: stats[:scheduled], data_key: "scheduled" %>
+      <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: stats[:claimed], data_key: "claimed" %>
+      <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: stats[:workers], data_key: "workers" %>
+      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: stats[:failed], data_key: "failed" %>
     </div>
   </section>
 <% else %>

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -22,6 +22,10 @@
   <noscript><button type="submit" class="so-btn">Apply</button></noscript>
 </form>
 
+<% if @stats[:available] %>
+  <%= render "chart" %>
+<% end %>
+
 <%= turbo_frame_tag "so_right_now", src: right_now_path do %>
   <%= render "right_now", stats: @stats %>
 <% end %>
@@ -33,7 +37,7 @@
       <div class="so-stat-cards">
         <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "in range", value: number_with_delimiter(@stats[:performed_in_range]) %>
         <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "in range", value: number_with_delimiter(@stats[:failed_in_range]) %>
-        <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "per min", value: "#{@stats[:enqueue_rate_per_min]} jobs/min" %>
+        <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "jobs/min", value: @stats[:enqueue_rate_per_min], data_key: "enqueue_rate_per_min" %>
       </div>
     </section>
   <% end %>

--- a/app/views/solid_observer/shared/_stat_card.html.erb
+++ b/app/views/solid_observer/shared/_stat_card.html.erb
@@ -1,8 +1,9 @@
 <% subtitle = local_assigns[:subtitle] %>
+<% data_key = local_assigns[:data_key] %>
 <div class="so-card">
   <div class="so-card__label"><%= label %></div>
   <% if subtitle.present? %>
     <div class="so-card__subtitle"><%= subtitle %></div>
   <% end %>
-  <div class="so-card__value"><%= value || 0 %></div>
+  <div class="so-card__value"<%= data_key ? " data-so-card-value=\"#{data_key}\"".html_safe : "".html_safe %>><%= value || 0 %></div>
 </div>

--- a/bin/quality_gate
+++ b/bin/quality_gate
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SolidObserver Quality Gate Suite
+# Runs all non-negotiable gates in sequence.
+# Usage: bin/quality_gate [--skip-appraisal]
+#
+# Individual gates can be run via:
+#   bin/quality_gate rspec
+#   bin/quality_gate standardrb
+#   bin/quality_gate reek
+#   bin/quality_gate appraisal
+#   bin/quality_gate audit
+
+SKIP_APPRAISAL=false
+SINGLE_GATE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --skip-appraisal) SKIP_APPRAISAL=true ;;
+    rspec|standardrb|reek|appraisal|audit) SINGLE_GATE="$arg" ;;
+  esac
+done
+
+red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+
+run_gate() {
+  local label="$1"; shift
+  dim "⏳ ${label}..."
+  if "$@" > /dev/null 2>&1; then
+    green "✅ ${label}"
+    return 0
+  else
+    red "❌ ${label} FAILED — check output above"
+    return 1
+  fi
+}
+
+gate_rspec() {
+  run_gate "RSpec" bundle exec rspec
+}
+
+gate_standardrb() {
+  run_gate "StandardRB" bundle exec standardrb
+}
+
+gate_reek() {
+  run_gate "Reek" bundle exec reek lib/ app/ db/
+}
+
+gate_appraisal() {
+  run_gate "Rails 8.0 appraisal" bundle exec appraisal rails-8.0 rspec \
+    && run_gate "Rails 8.1 appraisal" bundle exec appraisal rails-8.1 rspec
+}
+
+gate_audit() {
+  dim "⏳ bundler-audit: updating advisory DB..."
+  bundle exec bundler-audit update > /dev/null 2>&1 || true
+  run_gate "bundler-audit" bundle exec bundler-audit check
+}
+
+run_all() {
+  local failed=0
+
+  gate_rspec      || failed=$((failed + 1))
+  gate_standardrb || failed=$((failed + 1))
+  gate_reek       || failed=$((failed + 1))
+
+  if [ "$SKIP_APPRAISAL" = false ]; then
+    gate_appraisal || failed=$((failed + 1))
+  else
+    dim "⏭️  Skipping appraisal (--skip-appraisal)"
+  fi
+
+  gate_audit      || failed=$((failed + 1))
+
+  echo ""
+  if [ "$failed" -eq 0 ]; then
+    green "All quality gates passed"
+  else
+    red "${failed} gate(s) failed"
+    return 1
+  fi
+}
+
+case "$SINGLE_GATE" in
+  rspec)      gate_rspec ;;
+  standardrb) gate_standardrb ;;
+  reek)       gate_reek ;;
+  appraisal)  gate_appraisal ;;
+  audit)      gate_audit ;;
+  "")         run_all ;;
+esac

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("Failed")
       expect(page).to have_content("in range")
       expect(page).to have_content("Enqueue rate")
-      expect(page).to have_content("4.6 jobs/min")
+      expect(page).to have_css('[data-so-card-value="enqueue_rate_per_min"]', text: "4.6")
+      expect(page).to have_content("jobs/min")
     end
 
     it "renders both dashboard turbo frames" do
@@ -108,6 +109,42 @@ RSpec.describe "Dashboard", type: :feature do
 
       expect(page).to have_css('form[data-so-live][data-so-live-frame="so_right_now"][data-so-live-interval="5"]')
       expect(page).to have_css('input[type="checkbox"][name="live"][value="on"][checked]')
+    end
+
+    it "renders the chart strip with three sparkline figures" do
+      visit "/solid_observer"
+
+      expect(page).to have_css('[data-so-spark="performed"]')
+      expect(page).to have_css('[data-so-spark="failed"]')
+      expect(page).to have_css('[data-so-spark="ready"]')
+    end
+
+    it "renders each sparkline figure with baseline and polyline" do
+      visit "/solid_observer"
+
+      within('[data-so-spark="performed"]') do
+        expect(page).to have_css(".so-spark__baseline")
+        expect(page).to have_css(".so-spark__line")
+      end
+      within('[data-so-spark="failed"]') do
+        expect(page).to have_css(".so-spark__baseline")
+        expect(page).to have_css(".so-spark__line")
+      end
+      within('[data-so-spark="ready"]') do
+        expect(page).to have_css(".so-spark__baseline")
+        expect(page).to have_css(".so-spark__line")
+      end
+    end
+
+    it "renders card value elements with data-so-card-value attributes" do
+      visit "/solid_observer"
+
+      expect(page).to have_css('[data-so-card-value="ready"]')
+      expect(page).to have_css('[data-so-card-value="scheduled"]')
+      expect(page).to have_css('[data-so-card-value="claimed"]')
+      expect(page).to have_css('[data-so-card-value="workers"]')
+      expect(page).to have_css('[data-so-card-value="failed"]')
+      expect(page).to have_css('[data-so-card-value="enqueue_rate_per_min"]')
     end
   end
 
@@ -161,6 +198,46 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_css('turbo-frame#so_right_now[src$="/right_now"]')
       expect(page).not_to have_css("turbo-frame#so_scoped")
       expect(page).to have_select("Range", selected: "15m")
+    end
+
+    it "renders only the ready sparkline figure" do
+      allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
+        ready: 1,
+        scheduled: 0,
+        claimed: 0,
+        failed: 0,
+        workers: 1,
+        queues: {},
+        available: true,
+        range: "15m"
+      )
+
+      visit "/solid_observer"
+
+      expect(page).to have_css('[data-so-spark="ready"]')
+      expect(page).not_to have_css('[data-so-spark="performed"]')
+      expect(page).not_to have_css('[data-so-spark="failed"]')
+    end
+
+    it "renders card value elements with data-so-card-value attributes in realtime mode" do
+      allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
+        ready: 1,
+        scheduled: 0,
+        claimed: 0,
+        failed: 0,
+        workers: 1,
+        queues: {},
+        available: true,
+        range: "15m"
+      )
+
+      visit "/solid_observer"
+
+      expect(page).to have_css('[data-so-card-value="ready"]')
+      expect(page).to have_css('[data-so-card-value="scheduled"]')
+      expect(page).to have_css('[data-so-card-value="claimed"]')
+      expect(page).to have_css('[data-so-card-value="workers"]')
+      expect(page).to have_css('[data-so-card-value="failed"]')
     end
   end
 

--- a/spec/solid_observer/application_layout_spec.rb
+++ b/spec/solid_observer/application_layout_spec.rb
@@ -138,6 +138,17 @@ RSpec.describe "SolidObserver application layout" do
       expect(template_source).to include("events_path")
       expect(template_source).to include("storage_path")
     end
+
+    it "includes sparkline CSS rules for chart strip and spark components" do
+      expect(template_source).to include(".so-chart-strip")
+      expect(template_source).to include(".so-chart-strip:has(> .so-spark:only-child)")
+      expect(template_source).to include(".so-spark")
+      expect(template_source).to include(".so-spark__svg")
+      expect(template_source).to include(".so-spark__baseline")
+      expect(template_source).to include(".so-spark__line")
+      expect(template_source).to include(".so-spark__label")
+      expect(template_source).to include(".so-spark__value")
+    end
   end
 
   describe "rendering" do

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe SolidObserver::DashboardController do
 
       expect(status).to eq(200)
       expect(headers["Content-Type"]).to include("application/javascript")
-      expect(body).to include("function init(root)")
+      expect(body).to include("function init()")
       expect(body).not_to include("<html")
       expect(body).not_to include("so-sidebar")
     end


### PR DESCRIPTION
## Summary of changes
- Rewrite `live_poll.js` end-to-end to consume the SO-062 JSON `/solid_observer/poll_data` endpoint: per-card DOM updates via `[data-so-card-value]` selectors, plus three hand-rolled inline-SVG sparklines (Performed, Failed, Ready) — no library, no canvas, no new runtime deps.
- New `_chart.html.erb` partial with permanent baseline `<line>` so cells never read empty pre-first-tick; mounted gated on `@stats[:available]` so SolidQueue-unreachable state isn't visually cluttered.
- Seven CSS rules + one `:has()` override in `application.html.erb`; realtime mode caps the single Ready cell at 340px so it doesn't read as a banner.
- Enqueue-rate card refactored: raw int value, "jobs/min" moves to the `subtitle` slot (otherwise the JS hydration would silently drop the unit suffix).
- Add `bin/quality_gate` convenience runner (supports `--skip-appraisal` and single-gate invocation).
- One follow-up ticket spun out: **SO-065 — Harden flaky appraisal specs** (3 pre-existing intermittent failures in the appraisal matrix, not caused by this PR).