### PR TITLE
[SO-064][FEAT] UX wiring: card consolidation + pill toggle + legacy retire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - Stat counter subtitles ("queued" / "future runs" / "in progress" / "awaiting retry" / "active processes") clarify SolidQueue lifecycle terminology.
 - Conceptual hint banner on the dashboard explains the difference between Jobs tab (in-flight + failed) and Events tab (historical record).
 - Jobs tab now has an empty state with a hint pointing to Events tab for completed-job history.
+- Dashboard polled chart strip and unified card grid: a JSON-fed polling client refreshes six stat cards (Ready, Scheduled, Claimed, Workers, Failed, Enqueue Rate) and three sparklines (Performed/min, Ready depth, Failed/min) every `SolidObserver.config.ui_refresh_interval` seconds (default `30`, `0` disables polling). In realtime mode only the Ready sparkline renders and the Enqueue Rate card is omitted. Toggle in the dashboard top bar enables/disables polling; state lives in `?live=on` URL param. Hand-rolled inline-SVG sparklines, no JS framework, no external chart library.
 
 ### Fixed
 - **Duration was displayed off by 1000x.** `RecordEvent` stored `ActiveSupport::Notifications::Event#duration` (milliseconds) directly; `format_duration` interpreted it as seconds. Fixed by converting ms → seconds at write time. No data migration needed (v0.3.0 unreleased); run `bin/rails solid_observer:storage:purge` to clear pre-fix local data.
@@ -40,6 +41,7 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 
 ### Removed
 - Removed the legacy implicit dashboard auto-refresh (`<meta http-equiv="refresh">` plus inline fetch/DOM-swap script for `.so-content`). Replaced by explicit, opt-in Live Mode targeting only the Right-Now frame.
+- Removed the legacy `GET /solid_observer/right_now` HTML endpoint and its action template (it was the SO-060-era polling target that returned a partial-only HTML response wrapped in a turbo-frame). Replaced by `GET /solid_observer/poll_data` which returns JSON for the polling client. The `live_poll.js` script-delivery route is unchanged.
 
 ### Changed
 - Web UI controllers refactored to thin actions + query/param/presenter objects; Rails built-in number helpers replace custom ones
@@ -51,6 +53,8 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 - Refreshed the engine UI to a minimalist visual language: light surfaces, near-black text, restrained semantic colour accents reserved for badges/state, hairline separators, consistent rounding. Sidebar moves from dark slate to a light surface. No external CSS dependencies, no JS, no dark mode (single light theme).
 - Dashboard: replaced the multi-line "Recent Failures" panel with a single-line **Stability** indicator (pill badge + summary + "View failures" link). Three states based on rolling failure counts: **Stable** (no failures in last 24h), **Degraded** (failures in last 24h but none in last hour), **Critical** (any failure in the last hour). Click-through targets the Events page filtered to `job_failed`.
 - Dashboard: removed the "Jobs tab / Events tab" orientation banner. The distinction is discoverable via navigation; the dashboard is reserved for signal.
+- Dashboard layout consolidated: dropped the previous two-frame split (Right-Now + Scoped) and the redundant Performed-in-range / Failed-in-range cards (those metrics now live in the polled sparkline strip).
+- Live toggle restyled as a pill switch with cadence visible in-line ("Live · 2s" / "Live · off") and a pulsing dot when active.
 
 ## [0.1.1] - 2026-02-10
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     appraisal (2.5.0)
       bundler
@@ -248,7 +248,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/app/assets/javascripts/solid_observer/live_poll.js
+++ b/app/assets/javascripts/solid_observer/live_poll.js
@@ -83,6 +83,9 @@
 
     checkbox.addEventListener("change", function () {
       syncUrl();
+      checkbox
+        .closest("label")
+        .classList.toggle("so-toggle--on", checkbox.checked);
       if (checkbox.checked) {
         start();
       } else {
@@ -91,6 +94,9 @@
     });
 
     if (checkbox.checked) start();
+    checkbox
+      .closest("label")
+      .classList.toggle("so-toggle--on", checkbox.checked);
 
     window.addEventListener("beforeunload", stop);
   }

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -10,11 +10,6 @@ module SolidObserver
       load_persistence_data if persistence_mode?
     end
 
-    def right_now
-      @stats = QueueStats.snapshot(range: nil)
-      render layout: false
-    end
-
     def live_poll
       send_file(
         SolidObserver::Engine.root.join("app/assets/javascripts/solid_observer/live_poll.js"),

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -280,9 +280,22 @@
       background: var(--so-card-bg);
       color: var(--so-text);
     }
-    .so-toggle { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; cursor: pointer; }
-    .so-toggle input[type=checkbox] { margin: 0; cursor: pointer; }
-    .so-toggle__hint { color: var(--so-text-subtle); font-size: 0.75rem; }
+    .so-toggle--pill { position: relative; display: inline-flex; align-items: center; gap: 0.5rem; min-height: 32px; cursor: pointer; user-select: none; }
+    .so-toggle--pill input[type=checkbox] { position: absolute; opacity: 0; pointer-events: none; }
+    .so-toggle__track { position: relative; width: 32px; height: 18px; background: var(--so-border); border-radius: 9999px; transition: background 150ms ease; }
+    .so-toggle__thumb { position: absolute; top: 2px; left: 2px; width: 14px; height: 14px; background: var(--so-card-bg); border: 1px solid var(--so-border-strong); border-radius: 9999px; transition: transform 150ms ease; box-sizing: border-box; }
+    .so-toggle--on .so-toggle__track { background: var(--so-success); }
+    .so-toggle--on .so-toggle__thumb { transform: translateX(14px); }
+    .so-toggle--pill input:focus-visible + .so-toggle__track { outline: 2px solid var(--so-info); outline-offset: 2px; }
+    .so-toggle__label, .so-toggle__sep, .so-toggle__cadence { font-size: 0.85rem; color: var(--so-text-muted); }
+    .so-toggle--on .so-toggle__label, .so-toggle--on .so-toggle__cadence { color: var(--so-text); }
+    .so-toggle__dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--so-success); opacity: 0; }
+    .so-toggle--on .so-toggle__dot { opacity: 1; animation: so-pulse 1.5s ease-in-out infinite; }
+    @keyframes so-pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
+    @media (prefers-reduced-motion: reduce) {
+      .so-toggle--on .so-toggle__dot { animation: none; opacity: 1; }
+      .so-toggle__track, .so-toggle__thumb { transition: none; }
+    }
 
     .so-empty { text-align: center; padding: 3rem 1rem; color: var(--so-text-muted); }
     .so-empty__icon { font-size: 2rem; margin-bottom: 0.5rem; }

--- a/app/views/solid_observer/dashboard/_right_now.html.erb
+++ b/app/views/solid_observer/dashboard/_right_now.html.erb
@@ -1,14 +1,14 @@
 <% if stats[:available] %>
-  <section class="so-cards-section">
-    <h2 class="so-cards-section__title">Right Now</h2>
-    <div class="so-stat-cards">
-      <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: stats[:ready], data_key: "ready" %>
-      <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: stats[:scheduled], data_key: "scheduled" %>
-      <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: stats[:claimed], data_key: "claimed" %>
-      <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: stats[:workers], data_key: "workers" %>
-      <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: stats[:failed], data_key: "failed" %>
-    </div>
-  </section>
+  <div class="so-stat-cards">
+    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: stats[:ready], data_key: "ready" %>
+    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: stats[:scheduled], data_key: "scheduled" %>
+    <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: stats[:claimed], data_key: "claimed" %>
+    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: stats[:workers], data_key: "workers" %>
+    <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: stats[:failed], data_key: "failed" %>
+    <% if SolidObserver.config.persistence_mode? %>
+      <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "jobs/min", value: stats[:enqueue_rate_per_min], data_key: "enqueue_rate_per_min" %>
+    <% end %>
+  </div>
 <% else %>
   <div class="so-card">
     <div class="so-empty">

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <form method="get" action="<%= root_path %>" class="so-filters" data-turbo-frame="_top"
-      data-so-live data-so-live-interval="<%= SolidObserver.config.ui_refresh_interval.to_i %>" data-so-live-frame="so_right_now">
+      data-so-live data-so-live-interval="<%= SolidObserver.config.ui_refresh_interval.to_i %>">
   <label for="so-range" class="so-card__label so-filters__label">Range</label>
   <select id="so-range" name="range" onchange="this.form.requestSubmit()">
     <% SolidObserver::QueueStats::RANGES.each_key do |key| %>
@@ -13,10 +13,15 @@
     <% end %>
   </select>
   <% if SolidObserver.config.ui_refresh_interval.to_i > 0 %>
-    <label class="so-filters__label so-toggle">
+    <label class="so-toggle so-toggle--pill <%= "so-toggle--on" if @live %>">
       <input type="checkbox" name="live" value="on" <%= "checked" if @live %>>
-      <span>Live</span>
-      <span class="so-toggle__hint">every <%= SolidObserver.config.ui_refresh_interval %>s</span>
+      <span class="so-toggle__track" aria-hidden="true">
+        <span class="so-toggle__thumb"></span>
+      </span>
+      <span class="so-toggle__label">Live</span>
+      <span class="so-toggle__sep" aria-hidden="true"> · </span>
+      <span class="so-toggle__cadence"><%= @live ? "#{SolidObserver.config.ui_refresh_interval}s" : "off" %></span>
+      <span class="so-toggle__dot" aria-hidden="true"></span>
     </label>
   <% end %>
   <noscript><button type="submit" class="so-btn">Apply</button></noscript>
@@ -26,22 +31,7 @@
   <%= render "chart" %>
 <% end %>
 
-<%= turbo_frame_tag "so_right_now", src: right_now_path do %>
-  <%= render "right_now", stats: @stats %>
-<% end %>
-
-<% if @stats[:available] && persistence_mode? %>
-  <%= turbo_frame_tag "so_scoped" do %>
-    <section class="so-cards-section">
-      <h2 class="so-cards-section__title">Last <%= @range %></h2>
-      <div class="so-stat-cards">
-        <%= render "solid_observer/shared/stat_card", label: "Performed", subtitle: "in range", value: number_with_delimiter(@stats[:performed_in_range]) %>
-        <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "in range", value: number_with_delimiter(@stats[:failed_in_range]) %>
-        <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "jobs/min", value: @stats[:enqueue_rate_per_min], data_key: "enqueue_rate_per_min" %>
-      </div>
-    </section>
-  <% end %>
-<% end %>
+<%= render "right_now", stats: @stats %>
 
 <% if @stats[:available] && @stats[:queues].any? %>
   <div class="so-card so-card--section">

--- a/app/views/solid_observer/dashboard/right_now.html.erb
+++ b/app/views/solid_observer/dashboard/right_now.html.erb
@@ -1,3 +1,0 @@
-<%= turbo_frame_tag "so_right_now", src: right_now_path do %>
-  <%= render "right_now", stats: @stats %>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@
 SolidObserver::Engine.routes.draw do
   root "dashboard#index"
   get "poll_data", to: "dashboard#poll_data", as: :poll_data
-  get "right_now", to: "dashboard#right_now", as: :right_now
   get "live_poll.js", to: "dashboard#live_poll", as: :live_poll_script
 
   resources :jobs, only: %i[index show] do

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -54,37 +54,29 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("Persistence")
     end
 
-    it "shows throughput cards" do
+    it "shows Enqueue rate card in persistence mode" do
       visit "/solid_observer"
 
-      expect(page).to have_content("Last 1h")
-      expect(page).to have_content("Performed")
-      expect(page).to have_content("Failed")
-      expect(page).to have_content("in range")
-      expect(page).to have_content("Enqueue rate")
       expect(page).to have_css('[data-so-card-value="enqueue_rate_per_min"]', text: "4.6")
       expect(page).to have_content("jobs/min")
     end
 
-    it "renders both dashboard turbo frames" do
+    it "does not render turbo frame wrappers" do
       visit "/solid_observer"
 
-      expect(page).to have_css('turbo-frame#so_right_now[src$="/right_now"]')
-      expect(page).to have_css("turbo-frame#so_scoped")
+      expect(page).not_to have_css("turbo-frame")
     end
 
     it "keeps selected range for a valid range param" do
       visit "/solid_observer?range=15m"
 
       expect(page).to have_select("Range", selected: "15m")
-      expect(page).to have_content("Last 15m")
     end
 
     it "falls back selected range for an invalid range param" do
       visit "/solid_observer?range=bogus"
 
       expect(page).to have_select("Range", selected: "1h")
-      expect(page).to have_content("Last 1h")
     end
 
     it "shows the Stability indicator with a click-through to failures" do
@@ -102,13 +94,32 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).not_to have_css('input[type="checkbox"][name="live"]')
     end
 
-    it "renders checked Live toggle with frame polling data attributes when enabled in params" do
+    it "renders checked Live toggle as pill switch when enabled in params" do
       SolidObserver.config.ui_refresh_interval = 5
 
       visit "/solid_observer?live=on"
 
-      expect(page).to have_css('form[data-so-live][data-so-live-frame="so_right_now"][data-so-live-interval="5"]')
+      expect(page).to have_css('form[data-so-live][data-so-live-interval="5"]')
       expect(page).to have_css('input[type="checkbox"][name="live"][value="on"][checked]')
+      expect(page).to have_css("label.so-toggle.so-toggle--pill.so-toggle--on")
+      expect(page).to have_css(".so-toggle__label", text: "Live")
+      expect(page).to have_css(".so-toggle__cadence", text: "5s")
+      expect(page).to have_css(".so-toggle__dot")
+    end
+
+    it "renders pill toggle with correct markup and a11y attributes" do
+      SolidObserver.config.ui_refresh_interval = 2
+
+      visit "/solid_observer"
+
+      expect(page).to have_css("label.so-toggle.so-toggle--pill")
+      expect(page).not_to have_css("label.so-toggle--on")
+      expect(page).to have_css(".so-toggle__label", text: "Live")
+      expect(page).to have_css(".so-toggle__sep", text: "·")
+      expect(page).to have_css(".so-toggle__cadence", text: "off")
+      expect(page).to have_css('.so-toggle__track[aria-hidden="true"]')
+      expect(page).to have_css('.so-toggle__sep[aria-hidden="true"]')
+      expect(page).to have_css('.so-toggle__dot[aria-hidden="true"]')
     end
 
     it "renders the chart strip with three sparkline figures" do
@@ -162,7 +173,7 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("Real-time")
     end
 
-    it "does not show persistence-only hint and throughput cards" do
+    it "does not show Enqueue rate card or Stability in realtime mode" do
       allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
         ready: 1,
         scheduled: 0,
@@ -176,12 +187,11 @@ RSpec.describe "Dashboard", type: :feature do
 
       visit "/solid_observer"
 
-      expect(page).not_to have_content("Performed")
-      expect(page).not_to have_content("Enqueue rate")
+      expect(page).not_to have_css('[data-so-card-value="enqueue_rate_per_min"]')
       expect(page).not_to have_content("Stability")
     end
 
-    it "renders only the right-now turbo frame" do
+    it "renders five-card grid without turbo frames in realtime mode" do
       allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
         ready: 1,
         scheduled: 0,
@@ -195,8 +205,13 @@ RSpec.describe "Dashboard", type: :feature do
 
       visit "/solid_observer?range=15m"
 
-      expect(page).to have_css('turbo-frame#so_right_now[src$="/right_now"]')
-      expect(page).not_to have_css("turbo-frame#so_scoped")
+      expect(page).not_to have_css("turbo-frame")
+      expect(page).to have_css('[data-so-card-value="ready"]')
+      expect(page).to have_css('[data-so-card-value="scheduled"]')
+      expect(page).to have_css('[data-so-card-value="claimed"]')
+      expect(page).to have_css('[data-so-card-value="workers"]')
+      expect(page).to have_css('[data-so-card-value="failed"]')
+      expect(page).not_to have_css('[data-so-card-value="enqueue_rate_per_min"]')
       expect(page).to have_select("Range", selected: "15m")
     end
 

--- a/spec/solid_observer/application_layout_spec.rb
+++ b/spec/solid_observer/application_layout_spec.rb
@@ -149,6 +149,40 @@ RSpec.describe "SolidObserver application layout" do
       expect(template_source).to include(".so-spark__label")
       expect(template_source).to include(".so-spark__value")
     end
+
+    it "includes pill toggle CSS rules for the restyled Live switch" do
+      expect(template_source).to include(".so-toggle--pill")
+      expect(template_source).to include(".so-toggle__track")
+      expect(template_source).to include(".so-toggle__thumb")
+      expect(template_source).to include(".so-toggle--on .so-toggle__track")
+      expect(template_source).to include(".so-toggle--on .so-toggle__thumb")
+      expect(template_source).to include("input:focus-visible + .so-toggle__track")
+      expect(template_source).to include(".so-toggle__label")
+      expect(template_source).to include(".so-toggle__sep")
+      expect(template_source).to include(".so-toggle__cadence")
+      expect(template_source).to include(".so-toggle__dot")
+      expect(template_source).to include(".so-toggle--on .so-toggle__dot")
+    end
+
+    it "includes so-pulse keyframe animation for the toggle dot" do
+      expect(template_source).to include("@keyframes so-pulse")
+    end
+
+    it "includes prefers-reduced-motion media query for toggle animations" do
+      expect(template_source).to include("@media (prefers-reduced-motion: reduce)")
+      expect(template_source).to include("animation: none")
+      expect(template_source).to include("transition: none")
+    end
+
+    it "does not use box-shadow inside any .so-toggle CSS rule" do
+      # Extract the toggle-related CSS block and assert no box-shadow
+      toggle_block = template_source[/\.so-toggle--pill.*?(?=\n\s*\.[a-z]|\n\s+\.so-empty)/m, 0] || ""
+      expect(toggle_block).not_to include("box-shadow")
+    end
+
+    it "does not include legacy toggle hint rule" do
+      expect(template_source).not_to include(".so-toggle__hint")
+    end
   end
 
   describe "rendering" do

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe SolidObserver::DashboardController do
   def call_controller_action(action_name, path = "/", env_overrides = {})
     ensure_engine_view_path!
     described_class.helper(SolidObserver::ApplicationHelper)
-    unless described_class.method_defined?(:right_now_path)
-      described_class.define_method(:right_now_path) { "/solid_observer/right_now" }
-      described_class.helper_method(:right_now_path)
-    end
     env = Rack::MockRequest.env_for(
       path,
       {"action_dispatch.routes" => SolidObserver::Engine.routes}.merge(env_overrides)
@@ -218,113 +214,6 @@ RSpec.describe SolidObserver::DashboardController do
           :enqueue_rate_per_min
         )
       end
-    end
-  end
-
-  describe "#right_now" do
-    let(:available_stats) do
-      {
-        ready: 3,
-        scheduled: 1,
-        claimed: 0,
-        failed: 2,
-        workers: 1,
-        queues: {},
-        available: true
-      }
-    end
-
-    it "returns html without layout chrome" do
-      allow(SolidObserver::QueueStats).to receive(:snapshot).with(range: nil).and_return(available_stats)
-
-      status, headers, body = call_controller_action(:right_now, "/right_now")
-
-      expect(status).to eq(200)
-      expect(headers["Content-Type"]).to include("text/html")
-      expect(body).not_to include("<html")
-      expect(body).not_to include("so-sidebar")
-    end
-
-    it "renders one right-now turbo frame wrapper" do
-      allow(SolidObserver::QueueStats).to receive(:snapshot).with(range: nil).and_return(available_stats)
-
-      status, _headers, body = call_controller_action(:right_now, "/right_now")
-
-      expect(status).to eq(200)
-      expect(body.scan(/<turbo-frame[^>]+id="so_right_now"/).size).to eq(1)
-    end
-
-    it "renders the five right-now cards when available" do
-      allow(SolidObserver::QueueStats).to receive(:snapshot).with(range: nil).and_return(available_stats)
-
-      status, _headers, body = call_controller_action(:right_now, "/right_now")
-
-      expect(status).to eq(200)
-      expect(body).to include("Right Now")
-      expect(body).to include("Ready")
-      expect(body).to include("Scheduled")
-      expect(body).to include("Claimed")
-      expect(body).to include("Workers")
-      expect(body).to include("Failed")
-    end
-
-    it "renders the unavailable branch without raising when SolidQueue is unavailable" do
-      unavailable_stats = available_stats.merge(available: false)
-      allow(SolidObserver::QueueStats).to receive(:snapshot).with(range: nil).and_return(unavailable_stats)
-
-      status, _headers, body = call_controller_action(:right_now, "/right_now")
-
-      expect(status).to eq(200)
-      expect(body).to include("SolidQueue is not available")
-    end
-
-    it "does not call QueueEvent throughput/failure queries in persistence mode" do
-      SolidObserver.config.storage_mode = :persistence
-
-      stub_const("SolidQueue", Module.new)
-      stub_const("SolidQueue::Job", Class.new)
-      stub_const("SolidQueue::ReadyExecution", Class.new do
-        def self.count
-        end
-
-        def self.group(*)
-        end
-      end)
-      stub_const("SolidQueue::ScheduledExecution", Class.new do
-        def self.count
-        end
-      end)
-      stub_const("SolidQueue::ClaimedExecution", Class.new do
-        def self.count
-        end
-      end)
-      stub_const("SolidQueue::FailedExecution", Class.new do
-        def self.count
-        end
-      end)
-      stub_const("SolidQueue::Process", Class.new do
-        def self.where(*)
-        end
-      end)
-
-      allow(SolidQueue::ReadyExecution).to receive(:count).and_return(3)
-      allow(SolidQueue::ScheduledExecution).to receive(:count).and_return(1)
-      allow(SolidQueue::ClaimedExecution).to receive(:count).and_return(0)
-      allow(SolidQueue::FailedExecution).to receive(:count).and_return(2)
-      allow(SolidQueue::Process).to receive(:where).with(kind: "Worker").and_return(double(count: 1))
-
-      queue_group = double("queue_group", count: {"default" => 3})
-      allow(SolidQueue::ReadyExecution).to receive(:group).with(:queue_name).and_return(queue_group)
-
-      expect(SolidObserver::QueueEvent).not_to receive(:performed_count_last)
-      expect(SolidObserver::QueueEvent).not_to receive(:failed_count_last)
-      expect(SolidObserver::QueueEvent).not_to receive(:enqueue_rate_per_minute)
-      expect(SolidObserver::QueueEvent).not_to receive(:recent_failures)
-
-      status, _headers, body = call_controller_action(:right_now, "/right_now")
-
-      expect(status).to eq(200)
-      expect(body).to include("Right Now")
     end
   end
 


### PR DESCRIPTION
## Summary of changes
- Consolidate dashboard into a single 6-card grid (5 in realtime) + chart strip
  above; drop the Right-Now / Scoped two-frame split and the redundant
  Performed-in-range / Failed-in-range cards.
- Pill-switch Live toggle with three-span label (`Live · 2s` / `Live · off`),
  pulsing dot, `:focus-visible` outline, and `prefers-reduced-motion`
  suppression. No `box-shadow` — thumb uses a 1px border via existing
  `--so-border-strong` token.
- Remove legacy `GET /solid_observer/right_now` HTML endpoint (action +
  template + route). The `live_poll.js` script-delivery and `poll_data` JSON
  routes are unchanged.
- `CHANGELOG.md` `[0.3.0]`: Added / Changed / Removed entries describing the
  final shipped feature shape (SO-062 + SO-063 + SO-064 combined).
- Transitive security bumps via `bundler-audit`: `addressable 2.8.8 → 2.9.0`,
  `rack-session 2.1.1 → 2.1.2`.