### PR TITLE
[SO-066][FIX] Polish dashboard live mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 
 ### Fixed
 - **Duration was displayed off by 1000x.** `RecordEvent` stored `ActiveSupport::Notifications::Event#duration` (milliseconds) directly; `format_duration` interpreted it as seconds. Fixed by converting ms → seconds at write time. No data migration needed (v0.3.0 unreleased); run `bin/rails solid_observer:storage:purge` to clear pre-fix local data.
+- **Dashboard chart strip renders populated polylines on first paint** instead of empty placeholders. Server-side `spark_points` helper mirrors the JS `Sparkline.render` projection formula so the first HTML response ships with real data; the first JS poll appends one additional segment with no visible "empty → full" transition.
+- **Live toggle cadence label stays in sync with toggle state.** The `.so-toggle__cadence` span now carries `aria-live="polite"` and is updated in the same synchronous tick as the `--on` class toggle. Server-side ERB hardcodes `"5s"` / `"off"` matching the JS literals.
 - Jobs details page no longer crashes for `SolidQueue::FailedExecution`; Queue and Priority now fall back to underlying `SolidQueue::Job` values and show `N/A` when unavailable.
 - Web UI now works on API-only Rails hosts. The engine ships its own Cookies / Session::CookieStore (`key: "_solid_observer_session"`) / Flash middleware stack, so requests routed to `/solid_observer/*` get the middleware they need regardless of whether the host app strips them via `config.api_only = true`. Previously, API-only hosts hit `NoMethodError: undefined method 'flash' for an instance of ActionDispatch::Request` rendering the dashboard layout.
 - `bin/rails solid_observer:install:migrations` now respects `migrations_paths` from the `solid_observer_queue` connection in `config/database.yml`. When the host configures a dedicated migration folder (e.g. `db/solid_observer_migrate`), the install task copies migrations directly there instead of `db/migrate/`. Previously, operators in multi-database setups had to manually move the files after install to prevent cross-database migration contamination.
@@ -42,12 +44,15 @@ Headline: **Web UI Dashboard** + stability hardening from pre-release review.
 ### Removed
 - Removed the legacy implicit dashboard auto-refresh (`<meta http-equiv="refresh">` plus inline fetch/DOM-swap script for `.so-content`). Replaced by explicit, opt-in Live Mode targeting only the Right-Now frame.
 - Removed the legacy `GET /solid_observer/right_now` HTML endpoint and its action template (it was the SO-060-era polling target that returned a partial-only HTML response wrapped in a turbo-frame). Replaced by `GET /solid_observer/poll_data` which returns JSON for the polling client. The `live_poll.js` script-delivery route is unchanged.
+- **Removed `SolidObserver.config.ui_refresh_interval`** (was unreliable; cadence is now hardcoded at 5s). Upgrade note: remove the line from your initializer or boot will raise `NoMethodError`.
 
 ### Changed
 - Web UI controllers refactored to thin actions + query/param/presenter objects; Rails built-in number helpers replace custom ones
 - Specs: `allow_any_instance_of` → `instance_double`; sleep-based timer specs use deterministic synchronisation; dead private-method `describe` blocks removed
 - `.reek.yml` suppressions trimmed; hot-path services/buffer/engine methods refactored to pass `TooManyStatements` without new suppressions
 - `SolidObserver.config.ui_refresh_interval` now controls Live Mode polling cadence instead of implicit full-page dashboard refresh. Default value is unchanged.
+- Dashboard default range is `15m` (was `1h`); aligns with poll default.
+- Live polling pauses while the tab is hidden and resumes on return (one immediate tick on visibility return so the user doesn't wait up to 5s for fresh data).
 - Jobs tab default filter changed from `status=ready` to `status=all_active` (ready + scheduled + claimed + failed).
 - Duration values on the Events index and detail pages now use per-event-type semantic context via `<abbr title="...">` tooltips so operators can distinguish enqueue call latency (`job_enqueued`) from perform-time duration (`job_completed` / `job_failed` / `job_discarded`).
 - Refreshed the engine UI to a minimalist visual language: light surfaces, near-black text, restrained semantic colour accents reserved for badges/state, hairline separators, consistent rounding. Sidebar moves from dark slate to a light surface. No external CSS dependencies, no JS, no dark mode (single light theme).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     nenv (0.3.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ SolidObserver.configure do |config|
   config.ui_enabled          = !Rails.env.production?  # default: true outside production
   config.ui_username         = "admin"                 # HTTP Basic Auth: BOTH username AND password must be set
   config.ui_password         = ENV["SOLID_OBSERVER_PASSWORD"]
-  config.ui_refresh_interval = 30                      # seconds; 0 disables auto-refresh
   config.ui_base_controller  = "ApplicationController" # name of your host app's base controller (used for API-only detection)
 end
 ```
@@ -191,8 +190,9 @@ end
 |---|---|---|
 | `ui_enabled` | `!Rails.env.production?` | Master switch for the Web UI |
 | `ui_username` / `ui_password` | `nil` | HTTP Basic Auth credentials. Auth is enabled only when **both** are set; if either is missing or `nil`, the UI is unauthenticated |
-| `ui_refresh_interval` | `30` | Dashboard auto-refresh interval in seconds |
 | `ui_base_controller` | `"ApplicationController"` | Name of your host app's base controller. SolidObserver does **not** inherit from it; the value is used to detect API-only apps so the engine can include the rendering modules its dashboard needs |
+
+Live polling cadence is hardcoded at 5s.
 
 ### Production hardening (recommended)
 

--- a/app/assets/javascripts/solid_observer/live_poll.js
+++ b/app/assets/javascripts/solid_observer/live_poll.js
@@ -4,16 +4,11 @@
   var MAX_POINTS = 60;
   var SVG_W = 120,
     SVG_H = 32;
+  var INTERVAL_SEC = 5;
 
   function init() {
     var wrapper = document.querySelector("[data-so-live]");
     if (!wrapper) return;
-
-    var intervalSec = parseInt(
-      wrapper.getAttribute("data-so-live-interval"),
-      10,
-    );
-    if (!intervalSec || intervalSec <= 0) return;
 
     var checkbox = wrapper.querySelector("input[type=checkbox][name=live]");
     if (!checkbox) return;
@@ -60,7 +55,7 @@
 
     function start() {
       stop();
-      timerId = window.setInterval(tick, intervalSec * 1000);
+      timerId = window.setInterval(tick, INTERVAL_SEC * 1000);
     }
 
     function stop() {
@@ -83,9 +78,11 @@
 
     checkbox.addEventListener("change", function () {
       syncUrl();
-      checkbox
-        .closest("label")
-        .classList.toggle("so-toggle--on", checkbox.checked);
+      var label = checkbox.closest("label");
+      label.classList.toggle("so-toggle--on", checkbox.checked);
+      label.querySelector(".so-toggle__cadence").textContent = checkbox.checked
+        ? "5s"
+        : "off";
       if (checkbox.checked) {
         start();
       } else {
@@ -93,12 +90,19 @@
       }
     });
 
+    document.addEventListener("visibilitychange", function () {
+      if (document.hidden) {
+        stop();
+      } else if (checkbox.checked) {
+        tick();
+        start();
+      }
+    });
+
     if (checkbox.checked) start();
     checkbox
       .closest("label")
       .classList.toggle("so-toggle--on", checkbox.checked);
-
-    window.addEventListener("beforeunload", stop);
   }
 
   function collectSparks() {

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -38,6 +38,7 @@ module SolidObserver
       @range = range
       @live = request_live_param == "on"
       @stats = QueueStats.snapshot(range: range)
+      @chart = QueueStats.chart_data(window: QueueStats.range_duration(@range))
     end
 
     def load_persistence_data

--- a/app/helpers/solid_observer/dashboard_helper.rb
+++ b/app/helpers/solid_observer/dashboard_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Mirrors live_poll.js Sparkline.render — keep in sync.
+module SolidObserver
+  module DashboardHelper
+    SVG_W = 120
+    SVG_H = 32
+
+    def spark_points(series, width: SVG_W, height: SVG_H)
+      return "" if series.blank?
+
+      t_min = series.first[:t]
+      t_max = series.last[:t]
+      v_max = [series.max_by { |point| point[:v] }[:v], 1].max
+      time_span = t_max - t_min
+
+      series.map { |point|
+        val = point[:v]
+        point_x = time_span.zero? ? width / 2.0 : ((point[:t] - t_min).to_f / time_span) * (width - 2) + 1
+        point_y = height - 1 - (val.to_f / v_max) * (height - 2)
+        format("%.1f,%.1f", point_x, point_y)
+      }.join(" ")
+    end
+  end
+end

--- a/app/views/solid_observer/dashboard/_chart.html.erb
+++ b/app/views/solid_observer/dashboard/_chart.html.erb
@@ -4,25 +4,25 @@
       <figcaption class="so-spark__label">Performed/min</figcaption>
       <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
         <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
-        <polyline class="so-spark__line" points=""/>
+        <polyline class="so-spark__line" points="<%= spark_points(@chart[:performed]) %>"/>
       </svg>
-      <span class="so-spark__value" data-so-spark-value>—</span>
+      <span class="so-spark__value" data-so-spark-value><%= @chart[:performed].last&.dig(:v) || "—" %></span>
     </figure>
     <figure class="so-spark" data-so-spark="failed">
       <figcaption class="so-spark__label">Failed/min</figcaption>
       <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
         <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
-        <polyline class="so-spark__line" points=""/>
+        <polyline class="so-spark__line" points="<%= spark_points(@chart[:failed]) %>"/>
       </svg>
-      <span class="so-spark__value" data-so-spark-value>—</span>
+      <span class="so-spark__value" data-so-spark-value><%= @chart[:failed].last&.dig(:v) || "—" %></span>
     </figure>
   <% end %>
   <figure class="so-spark" data-so-spark="ready">
     <figcaption class="so-spark__label">Ready depth</figcaption>
     <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
       <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
-      <polyline class="so-spark__line" points=""/>
+      <polyline class="so-spark__line" points="<%= spark_points(@chart[:ready]) %>"/>
     </svg>
-    <span class="so-spark__value" data-so-spark-value>—</span>
+    <span class="so-spark__value" data-so-spark-value><%= @chart[:ready].last&.dig(:v) || "—" %></span>
   </figure>
 </div>

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -5,25 +5,23 @@
 </div>
 
 <form method="get" action="<%= root_path %>" class="so-filters" data-turbo-frame="_top"
-      data-so-live data-so-live-interval="<%= SolidObserver.config.ui_refresh_interval.to_i %>">
+      data-so-live>
   <label for="so-range" class="so-card__label so-filters__label">Range</label>
   <select id="so-range" name="range" onchange="this.form.requestSubmit()">
     <% SolidObserver::QueueStats::RANGES.each_key do |key| %>
       <option value="<%= key %>" <%= "selected" if key == @range %>><%= key %></option>
     <% end %>
   </select>
-  <% if SolidObserver.config.ui_refresh_interval.to_i > 0 %>
-    <label class="so-toggle so-toggle--pill <%= "so-toggle--on" if @live %>">
-      <input type="checkbox" name="live" value="on" <%= "checked" if @live %>>
-      <span class="so-toggle__track" aria-hidden="true">
-        <span class="so-toggle__thumb"></span>
-      </span>
-      <span class="so-toggle__label">Live</span>
-      <span class="so-toggle__sep" aria-hidden="true"> · </span>
-      <span class="so-toggle__cadence"><%= @live ? "#{SolidObserver.config.ui_refresh_interval}s" : "off" %></span>
-      <span class="so-toggle__dot" aria-hidden="true"></span>
-    </label>
-  <% end %>
+  <label class="so-toggle so-toggle--pill <%= "so-toggle--on" if @live %>">
+    <input type="checkbox" name="live" value="on" <%= "checked" if @live %>>
+    <span class="so-toggle__track" aria-hidden="true">
+      <span class="so-toggle__thumb"></span>
+    </span>
+    <span class="so-toggle__label">Live</span>
+    <span class="so-toggle__sep" aria-hidden="true"> · </span>
+    <span class="so-toggle__cadence" aria-live="polite"><%= @live ? "5s" : "off" %></span>
+    <span class="so-toggle__dot" aria-hidden="true"></span>
+  </label>
   <noscript><button type="submit" class="so-btn">Apply</button></noscript>
 </form>
 

--- a/lib/generators/solid_observer/templates/initializer.rb.tt
+++ b/lib/generators/solid_observer/templates/initializer.rb.tt
@@ -13,9 +13,6 @@ SolidObserver.configure do |config|
   # config.ui_username = "admin"
   # config.ui_password = "secret"
 
-  # Auto-refresh interval in seconds for the web UI (0 = disabled)
-  # config.ui_refresh_interval = 30
-
   # Base controller for UI (customize authorization)
   # config.ui_base_controller = "ApplicationController"
 

--- a/lib/solid_observer/chart_buffer.rb
+++ b/lib/solid_observer/chart_buffer.rb
@@ -77,9 +77,7 @@ module SolidObserver
     end
 
     def compute_cap
-      interval = SolidObserver.config.ui_refresh_interval.to_i
-      interval = 1 if interval < 1
-      (3600 / interval).to_i
+      (3600 / 5).to_i # 720 samples — 1h at the 5s cadence
     end
   end
 end

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -13,13 +13,10 @@ module SolidObserver
   #   end
   class Configuration
     # UI Settings
-    # Polling cadence in seconds for the dashboard Live toggle.
-    # 0 disables the toggle entirely.
     attr_accessor :ui_enabled,
       :ui_base_controller,
       :ui_username,
-      :ui_password,
-      :ui_refresh_interval
+      :ui_password
 
     # Observer Settings
     attr_accessor :observe_queue
@@ -56,12 +53,12 @@ module SolidObserver
     attr_accessor :correlation_id_generator
 
     def initialize
-      @ui_enabled, @ui_base_controller, @ui_username, @ui_password, @ui_refresh_interval,
+      @ui_enabled, @ui_base_controller, @ui_username, @ui_password,
         @storage_mode, @observe_queue, @observe_cache, @observe_cable,
         @event_retention, @metrics_retention, @max_db_size, @warning_threshold,
         @sampling_rate, @cache_sampling_rate, @buffer_size, @flush_interval,
         @max_buffer_size, @buffer_overflow_strategy, @filter_cache_ttl,
-        @correlation_id_generator = !production?, "::ApplicationController", nil, nil, 30,
+        @correlation_id_generator = !production?, "::ApplicationController", nil, nil,
           :persistence, true, false, false,
           30.days, 90.days, 1.gigabyte, 0.8,
           1.0, 0.1, 1000, 10.seconds,

--- a/lib/solid_observer/queue_stats.rb
+++ b/lib/solid_observer/queue_stats.rb
@@ -14,7 +14,7 @@ module SolidObserver
       "7d" => 7.days,
       "14d" => 14.days
     }.freeze
-    DEFAULT_RANGE = "1h"
+    DEFAULT_RANGE = "15m"
     POLL_DEFAULT_RANGE = "15m"
     POLL_EMPTY_SNAPSHOT = {
       ready: 0,

--- a/spec/dummy/config/initializers/solid_observer.rb
+++ b/spec/dummy/config/initializers/solid_observer.rb
@@ -8,7 +8,4 @@ SolidObserver.configure do |config|
   # Uncomment to enable HTTP Basic Auth:
   # config.ui_username = "admin"
   # config.ui_password = "secret"
-
-  # Auto-refresh interval in seconds (0 = disabled)
-  config.ui_refresh_interval = 0
 end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -12,6 +12,7 @@ Capybara.app = Rails.application
 SolidObserver::ApplicationController.include SolidObserver::Engine.routes.url_helpers
 SolidObserver::ApplicationController.helper SolidObserver::Engine.routes.url_helpers
 SolidObserver::ApplicationController.helper SolidObserver::ApplicationHelper
+SolidObserver::ApplicationController.helper SolidObserver::DashboardHelper
 
 RSpec.configure do |config|
   config.include Capybara::DSL, type: :feature

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Dashboard", type: :feature do
         workers: 3,
         queues: {},
         available: true,
-        range: "1h",
+        range: "15m",
         performed_in_range: 1200,
         failed_in_range: 9,
         failed_last_24h: 9,
@@ -41,6 +41,13 @@ RSpec.describe "Dashboard", type: :feature do
       )
       allow(SolidObserver::QueueEvent).to receive(:recent).and_return([])
       allow(SolidObserver::QueueEvent).to receive(:recent_failures).and_return([])
+      allow(SolidObserver::QueueStats).to receive(:chart_data).and_return(
+        {
+          performed: [{t: 100, v: 5}, {t: 200, v: 10}],
+          failed: [{t: 100, v: 1}],
+          ready: [{t: 100, v: 3}, {t: 200, v: 7}]
+        }
+      )
     end
 
     it "shows Events and Storage navigation links" do
@@ -76,7 +83,7 @@ RSpec.describe "Dashboard", type: :feature do
     it "falls back selected range for an invalid range param" do
       visit "/solid_observer?range=bogus"
 
-      expect(page).to have_select("Range", selected: "1h")
+      expect(page).to have_select("Range", selected: "15m")
     end
 
     it "shows the Stability indicator with a click-through to failures" do
@@ -86,20 +93,16 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_link("View failures", href: "/solid_observer/events?event_type=job_failed")
     end
 
-    it "hides the Live toggle when ui_refresh_interval is 0" do
-      SolidObserver.config.ui_refresh_interval = 0
-
+    it "renders the Live toggle unconditionally regardless of config" do
       visit "/solid_observer"
 
-      expect(page).not_to have_css('input[type="checkbox"][name="live"]')
+      expect(page).to have_css('input[type="checkbox"][name="live"]')
     end
 
     it "renders checked Live toggle as pill switch when enabled in params" do
-      SolidObserver.config.ui_refresh_interval = 5
-
       visit "/solid_observer?live=on"
 
-      expect(page).to have_css('form[data-so-live][data-so-live-interval="5"]')
+      expect(page).to have_css("form[data-so-live]")
       expect(page).to have_css('input[type="checkbox"][name="live"][value="on"][checked]')
       expect(page).to have_css("label.so-toggle.so-toggle--pill.so-toggle--on")
       expect(page).to have_css(".so-toggle__label", text: "Live")
@@ -108,8 +111,6 @@ RSpec.describe "Dashboard", type: :feature do
     end
 
     it "renders pill toggle with correct markup and a11y attributes" do
-      SolidObserver.config.ui_refresh_interval = 2
-
       visit "/solid_observer"
 
       expect(page).to have_css("label.so-toggle.so-toggle--pill")
@@ -117,6 +118,7 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_css(".so-toggle__label", text: "Live")
       expect(page).to have_css(".so-toggle__sep", text: "·")
       expect(page).to have_css(".so-toggle__cadence", text: "off")
+      expect(page).to have_css('.so-toggle__cadence[aria-live="polite"]')
       expect(page).to have_css('.so-toggle__track[aria-hidden="true"]')
       expect(page).to have_css('.so-toggle__sep[aria-hidden="true"]')
       expect(page).to have_css('.so-toggle__dot[aria-hidden="true"]')
@@ -157,10 +159,32 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_css('[data-so-card-value="failed"]')
       expect(page).to have_css('[data-so-card-value="enqueue_rate_per_min"]')
     end
+
+    it "renders chart polylines with non-empty points on first paint" do
+      visit "/solid_observer"
+
+      within('[data-so-spark="performed"]') do
+        polyline = find(".so-spark__line")
+        expect(polyline["points"]).not_to be_empty
+      end
+      within('[data-so-spark="failed"]') do
+        polyline = find(".so-spark__line")
+        expect(polyline["points"]).not_to be_empty
+      end
+      within('[data-so-spark="ready"]') do
+        polyline = find(".so-spark__line")
+        expect(polyline["points"]).not_to be_empty
+      end
+    end
   end
 
   context "in realtime mode" do
-    before { SolidObserver.config.storage_mode = :realtime }
+    before do
+      SolidObserver.config.storage_mode = :realtime
+      allow(SolidObserver::QueueStats).to receive(:chart_data).and_return(
+        {performed: [], failed: [], ready: [{t: 100, v: 3}]}
+      )
+    end
 
     it "does not show Events and Storage navigation links" do
       visit "/solid_observer"

--- a/spec/helpers/solid_observer/dashboard_helper_spec.rb
+++ b/spec/helpers/solid_observer/dashboard_helper_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../app/helpers/solid_observer/dashboard_helper"
+
+RSpec.describe SolidObserver::DashboardHelper do
+  include described_class
+
+  describe "#spark_points" do
+    it "returns empty string for empty series" do
+      expect(spark_points([])).to eq("")
+    end
+
+    it "returns midpoint x and height-mapped y for a single sample" do
+      result = spark_points([{t: 100, v: 5}])
+      # t_min == t_max → x = width/2 = 60.0
+      # v_max = max(5, 1) = 5
+      # y = 32 - 1 - (5/5)*(32-2) = 31 - 30 = 1.0
+      expect(result).to eq("60.0,1.0")
+    end
+
+    it "projects multi-sample monotonic series matching the JS Sparkline.render formula" do
+      series = [
+        {t: 0, v: 0},
+        {t: 10, v: 5},
+        {t: 20, v: 10},
+        {t: 30, v: 15},
+        {t: 40, v: 20}
+      ]
+      result = spark_points(series)
+      points = result.split(" ")
+
+      # t_min=0, t_max=40, v_max=max(0,5,10,15,20)=20 → v_max=max(20,1)=20
+      # x = ((t - 0) / (40 - 0)) * (120 - 2) + 1 = (t/40)*118 + 1
+      # y = 32 - 1 - (v/20)*(32-2) = 31 - v*1.5
+
+      # Point 0: t=0, v=0 → x=1.0, y=31.0
+      expect(points[0]).to eq("1.0,31.0")
+      # Point 1: t=10, v=5 → x=(10/40)*118+1=30.5, y=31-7.5=23.5
+      expect(points[1]).to eq("30.5,23.5")
+      # Point 2: t=20, v=10 → x=(20/40)*118+1=60.0, y=31-15=16.0
+      expect(points[2]).to eq("60.0,16.0")
+      # Point 3: t=30, v=15 → x=(30/40)*118+1=89.5, y=31-22.5=8.5
+      expect(points[3]).to eq("89.5,8.5")
+      # Point 4: t=40, v=20 → x=(40/40)*118+1=119.0, y=31-30=1.0
+      expect(points[4]).to eq("119.0,1.0")
+    end
+
+    it "floors v_max at 1 to prevent division by zero on all-zero series" do
+      series = [
+        {t: 0, v: 0},
+        {t: 10, v: 0},
+        {t: 20, v: 0}
+      ]
+      result = spark_points(series)
+      points = result.split(" ")
+
+      # v_max = max(0, 1) = 1
+      # y = 32 - 1 - (0/1)*(32-2) = 31.0 for all points
+      expect(points[0]).to end_with(",31.0")
+      expect(points[1]).to end_with(",31.0")
+      expect(points[2]).to end_with(",31.0")
+    end
+
+    it "falls back to midpoint x when t_min equals t_max" do
+      series = [
+        {t: 50, v: 3},
+        {t: 50, v: 7}
+      ]
+      result = spark_points(series)
+      points = result.split(" ")
+
+      # t_min == t_max → x = 120/2.0 = 60.0 for all points
+      # v_max = max(3, 7) = 7
+      # Point 0: v=3 → y = 32-1-(3/7)*30 = 31-12.857... ≈ 18.1
+      # Point 1: v=7 → y = 32-1-(7/7)*30 = 31-30 = 1.0
+      expect(points[0]).to start_with("60.0,")
+      expect(points[1]).to eq("60.0,1.0")
+    end
+
+    it "accepts custom width and height parameters" do
+      series = [{t: 0, v: 5}, {t: 10, v: 10}]
+      result = spark_points(series, width: 200, height: 50)
+      points = result.split(" ")
+
+      # t_min=0, t_max=10, v_max=10
+      # x = ((t-0)/(10-0))*(200-2)+1 = (t/10)*198+1
+      # y = 50-1-(v/10)*(50-2) = 49-v*4.8
+
+      # Point 0: t=0, v=5 → x=1.0, y=49-24.0=25.0
+      expect(points[0]).to eq("1.0,25.0")
+      # Point 1: t=10, v=10 → x=199.0, y=49-48.0=1.0
+      expect(points[1]).to eq("199.0,1.0")
+    end
+  end
+end

--- a/spec/solid_observer/application_layout_spec.rb
+++ b/spec/solid_observer/application_layout_spec.rb
@@ -195,7 +195,6 @@ RSpec.describe "SolidObserver application layout" do
 
     describe "live polling script" do
       it "does not emit a refresh meta tag" do
-        SolidObserver.config.ui_refresh_interval = 30
         expect(render_layout).not_to include('http-equiv="refresh"')
       end
 

--- a/spec/solid_observer/chart_buffer_spec.rb
+++ b/spec/solid_observer/chart_buffer_spec.rb
@@ -25,18 +25,17 @@ RSpec.describe SolidObserver::ChartBuffer do
   end
 
   describe ".append" do
-    it "enforces cap derived from ui_refresh_interval" do
-      SolidObserver.config.ui_refresh_interval = 60
+    it "enforces cap of 720 samples (1h at 5s cadence)" do
       start_time = Time.utc(2026, 5, 10, 12, 0, 0)
 
-      65.times do |index|
+      725.times do |index|
         described_class.append(index, at: start_time + index.seconds)
       end
 
       samples = described_class.recent(10.years.to_i)
-      expect(samples.size).to eq(60)
+      expect(samples.size).to eq(720)
       expect(samples.first).to eq({t: (start_time + 5.seconds).to_i, v: 5})
-      expect(samples.last).to eq({t: (start_time + 64.seconds).to_i, v: 64})
+      expect(samples.last).to eq({t: (start_time + 724.seconds).to_i, v: 724})
     end
 
     it "deduplicates same-second samples by replacing the latest value" do
@@ -53,7 +52,6 @@ RSpec.describe SolidObserver::ChartBuffer do
     end
 
     it "is safe under concurrent appends" do
-      SolidObserver.config.ui_refresh_interval = 10
       start_time = Time.utc(2026, 5, 10, 12, 0, 0)
 
       threads = 4.times.map do |thread_index|
@@ -67,7 +65,7 @@ RSpec.describe SolidObserver::ChartBuffer do
       threads.each(&:value)
 
       samples = described_class.recent(10.years.to_i)
-      expect(samples.size).to eq(360)
+      expect(samples.size).to eq(400)
       expect(samples).to all(include(:t, :v))
     end
   end

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SolidObserver::DashboardController do
         workers: 1,
         queues: {},
         available: true,
-        range: "1h"
+        range: "15m"
       }
     end
     let(:request_double) do
@@ -63,15 +63,33 @@ RSpec.describe SolidObserver::DashboardController do
     before do
       allow(controller).to receive(:request).and_return(request_double)
       allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(stats)
+      allow(SolidObserver::QueueStats).to receive(:chart_data).and_return(
+        {performed: [], failed: [], ready: []}
+      )
     end
 
     it "assigns @stats from QueueStats.snapshot and exposes available ranges" do
       SolidObserver.config.storage_mode = :realtime
       controller.index
 
-      expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "1h")
+      expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "15m")
       expect(controller.instance_variable_get(:@stats)).to eq(stats)
-      expect(controller.instance_variable_get(:@range)).to eq("1h")
+      expect(controller.instance_variable_get(:@range)).to eq("15m")
+    end
+
+    it "assigns @chart from QueueStats.chart_data with performed, failed, and ready keys" do
+      chart_data = {
+        performed: [{t: 100, v: 5}, {t: 200, v: 10}],
+        failed: [{t: 100, v: 1}],
+        ready: [{t: 100, v: 3}, {t: 200, v: 7}]
+      }
+      allow(SolidObserver::QueueStats).to receive(:chart_data).and_return(chart_data)
+      SolidObserver.config.storage_mode = :persistence
+      controller.index
+
+      expect(SolidObserver::QueueStats).to have_received(:chart_data).with(window: 15.minutes)
+      result = controller.instance_variable_get(:@chart)
+      expect(result).to include(:performed, :failed, :ready)
     end
 
     describe "GET #index with range param" do
@@ -96,9 +114,9 @@ RSpec.describe SolidObserver::DashboardController do
           SolidObserver.config.storage_mode = :realtime
           controller.index
 
-          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "1h")
-          expect(controller.instance_variable_get(:@range)).to eq("1h")
-          expect(controller.instance_variable_get(:@stats)[:range]).to eq("1h")
+          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "15m")
+          expect(controller.instance_variable_get(:@range)).to eq("15m")
+          expect(controller.instance_variable_get(:@stats)[:range]).to eq("15m")
         end
       end
 
@@ -107,9 +125,9 @@ RSpec.describe SolidObserver::DashboardController do
           SolidObserver.config.storage_mode = :realtime
           controller.index
 
-          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "1h")
-          expect(controller.instance_variable_get(:@range)).to eq("1h")
-          expect(controller.instance_variable_get(:@stats)[:range]).to eq("1h")
+          expect(SolidObserver::QueueStats).to have_received(:snapshot).with(range: "15m")
+          expect(controller.instance_variable_get(:@range)).to eq("15m")
+          expect(controller.instance_variable_get(:@stats)[:range]).to eq("15m")
         end
       end
     end

--- a/spec/solid_observer/queue_stats_spec.rb
+++ b/spec/solid_observer/queue_stats_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe SolidObserver::QueueStats do
     end
 
     it "falls back to the default for unknown values" do
-      expect(described_class.parse_range("999d")).to eq("1h")
-      expect(described_class.parse_range(nil)).to eq("1h")
+      expect(described_class.parse_range("999d")).to eq("15m")
+      expect(described_class.parse_range(nil)).to eq("15m")
     end
   end
 
@@ -103,7 +103,7 @@ RSpec.describe SolidObserver::QueueStats do
           workers: 0,
           queues: {},
           available: false,
-          range: "1h",
+          range: "15m",
           error: "SolidQueue not available"
         )
       end
@@ -143,13 +143,11 @@ RSpec.describe SolidObserver::QueueStats do
       context "when persistence_mode? is true" do
         before do
           SolidObserver.config.storage_mode = :persistence
-          allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(1.hour).and_return(120)
           allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(15.minutes).and_return(34)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(15.minutes).and_return(2)
           allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 15.minutes).and_return(9.1)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(1.hour).and_return(0)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
-          allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 1.hour).and_return(14.2)
           allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(1).and_return([])
         end
 
@@ -164,13 +162,13 @@ RSpec.describe SolidObserver::QueueStats do
             workers: 4,
             queues: {"default" => 8, "mailers" => 2},
             available: true,
-            performed_in_range: 120,
-            failed_in_range: 0,
+            performed_in_range: 34,
+            failed_in_range: 2,
             failed_last_24h: 7,
             failed_last_hour: 0,
             latest_failure_at: nil,
-            enqueue_rate_per_min: 14.2,
-            range: "1h"
+            enqueue_rate_per_min: 9.1,
+            range: "15m"
           )
         end
 
@@ -265,7 +263,7 @@ RSpec.describe SolidObserver::QueueStats do
           workers: 0,
           queues: {},
           available: false,
-          range: "1h",
+          range: "15m",
           error: "Database connection failed"
         )
       end


### PR DESCRIPTION
## Summary of changes
- Populate dashboard chart sparklines on first paint and keep JS sparkline projection in sync with a Ruby helper.
- Hardcode Live polling to 5s, remove `ui_refresh_interval`, align default range to 15m, and pause polling in hidden tabs.
- Update specs, CHANGELOG, README config references, and bundler-audit lockfile remediation.