### PR TITLE
[SO-067][FEAT] Rework dashboard observability zones

### DIFF
--- a/app/assets/javascripts/solid_observer/live_poll.js
+++ b/app/assets/javascripts/solid_observer/live_poll.js
@@ -6,78 +6,88 @@
     SVG_H = 32;
   var INTERVAL_SEC = 5;
 
+  // Shared state — IIFE-level so all functions can access them
+  var checkbox, rangeSelect, refreshBtn, helpBtn, helpPanel, freshnessEl;
+  var sparks = {};
+  var url = "/solid_observer/poll_data";
+  var inFlight = false;
+  var timerId = null;
+  var lastFullSnapshot = null;
+  var lastFullChart = null;
+  var lastRange = null;
+
   function init() {
     var wrapper = document.querySelector("[data-so-live]");
     if (!wrapper) return;
 
-    var checkbox = wrapper.querySelector("input[type=checkbox][name=live]");
+    checkbox = wrapper.querySelector('[data-so-live-toggle]');
     if (!checkbox) return;
 
-    var sparks = collectSparks();
-    var url = "/solid_observer/poll_data";
-    var inFlight = false,
-      timerId = null;
+    rangeSelect = wrapper.querySelector("[data-so-range-select]");
+    refreshBtn = wrapper.querySelector("[data-so-refresh]");
+    helpBtn = wrapper.querySelector("[data-so-help-btn]");
+    helpPanel = wrapper.querySelector("[data-so-help-panel]");
+    freshnessEl = wrapper.querySelector("[data-so-freshness]");
 
-    function tick() {
-      if (inFlight) return;
-      inFlight = true;
-      var rangeParam = readRangeFromUrl();
-      fetch(
-        url + (rangeParam ? "?range=" + encodeURIComponent(rangeParam) : ""),
-        { headers: { Accept: "application/json" }, credentials: "same-origin" },
-      )
-        .then(function (r) {
-          return r.ok ? r.json() : null;
-        })
-        .then(function (data) {
-          if (data) applyUpdate(data);
-        })
-        .catch(function () {
-          /* drop tick silently */
-        })
-        .finally(function () {
-          inFlight = false;
-        });
-    }
+    sparks = collectSparks();
+    lastRange = readRangeFromUrl() || "15m";
 
-    function applyUpdate(data) {
-      var snapshot = data.snapshot || {};
-      Object.keys(snapshot).forEach(function (key) {
-        var el = document.querySelector('[data-so-card-value="' + key + '"]');
-        if (el) el.textContent = formatValue(snapshot[key]);
-      });
-      var chart = data.chart || {};
-      Object.keys(sparks).forEach(function (key) {
-        var series = chart[key];
-        if (Array.isArray(series)) sparks[key].render(series);
+    // --- Range change (full fetch) ---
+    if (rangeSelect) {
+      rangeSelect.addEventListener("change", function () {
+        lastRange = rangeSelect.value;
+        updateUrlRange(lastRange);
+        updateUrlLive(checkbox.checked);
+        fullFetch();
       });
     }
 
-    function start() {
-      stop();
-      timerId = window.setInterval(tick, INTERVAL_SEC * 1000);
+    // --- Refresh button (full fetch) ---
+    if (refreshBtn) {
+      refreshBtn.addEventListener("click", function () {
+        fullFetch();
+      });
     }
 
-    function stop() {
-      if (timerId !== null) {
-        window.clearInterval(timerId);
-        timerId = null;
-      }
-      inFlight = false;
+    // --- Help disclosure ---
+    if (helpBtn && helpPanel) {
+      helpBtn.addEventListener("click", function () {
+        var expanded = helpBtn.getAttribute("aria-expanded") === "true";
+        helpBtn.setAttribute("aria-expanded", String(!expanded));
+        helpPanel.hidden = expanded;
+      });
+      helpBtn.addEventListener("keydown", function (e) {
+        if (e.key === "Escape") {
+          helpBtn.setAttribute("aria-expanded", "false");
+          helpPanel.hidden = true;
+          helpBtn.focus();
+        }
+      });
+      helpBtn.addEventListener("focusout", function (e) {
+        var related = e.relatedTarget;
+        if (!related || !helpPanel.contains(related)) {
+          helpBtn.setAttribute("aria-expanded", "false");
+          helpPanel.hidden = true;
+        }
+      });
+      document.addEventListener("click", function (e) {
+        if (helpPanel && !helpPanel.contains(e.target) && e.target !== helpBtn) {
+          helpBtn.setAttribute("aria-expanded", "false");
+          helpPanel.hidden = true;
+        }
+      });
+      // Focusout/blur close behavior
+      helpPanel.addEventListener("focusout", function (e) {
+        if (!helpPanel.contains(e.relatedTarget) && e.relatedTarget !== helpBtn) {
+          helpBtn.setAttribute("aria-expanded", "false");
+          helpPanel.hidden = true;
+        }
+      });
     }
 
-    function syncUrl() {
-      var url = new URL(window.location.href);
-      if (checkbox.checked) {
-        url.searchParams.set("live", "on");
-      } else {
-        url.searchParams.delete("live");
-      }
-      window.history.replaceState({}, "", url.toString());
-    }
-
+    // --- Live toggle ---
     checkbox.addEventListener("change", function () {
-      syncUrl();
+      updateUrlLive(checkbox.checked);
       var label = checkbox.closest("label");
       label.classList.toggle("so-toggle--on", checkbox.checked);
       label.querySelector(".so-toggle__cadence").textContent = checkbox.checked
@@ -103,6 +113,193 @@
     checkbox
       .closest("label")
       .classList.toggle("so-toggle--on", checkbox.checked);
+  }
+
+  function fullFetch() {
+    if (inFlight) return;
+    inFlight = true;
+
+    if (refreshBtn) {
+      refreshBtn.textContent = "Refreshing\u2026";
+      refreshBtn.setAttribute("aria-busy", "true");
+      refreshBtn.disabled = true;
+    }
+
+    // Add loading class to range-bound zones
+    addLoadingClass(true);
+
+    var rangeParam = lastRange || readRangeFromUrl() || "15m";
+    fetch(
+      url + "?range=" + encodeURIComponent(rangeParam),
+      { headers: { Accept: "application/json" }, credentials: "same-origin" }
+    )
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data) {
+          lastFullSnapshot = data.snapshot || {};
+          lastFullChart = data.chart || {};
+          applyFullUpdate(data);
+          updateFreshness("Updated just now");
+        }
+      })
+      .catch(function () { /* drop silently */ })
+      .finally(function () {
+        inFlight = false;
+        addLoadingClass(false);
+        if (refreshBtn) {
+          refreshBtn.textContent = "Refresh data";
+          refreshBtn.setAttribute("aria-busy", "false");
+          refreshBtn.disabled = false;
+          refreshBtn.focus();
+        }
+      });
+  }
+
+  function tick() {
+    if (inFlight) return;
+    inFlight = true;
+    var rangeParam = lastRange || readRangeFromUrl() || "15m";
+    fetch(
+      url + "?range=" + encodeURIComponent(rangeParam) + "&tick=true",
+      { headers: { Accept: "application/json" }, credentials: "same-origin" }
+    )
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        if (data) applyTickUpdate(data);
+      })
+      .catch(function () { /* drop tick silently */ })
+      .finally(function () { inFlight = false; });
+  }
+
+  function applyFullUpdate(data) {
+    var snapshot = data.snapshot || {};
+    // Patch live-state values (Zone B)
+    patchZoneValues("live-state", snapshot);
+    // Patch throughput values (Zone C) — value nodes only, preserve suffix/range-copy
+    patchZoneValues("throughput", snapshot);
+    // Patch queue table (Zone E)
+    patchQueueTable(snapshot);
+    // Patch stability (Zone F)
+    patchStability(snapshot);
+    // Update chart (Zone D)
+    var chart = data.chart || {};
+    Object.keys(sparks).forEach(function (key) {
+      var series = chart[key];
+      if (Array.isArray(series)) sparks[key].render(series);
+    });
+    // Update range-copy nodes from server-provided label
+    if (data.range_label) {
+      updateRangeCopyFromLabel(data.range_label);
+    }
+  }
+
+  function applyTickUpdate(data) {
+    var snapshot = data.snapshot || {};
+    // Tick only patches live-state values (Zone B)
+    patchZoneValues("live-state", snapshot);
+    // chart is nil on tick — preserve last full-fetch chart/range state
+  }
+
+  function patchZoneValues(zone, snapshot) {
+    var zoneEl = document.querySelector('[data-so-zone="' + zone + '"]');
+    if (!zoneEl) return;
+    var valueEls = zoneEl.querySelectorAll("[data-so-card-value]");
+    valueEls.forEach(function (el) {
+      var key = el.getAttribute("data-so-card-value");
+      if (snapshot.hasOwnProperty(key)) {
+        var val = snapshot[key];
+        // Duration values arrive in seconds; display as milliseconds
+        if (key === "avg_duration_in_range" && val !== null && val !== undefined) {
+          var ms = Math.round(val * 1000);
+          el.textContent = formatValue(ms);
+          var suffixEl = el.parentElement.querySelector("[data-so-card-suffix]");
+          if (suffixEl) suffixEl.textContent = "ms";
+        } else {
+          el.textContent = formatValue(val);
+        }
+      }
+    });
+  }
+
+  function patchQueueTable(snapshot) {
+    var tableEl = document.querySelector('[data-so-zone="queue-table"]');
+    if (!tableEl) return;
+    var queues = snapshot.queues || {};
+    var performedByQueue = snapshot.performed_by_queue || {};
+    var failedByQueue = snapshot.failed_by_queue || {};
+
+    // Update live depth values
+    Object.keys(queues).forEach(function (qName) {
+      var el = tableEl.querySelector('[data-so-table-value="queue-depth-' + qName + '"]');
+      if (el) el.textContent = formatValue(queues[qName]);
+    });
+
+    // Update performed/failed in range
+    Object.keys(performedByQueue).forEach(function (qName) {
+      var el = tableEl.querySelector('[data-so-table-value="queue-performed-' + qName + '"]');
+      if (el) el.textContent = formatValue(performedByQueue[qName]);
+    });
+    Object.keys(failedByQueue).forEach(function (qName) {
+      var el = tableEl.querySelector('[data-so-table-value="queue-failed-' + qName + '"]');
+      if (el) el.textContent = formatValue(failedByQueue[qName]);
+    });
+  }
+
+  function patchStability(snapshot) {
+    // Stability is rendered server-side; tick does not update it.
+    // Full fetch re-renders via page or could patch, but we keep it simple.
+  }
+
+  function updateRangeCopyFromLabel(label) {
+    var els = document.querySelectorAll("[data-so-range-copy]");
+    els.forEach(function (el) { el.textContent = label; });
+  }
+
+  function updateFreshness(text) {
+    if (freshnessEl) freshnessEl.textContent = text;
+  }
+
+  function addLoadingClass(on) {
+    var zones = document.querySelectorAll(
+      '[data-so-zone="throughput"], [data-so-zone="chart"], [data-so-zone="queue-table"]'
+    );
+    zones.forEach(function (el) {
+      var section = el.closest(".so-dashboard-section") || el;
+      if (on) {
+        section.classList.add("is-loading");
+      } else {
+        section.classList.remove("is-loading");
+      }
+    });
+  }
+
+  function start() {
+    stop();
+    timerId = window.setInterval(tick, INTERVAL_SEC * 1000);
+  }
+
+  function stop() {
+    if (timerId !== null) {
+      window.clearInterval(timerId);
+      timerId = null;
+    }
+    inFlight = false;
+  }
+
+  function updateUrlRange(range) {
+    var urlObj = new URL(window.location.href);
+    urlObj.searchParams.set("range", range);
+    window.history.replaceState({}, "", urlObj.toString());
+  }
+
+  function updateUrlLive(isLive) {
+    var urlObj = new URL(window.location.href);
+    if (isLive) {
+      urlObj.searchParams.set("live", "on");
+    } else {
+      urlObj.searchParams.delete("live");
+    }
+    window.history.replaceState({}, "", urlObj.toString());
   }
 
   function collectSparks() {

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -21,14 +21,8 @@ module SolidObserver
     def poll_data
       range = QueueStats.parse_range(request_range_param, fallback: QueueStats::POLL_DEFAULT_RANGE)
       window = QueueStats.range_duration(range, fallback: QueueStats::POLL_DEFAULT_RANGE)
-
-      ChartBuffer.append(SolidQueue::ReadyExecution.count) if QueueStats.solid_queue_available?
-
-      render json: {
-        mode: persistence_mode? ? "persistence" : "realtime",
-        snapshot: QueueStats.snapshot_for_poll(range: range),
-        chart: QueueStats.chart_data(window: window)
-      }
+      append_chart_buffer
+      render json: tick_request? ? tick_payload : full_payload(range: range, window: window)
     end
 
     private
@@ -51,6 +45,35 @@ module SolidObserver
 
     def request_live_param
       request&.query_parameters&.[]("live") || request&.query_parameters&.[](:live)
+    end
+
+    def request_tick_param
+      request&.query_parameters&.[]("tick") || request&.query_parameters&.[](:tick)
+    end
+
+    def tick_request?
+      request_tick_param == "true"
+    end
+
+    def tick_payload
+      {
+        mode: persistence_mode? ? "persistence" : "realtime",
+        snapshot: QueueStats.snapshot_for_tick,
+        chart: nil
+      }
+    end
+
+    def full_payload(range:, window:)
+      {
+        mode: persistence_mode? ? "persistence" : "realtime",
+        snapshot: QueueStats.snapshot_for_poll(range: range),
+        chart: QueueStats.chart_data(window: window),
+        range_label: helpers.range_label(range)
+      }
+    end
+
+    def append_chart_buffer
+      ChartBuffer.append(SolidQueue::ReadyExecution.count) if QueueStats.solid_queue_available?
     end
   end
 end

--- a/app/helpers/solid_observer/dashboard_helper.rb
+++ b/app/helpers/solid_observer/dashboard_helper.rb
@@ -21,5 +21,19 @@ module SolidObserver
         format("%.1f,%.1f", point_x, point_y)
       }.join(" ")
     end
+
+    RANGE_LABELS = {
+      "15m" => "in last 15m",
+      "30m" => "in last 30m",
+      "1h" => "in last hour",
+      "7h" => "in last 7h",
+      "1d" => "in last day",
+      "7d" => "in last 7d",
+      "14d" => "in last 14d"
+    }.freeze
+
+    def range_label(range_key)
+      RANGE_LABELS.fetch(range_key, "in selected range")
+    end
   end
 end

--- a/app/models/solid_observer/queue_event.rb
+++ b/app/models/solid_observer/queue_event.rb
@@ -54,6 +54,22 @@ module SolidObserver
       (count.to_f / (window.to_f / 60.0)).round(1)
     end
 
+    def self.enqueued_count_last(duration)
+      by_event_type("job_enqueued").since(duration.ago).count
+    end
+
+    def self.avg_duration_last(duration)
+      by_event_type("job_completed").since(duration.ago).average(:duration).to_f
+    end
+
+    def self.count_by_queue_and_event_type(window:, event_type:)
+      since(window.ago)
+        .where(event_type: event_type)
+        .where.not(queue_name: nil)
+        .group(:queue_name)
+        .count
+    end
+
     def self.count_by_time_bucket(event_type:, window:, bucket_seconds:)
       context = build_bucket_context(window: window, bucket_seconds: bucket_seconds)
       return [] unless context

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SolidObserver — <%= content_for?(:title) ? yield(:title) : "Dashboard" %></title>
+  <title>SolidObserver - Dashboard</title>
   <%= csrf_meta_tags %>
   <style>
     :root {
@@ -15,7 +15,7 @@
       /* text */
       --so-text: #171717;
       --so-text-muted: #737373;
-      --so-text-subtle: #a3a3a3;
+      --so-text-subtle: #737373;
 
       /* lines */
       --so-border: #e5e5e5;
@@ -40,6 +40,12 @@
 
       /* type */
       --so-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+
+      /* SO-067 additions */
+      --so-focus-ring: rgba(37, 99, 235, 0.28);
+      --so-live-marker: var(--so-success);
+      --so-range-marker: var(--so-info);
+      --so-toolbar-gap: 0.75rem;
     }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -100,6 +106,56 @@
     .so-content { padding: 2rem; overflow-y: auto; }
     .so-content__header { margin-bottom: 1.5rem; }
     .so-content__header h1 { font-size: 1.375rem; font-weight: 500; }
+
+    /* SO-067 Dashboard layout */
+    .so-dashboard { max-width: 1120px; }
+    .so-dashboard-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: var(--so-toolbar-gap); margin-bottom: 1.5rem; }
+    .so-dashboard-toolbar__left { display: flex; align-items: center; gap: var(--so-toolbar-gap); }
+    .so-dashboard-toolbar__right { display: flex; align-items: center; gap: var(--so-toolbar-gap); margin-left: auto; }
+    .so-dashboard-section { margin-bottom: 2rem; }
+    .so-dashboard-section__header { display: flex; align-items: baseline; gap: 0.75rem; margin-bottom: 0.75rem; }
+    .so-dashboard-section__title { font-size: 0.875rem; font-weight: 600; color: var(--so-text); }
+    .so-dashboard-section__meta { font-size: 0.75rem; color: var(--so-text-muted); }
+    .so-dashboard-section__meta--idle,
+    .so-dashboard-section__meta--empty-range,
+    .so-dashboard-section__meta--empty-queue,
+    .so-dashboard-section__meta--empty-events { font-size: 0.8rem; color: var(--so-text-subtle); margin-top: 0.5rem; }
+
+    /* SO-067 Metric card anatomy — separated value/suffix/range-copy */
+    .so-metric { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.15rem; }
+    .so-metric__value { font-size: 1.625rem; font-weight: 600; color: var(--so-text); }
+    .so-metric__suffix { font-size: 0.75rem; color: var(--so-text-muted); }
+
+    /* SO-067 Toolbar controls */
+    .so-btn--refresh { font-size: 0.85rem; }
+    .so-btn--refresh[aria-busy="true"] { opacity: 0.6; pointer-events: none; }
+    .so-btn--help { font-size: 0.75rem; padding: 0.2rem 0.5rem; border: 1px solid var(--so-border); border-radius: var(--so-radius); background: var(--so-card-bg); color: var(--so-text-muted); cursor: pointer; }
+    .so-btn--help:hover { background: var(--so-surface-muted); }
+    .so-btn--help:focus-visible { outline: 2px solid var(--so-info); outline-offset: 2px; box-shadow: 0 0 0 3px var(--so-focus-ring); }
+    .so-help-panel { font-size: 0.8rem; color: var(--so-text-muted); padding: 0.5rem 0.75rem; border: 1px solid var(--so-border); border-radius: var(--so-radius); background: var(--so-card-bg); margin-top: 0.25rem; max-width: 420px; }
+    .so-toolbar-freshness { font-size: 0.75rem; color: var(--so-text-subtle); }
+
+    /* SO-067 Focus rings */
+    select:focus-visible,
+    .so-btn--refresh:focus-visible,
+    .so-toggle--pill input:focus-visible + .so-toggle__track,
+    .so-btn--help:focus-visible,
+    .so-stability__link:focus-visible {
+      outline: 2px solid var(--so-info);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 3px var(--so-focus-ring);
+    }
+
+    /* SO-067 Loading transition for range-bound zones */
+    .so-dashboard-section.is-loading,
+    .so-card--section.is-loading { opacity: 0.62; transition: opacity 140ms cubic-bezier(0.22, 1, 0.36, 1); }
+    @media (prefers-reduced-motion: reduce) {
+      .so-dashboard-section.is-loading,
+      .so-card--section.is-loading { transition: none; }
+    }
+
+    /* SO-067 sr-only utility */
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 
     .so-stat-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
     .so-chart-strip { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
@@ -290,10 +346,8 @@
     .so-toggle__label, .so-toggle__sep, .so-toggle__cadence { font-size: 0.85rem; color: var(--so-text-muted); }
     .so-toggle--on .so-toggle__label, .so-toggle--on .so-toggle__cadence { color: var(--so-text); }
     .so-toggle__dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--so-success); opacity: 0; }
-    .so-toggle--on .so-toggle__dot { opacity: 1; animation: so-pulse 1.5s ease-in-out infinite; }
-    @keyframes so-pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
+    .so-toggle--on .so-toggle__dot { opacity: 1; }
     @media (prefers-reduced-motion: reduce) {
-      .so-toggle--on .so-toggle__dot { animation: none; opacity: 1; }
       .so-toggle__track, .so-toggle__thumb { transition: none; }
     }
 
@@ -353,6 +407,13 @@
 
     .so-card li + li { margin-top: 0.45rem; }
 
+    @media (max-width: 960px) {
+      .so-dashboard-toolbar { flex-direction: column; align-items: stretch; }
+      .so-dashboard-toolbar__left, .so-dashboard-toolbar__right { margin-left: 0; }
+      .so-stat-cards { grid-template-columns: repeat(auto-fit, minmax(156px, 1fr)); }
+      .so-stability { flex-wrap: wrap; }
+    }
+
     @media (max-width: 768px) {
       .so-layout { grid-template-columns: 1fr; }
       .so-sidebar { position: relative; padding: 0.75rem 0; border-right: none; border-bottom: 1px solid var(--so-border); }
@@ -383,7 +444,8 @@
       </div>
     </aside>
 
-    <main class="so-content">
+    <main class="so-content" aria-labelledby="so-main-heading">
+      <h1 class="sr-only" id="so-main-heading">Dashboard</h1>
       <% if flash[:notice] %>
         <div class="so-flash so-flash--notice"><%= flash[:notice] %></div>
       <% end %>

--- a/app/views/solid_observer/dashboard/_chart.html.erb
+++ b/app/views/solid_observer/dashboard/_chart.html.erb
@@ -1,7 +1,7 @@
-<div class="so-chart-strip" data-so-chart>
+<div class="so-chart-strip" data-so-zone="chart" data-so-chart>
   <% if SolidObserver.config.persistence_mode? %>
     <figure class="so-spark" data-so-spark="performed">
-      <figcaption class="so-spark__label">Performed/min</figcaption>
+      <figcaption class="so-spark__label">Performed/min <span data-so-range-copy><%= range_label(local_assigns[:range] || "15m") %></span></figcaption>
       <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
         <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
         <polyline class="so-spark__line" points="<%= spark_points(@chart[:performed]) %>"/>
@@ -9,7 +9,7 @@
       <span class="so-spark__value" data-so-spark-value><%= @chart[:performed].last&.dig(:v) || "—" %></span>
     </figure>
     <figure class="so-spark" data-so-spark="failed">
-      <figcaption class="so-spark__label">Failed/min</figcaption>
+      <figcaption class="so-spark__label">Failed/min <span data-so-range-copy><%= range_label(local_assigns[:range] || "15m") %></span></figcaption>
       <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
         <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
         <polyline class="so-spark__line" points="<%= spark_points(@chart[:failed]) %>"/>

--- a/app/views/solid_observer/dashboard/_live_state.html.erb
+++ b/app/views/solid_observer/dashboard/_live_state.html.erb
@@ -1,0 +1,20 @@
+<%# Zone B: Right now — live state cards %>
+<% if stats[:available] %>
+  <div class="so-stat-cards" data-so-zone="live-state">
+    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: stats[:ready], data_key: "ready" %>
+    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: stats[:scheduled], data_key: "scheduled" %>
+    <%= render "solid_observer/shared/stat_card", label: "In-flight", subtitle: "in progress", value: stats[:claimed], data_key: "claimed" %>
+    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: stats[:workers], data_key: "workers" %>
+    <%= render "solid_observer/shared/stat_card", label: "Pending failures", subtitle: "awaiting retry", value: stats[:failed], data_key: "failed" %>
+  </div>
+  <% if stats[:ready].to_i.zero? && stats[:scheduled].to_i.zero? && stats[:claimed].to_i.zero? && stats[:failed].to_i.zero? %>
+    <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">Queue idle right now. No ready, scheduled, in-flight, or pending-failure work is currently visible.</p>
+  <% end %>
+<% else %>
+  <div class="so-card">
+    <div class="so-empty">
+      <div class="so-empty__icon">&#9888;&#65039;</div>
+      <div>SolidQueue is not available</div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/solid_observer/dashboard/_queue_table.html.erb
+++ b/app/views/solid_observer/dashboard/_queue_table.html.erb
@@ -1,0 +1,34 @@
+<%# Zone E: Per-queue table with live depth and range throughput %>
+<% if persistence_mode? && stats[:available] %>
+  <div class="so-card so-card--section" data-so-zone="queue-table">
+    <div class="so-card__label">Queue throughput</div>
+    <% queues = stats[:queues] || {} %>
+    <% performed_by_queue = stats[:performed_by_queue] || {} %>
+    <% failed_by_queue = stats[:failed_by_queue] || {} %>
+    <% all_queue_names = (queues.keys | performed_by_queue.keys | failed_by_queue.keys).sort %>
+    <% if all_queue_names.any? %>
+      <table class="so-table so-table--card">
+        <thead>
+          <tr>
+            <th>Queue</th>
+            <th>Live depth</th>
+            <th>Performed <span data-so-range-copy><%= range_label(range) %></span></th>
+            <th>Failed <span data-so-range-copy><%= range_label(range) %></span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% all_queue_names.each do |queue_name| %>
+            <tr>
+              <td><%= queue_name %></td>
+              <td data-so-table-value="queue-depth-<%= queue_name %>"><%= number_with_delimiter(queues[queue_name].to_i) %></td>
+              <td data-so-table-value="queue-performed-<%= queue_name %>"><%= number_with_delimiter(performed_by_queue[queue_name].to_i) %></td>
+              <td data-so-table-value="queue-failed-<%= queue_name %>"><%= number_with_delimiter(failed_by_queue[queue_name].to_i) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-queue">No queue activity in this range. Live depth still shows current waiting work when present.</p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/solid_observer/dashboard/_right_now.html.erb
+++ b/app/views/solid_observer/dashboard/_right_now.html.erb
@@ -1,19 +1,3 @@
-<% if stats[:available] %>
-  <div class="so-stat-cards">
-    <%= render "solid_observer/shared/stat_card", label: "Ready", subtitle: "queued", value: stats[:ready], data_key: "ready" %>
-    <%= render "solid_observer/shared/stat_card", label: "Scheduled", subtitle: "future runs", value: stats[:scheduled], data_key: "scheduled" %>
-    <%= render "solid_observer/shared/stat_card", label: "Claimed", subtitle: "in progress", value: stats[:claimed], data_key: "claimed" %>
-    <%= render "solid_observer/shared/stat_card", label: "Workers", subtitle: "active processes", value: stats[:workers], data_key: "workers" %>
-    <%= render "solid_observer/shared/stat_card", label: "Failed", subtitle: "awaiting retry", value: stats[:failed], data_key: "failed" %>
-    <% if SolidObserver.config.persistence_mode? %>
-      <%= render "solid_observer/shared/stat_card", label: "Enqueue rate", subtitle: "jobs/min", value: stats[:enqueue_rate_per_min], data_key: "enqueue_rate_per_min" %>
-    <% end %>
-  </div>
-<% else %>
-  <div class="so-card">
-    <div class="so-empty">
-      <div class="so-empty__icon">⚠️</div>
-      <div>SolidQueue is not available</div>
-    </div>
-  </div>
-<% end %>
+<%# Legacy partial — Zone B/C are now served by _live_state and _throughput partials.
+    This partial is retained for compatibility only and must not be the combined Zone B/C container. %>
+<%= render "live_state", stats: stats %>

--- a/app/views/solid_observer/dashboard/_throughput.html.erb
+++ b/app/views/solid_observer/dashboard/_throughput.html.erb
@@ -1,0 +1,32 @@
+<%# Zone C: Throughput in selected range %>
+<% if persistence_mode? && stats[:available] %>
+  <div class="so-stat-cards" data-so-zone="throughput">
+    <div class="so-card so-metric">
+      <div class="so-card__label">Performed</div>
+      <div class="so-metric__value" data-so-card-value="performed_in_range"><%= number_with_delimiter(stats[:performed_in_range].to_i) %></div>
+      <span class="so-metric__suffix" data-so-card-suffix>jobs</span>
+      <div class="so-card__subtitle" data-so-range-copy><%= range_label(range) %></div>
+    </div>
+    <div class="so-card so-metric">
+      <div class="so-card__label">Failed</div>
+      <div class="so-metric__value" data-so-card-value="failed_in_range"><%= number_with_delimiter(stats[:failed_in_range].to_i) %></div>
+      <span class="so-metric__suffix" data-so-card-suffix>jobs</span>
+      <div class="so-card__subtitle" data-so-range-copy><%= range_label(range) %></div>
+    </div>
+    <div class="so-card so-metric">
+      <div class="so-card__label">Enqueued</div>
+      <div class="so-metric__value" data-so-card-value="enqueued_in_range"><%= number_with_delimiter(stats[:enqueued_in_range].to_i) %></div>
+      <span class="so-metric__suffix" data-so-card-suffix>jobs</span>
+      <div class="so-card__subtitle" data-so-range-copy><%= range_label(range) %></div>
+    </div>
+    <div class="so-card so-metric">
+      <div class="so-card__label">Avg duration</div>
+      <div class="so-metric__value" data-so-card-value="avg_duration_in_range"><%= stats[:avg_duration_in_range] > 0 ? number_with_delimiter((stats[:avg_duration_in_range] * 1000).round) : "0" %></div>
+      <span class="so-metric__suffix" data-so-card-suffix>ms</span>
+      <div class="so-card__subtitle" data-so-range-copy><%= range_label(range) %></div>
+    </div>
+  </div>
+  <% if stats[:performed_in_range].to_i.zero? && stats[:failed_in_range].to_i.zero? && stats[:enqueued_in_range].to_i.zero? %>
+    <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-range"><%= "No throughput #{range_label(range).sub('in ', '')}".html_safe %>. Jobs may still be waiting right now; this row only counts completed queue events in the selected range.</p>
+  <% end %>
+<% end %>

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -1,89 +1,111 @@
 <% content_for :title, "Dashboard" %>
 
-<div class="so-content__header">
-  <h1>Dashboard</h1>
-</div>
-
-<form method="get" action="<%= root_path %>" class="so-filters" data-turbo-frame="_top"
-      data-so-live>
-  <label for="so-range" class="so-card__label so-filters__label">Range</label>
-  <select id="so-range" name="range" onchange="this.form.requestSubmit()">
-    <% SolidObserver::QueueStats::RANGES.each_key do |key| %>
-      <option value="<%= key %>" <%= "selected" if key == @range %>><%= key %></option>
-    <% end %>
-  </select>
-  <label class="so-toggle so-toggle--pill <%= "so-toggle--on" if @live %>">
-    <input type="checkbox" name="live" value="on" <%= "checked" if @live %>>
-    <span class="so-toggle__track" aria-hidden="true">
-      <span class="so-toggle__thumb"></span>
-    </span>
-    <span class="so-toggle__label">Live</span>
-    <span class="so-toggle__sep" aria-hidden="true"> · </span>
-    <span class="so-toggle__cadence" aria-live="polite"><%= @live ? "5s" : "off" %></span>
-    <span class="so-toggle__dot" aria-hidden="true"></span>
-  </label>
-  <noscript><button type="submit" class="so-btn">Apply</button></noscript>
-</form>
-
-<% if @stats[:available] %>
-  <%= render "chart" %>
-<% end %>
-
-<%= render "right_now", stats: @stats %>
-
-<% if @stats[:available] && @stats[:queues].any? %>
-  <div class="so-card so-card--section">
-    <div class="so-card__label">Queue Depths</div>
-    <table class="so-table so-table--card">
-      <thead>
-        <tr>
-          <th>Queue</th>
-          <th>Jobs</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @stats[:queues].each do |queue_name, count| %>
-          <tr>
-            <td><%= queue_name %></td>
-            <td><%= number_with_delimiter(count) %></td>
-          </tr>
+<div class="so-dashboard">
+  <%# Zone A: Toolbar — range selector, Refresh, Live toggle, help disclosure %>
+  <div class="so-dashboard-toolbar" data-so-live>
+    <div class="so-dashboard-toolbar__left">
+      <label for="so-range" class="so-card__label so-filters__label">Range</label>
+      <select id="so-range" name="range" data-so-range-select>
+        <% SolidObserver::QueueStats::RANGES.each_key do |key| %>
+          <option value="<%= key %>" <%= "selected" if key == @range %>><%= key %></option>
         <% end %>
-      </tbody>
-    </table>
+      </select>
+      <button type="button" class="so-btn so-btn--refresh" data-so-refresh aria-busy="false">Refresh data</button>
+      <span class="so-toolbar-freshness" data-so-freshness aria-live="polite"></span>
+    </div>
+    <div class="so-dashboard-toolbar__right">
+      <label class="so-toggle so-toggle--pill <%= "so-toggle--on" if @live %>">
+        <input type="checkbox" name="live" value="on" <%= "checked" if @live %> data-so-live-toggle>
+        <span class="so-toggle__track" aria-hidden="true">
+          <span class="so-toggle__thumb"></span>
+        </span>
+        <span class="so-toggle__label">Live</span>
+        <span class="so-toggle__sep" aria-hidden="true"> · </span>
+        <span class="so-toggle__cadence" aria-live="polite"><%= @live ? "5s" : "off" %></span>
+        <span class="so-toggle__dot" aria-hidden="true"></span>
+      </label>
+      <button type="button" class="so-btn so-btn--help" data-so-help-btn aria-expanded="false" aria-controls="so-help-panel">(?)
+      </button>
+      <div id="so-help-panel" class="so-help-panel" data-so-help-panel hidden>
+        <p>Live mode polls every 5 seconds for current queue state. Throughput and chart data update only on range change or manual refresh.</p>
+      </div>
+    </div>
   </div>
-<% end %>
 
-<% if @stats[:available] && persistence_mode? %>
-  <section class="so-stability">
-    <span class="so-stability__label">Stability</span>
-    <%= stability_badge(@stats) %>
-    <span class="so-stability__detail"><%= stability_detail(@stats) %></span>
-    <%= link_to "View failures →", events_path(event_type: "job_failed"), class: "so-stability__link" %>
+  <%# Zone B: Right now — live state %>
+  <section class="so-dashboard-section" aria-labelledby="so-live-state-heading">
+    <div class="so-dashboard-section__header">
+      <h2 class="so-dashboard-section__title" id="so-live-state-heading">Right now</h2>
+      <span class="so-dashboard-section__meta"><span class="so-badge so-badge--pill so-badge--success"><svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true"><circle r="3" cx="3" cy="3" fill="var(--so-live-marker, var(--so-success))"/></svg></span> current</span>
+    </div>
+    <%= render "live_state", stats: @stats %>
   </section>
 
-  <% if @recent_events.any? %>
-    <div class="so-card">
-      <div class="so-card__label">Recent Events</div>
-      <table class="so-table so-table--card">
-        <thead>
-          <tr>
-            <th>Event</th>
-            <th>Job Class</th>
-            <th>Queue</th>
-            <th>Time</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @recent_events.each do |event| %>
-            <tr>
-              <td><%= event.event_type.humanize %></td>
-              <td><%= event.job_class %></td>
-              <td><%= event.queue_name %></td>
-              <td><%= time_ago_in_words(event.recorded_at) %> ago</td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+  <%# Zone C: Throughput in selected range %>
+  <% if persistence_mode? && @stats[:available] %>
+    <section class="so-dashboard-section" aria-labelledby="so-throughput-heading">
+      <div class="so-dashboard-section__header">
+        <h2 class="so-dashboard-section__title" id="so-throughput-heading">Throughput in selected range</h2>
+        <span class="so-dashboard-section__meta"><span class="so-badge so-badge--pill so-badge--info"><svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true"><circle r="3" cx="3" cy="3" fill="var(--so-range-marker, var(--so-info))"/></svg></span> <span data-so-range-copy><%= range_label(@range) %></span></span>
+      </div>
+      <%= render "throughput", stats: @stats, range: @range %>
+    </section>
   <% end %>
-<% end %>
+
+  <%# Zone D: Charts %>
+  <% if @stats[:available] %>
+    <section class="so-dashboard-section" aria-labelledby="so-chart-heading">
+      <div class="so-dashboard-section__header">
+        <h2 class="so-dashboard-section__title" id="so-chart-heading">Charts</h2>
+      </div>
+      <%= render "chart", range: @range %>
+    </section>
+  <% end %>
+
+  <%# Zone E: Per-queue table %>
+  <%= render "queue_table", stats: @stats, range: @range %>
+
+  <%# Zone F: Stability strip %>
+  <% if @stats[:available] && persistence_mode? %>
+    <section class="so-stability" data-so-zone="stability" aria-labelledby="so-stability-heading">
+      <span class="so-stability__label" id="so-stability-heading">Stability</span>
+      <%= stability_badge(@stats) %>
+      <span class="so-stability__detail"><%= stability_detail(@stats) %></span>
+      <%= link_to "View failures →", events_path(event_type: "job_failed"), class: "so-stability__link" %>
+    </section>
+  <% end %>
+
+  <%# Zone G: Recent Events %>
+  <% if @stats[:available] && persistence_mode? %>
+    <% if defined?(@recent_events) && @recent_events.present? %>
+      <div class="so-card">
+        <div class="so-card__label">Recent Events</div>
+        <table class="so-table so-table--card">
+          <thead>
+            <tr>
+              <th>Event</th>
+              <th>Job Class</th>
+              <th>Queue</th>
+              <th>Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @recent_events.each do |event| %>
+              <tr>
+                <td><%= event.event_type.humanize %></td>
+                <td><%= event.job_class %></td>
+                <td><%= event.queue_name %></td>
+                <td><%= time_ago_in_words(event.recorded_at) %> ago</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <div class="so-card">
+        <div class="so-card__label">Recent Events</div>
+        <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-events">No recent events yet. Queue activity will appear here after jobs are enqueued, performed, or failed.</p>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/solid_observer/queue_stats.rb
+++ b/lib/solid_observer/queue_stats.rb
@@ -24,6 +24,13 @@ module SolidObserver
       failed: 0,
       enqueue_rate_per_min: nil
     }.freeze
+    TICK_EMPTY_SNAPSHOT = {
+      ready: 0,
+      scheduled: 0,
+      claimed: 0,
+      workers: 0,
+      failed: 0
+    }.freeze
     BUCKET_RULES = [
       [30.minutes.to_i, 30],
       [2.hours.to_i, 60],
@@ -37,6 +44,10 @@ module SolidObserver
 
       def snapshot_for_poll(range:)
         new.snapshot_for_poll(parse_range(range, fallback: POLL_DEFAULT_RANGE))
+      end
+
+      def snapshot_for_tick
+        new.snapshot_for_tick
       end
 
       def chart_data(window: 15.minutes)
@@ -73,16 +84,40 @@ module SolidObserver
       return empty_snapshot unless klass.solid_queue_available?
 
       window = klass.range_duration(range, fallback: POLL_DEFAULT_RANGE)
-      {
+      persistence = SolidObserver.config.persistence_mode?
+      base = {
         ready: ready_count,
         scheduled: scheduled_count,
         claimed: claimed_count,
         workers: active_workers_count,
         failed: failed_count,
-        enqueue_rate_per_min: SolidObserver.config.persistence_mode? ? QueueEvent.enqueue_rate_per_minute(window: window) : nil
+        enqueue_rate_per_min: persistence ? QueueEvent.enqueue_rate_per_minute(window: window) : nil
       }
+
+      if persistence
+        base.merge!(throughput_stats(range))
+        base[:queues] = queue_depths
+        base[:performed_by_queue] = QueueEvent.count_by_queue_and_event_type(window: window, event_type: "job_completed")
+        base[:failed_by_queue] = QueueEvent.count_by_queue_and_event_type(window: window, event_type: "job_failed")
+      end
+
+      base
     rescue
       empty_snapshot
+    end
+
+    def snapshot_for_tick
+      return TICK_EMPTY_SNAPSHOT unless self.class.solid_queue_available?
+
+      {
+        ready: ready_count,
+        scheduled: scheduled_count,
+        claimed: claimed_count,
+        workers: active_workers_count,
+        failed: failed_count
+      }
+    rescue
+      TICK_EMPTY_SNAPSHOT
     end
 
     # :reek:TooManyStatements
@@ -118,7 +153,12 @@ module SolidObserver
       base = snapshot_base
       return base unless SolidObserver.config.persistence_mode? && range_key
 
-      base.merge(throughput_stats(range_key)).merge(range: range_key)
+      duration = self.class.range_duration(range_key)
+      base.merge(throughput_stats(range_key)).merge(
+        range: range_key,
+        performed_by_queue: QueueEvent.count_by_queue_and_event_type(window: duration, event_type: "job_completed"),
+        failed_by_queue: QueueEvent.count_by_queue_and_event_type(window: duration, event_type: "job_failed")
+      )
     end
 
     def snapshot_base
@@ -138,6 +178,8 @@ module SolidObserver
       {
         performed_in_range: QueueEvent.performed_count_last(duration),
         failed_in_range: QueueEvent.failed_count_last(duration),
+        enqueued_in_range: QueueEvent.enqueued_count_last(duration),
+        avg_duration_in_range: QueueEvent.avg_duration_last(duration),
         # Stability indicator still uses dedicated rolling windows independent of selected range.
         failed_last_24h: QueueEvent.failed_count_last(24.hours),
         failed_last_hour: QueueEvent.failed_count_last(1.hour),

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -5,9 +5,10 @@ require "feature_helper"
 RSpec.describe "Dashboard", type: :feature do
   before { SolidObserver.config.storage_mode = :persistence }
 
-  it "displays the Dashboard heading" do
+  it "has an accessible sr-only h1 instead of visible h1" do
     visit "/solid_observer"
-    expect(page).to have_css("h1", text: "Dashboard")
+    expect(page).to have_css("h1.sr-only", text: "Dashboard")
+    expect(page).not_to have_css(".so-content__header h1", text: "Dashboard")
   end
 
   it "shows the SolidObserver logo in the sidebar" do
@@ -29,15 +30,19 @@ RSpec.describe "Dashboard", type: :feature do
         claimed: 2,
         failed: 1,
         workers: 3,
-        queues: {},
+        queues: {"default" => 8, "mailers" => 2},
         available: true,
         range: "15m",
         performed_in_range: 1200,
         failed_in_range: 9,
+        enqueued_in_range: 1500,
+        avg_duration_in_range: 1.2,
         failed_last_24h: 9,
         failed_last_hour: 0,
         latest_failure_at: nil,
-        enqueue_rate_per_min: 4.6
+        enqueue_rate_per_min: 4.6,
+        performed_by_queue: {"default" => 1100, "mailers" => 100},
+        failed_by_queue: {"default" => 8, "mailers" => 1}
       )
       allow(SolidObserver::QueueEvent).to receive(:recent).and_return([])
       allow(SolidObserver::QueueEvent).to receive(:recent_failures).and_return([])
@@ -61,120 +66,133 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("Persistence")
     end
 
-    it "shows Enqueue rate card in persistence mode" do
+    it "renders Zone B live-state cards with data-so-zone attribute" do
       visit "/solid_observer"
-
-      expect(page).to have_css('[data-so-card-value="enqueue_rate_per_min"]', text: "4.6")
-      expect(page).to have_content("jobs/min")
+      expect(page).to have_css('[data-so-zone="live-state"]')
+      expect(page).to have_css('[data-so-card-value="ready"]')
+      expect(page).to have_css('[data-so-card-value="scheduled"]')
+      expect(page).to have_css('[data-so-card-value="claimed"]')
+      expect(page).to have_css('[data-so-card-value="workers"]')
+      expect(page).to have_css('[data-so-card-value="failed"]')
     end
 
-    it "does not render turbo frame wrappers" do
+    it "renders Zone C throughput cards with separated value and suffix nodes" do
       visit "/solid_observer"
-
-      expect(page).not_to have_css("turbo-frame")
+      expect(page).to have_css('[data-so-zone="throughput"]')
+      expect(page).to have_css('[data-so-card-value="performed_in_range"]')
+      expect(page).to have_css('[data-so-card-value="failed_in_range"]')
+      expect(page).to have_css('[data-so-card-value="enqueued_in_range"]')
+      expect(page).to have_css('[data-so-card-value="avg_duration_in_range"]')
+      expect(page).to have_css(".so-metric__suffix", text: "jobs")
+      expect(page).to have_css("[data-so-range-copy]", text: "in last 15m")
+      # Avg duration value node contains only a number; suffix is "ms"
+      avg_card = find('[data-so-card-value="avg_duration_in_range"]')
+      expect(avg_card.text).to match(/\A[\d,]+\z/)
+      expect(page).to have_css("[data-so-card-suffix]", text: "ms")
     end
 
-    it "keeps selected range for a valid range param" do
-      visit "/solid_observer?range=15m"
-
-      expect(page).to have_select("Range", selected: "15m")
-    end
-
-    it "falls back selected range for an invalid range param" do
-      visit "/solid_observer?range=bogus"
-
-      expect(page).to have_select("Range", selected: "15m")
-    end
-
-    it "shows the Stability indicator with a click-through to failures" do
+    it "renders Zone E per-queue table with live depth and range columns" do
       visit "/solid_observer"
+      expect(page).to have_css('[data-so-zone="queue-table"]')
+      expect(page).to have_content("Queue throughput")
+      expect(page).to have_css("th", text: "Queue")
+      expect(page).to have_css("th", text: "Live depth")
+      expect(page).to have_content("default")
+      expect(page).to have_content("mailers")
+    end
 
+    it "renders Zone F Stability strip with badge and detail" do
+      visit "/solid_observer"
       expect(page).to have_content("Stability")
       expect(page).to have_link("View failures", href: "/solid_observer/events?event_type=job_failed")
     end
 
-    it "renders the Live toggle unconditionally regardless of config" do
+    it "renders the Live toggle with correct markup" do
       visit "/solid_observer"
-
-      expect(page).to have_css('input[type="checkbox"][name="live"]')
+      expect(page).to have_css('input[data-so-live-toggle][type="checkbox"][name="live"]')
     end
 
     it "renders checked Live toggle as pill switch when enabled in params" do
       visit "/solid_observer?live=on"
 
-      expect(page).to have_css("form[data-so-live]")
-      expect(page).to have_css('input[type="checkbox"][name="live"][value="on"][checked]')
+      expect(page).to have_css("[data-so-live]")
+      expect(page).to have_css('input[data-so-live-toggle][type="checkbox"][name="live"][value="on"][checked]')
       expect(page).to have_css("label.so-toggle.so-toggle--pill.so-toggle--on")
       expect(page).to have_css(".so-toggle__label", text: "Live")
       expect(page).to have_css(".so-toggle__cadence", text: "5s")
       expect(page).to have_css(".so-toggle__dot")
     end
 
-    it "renders pill toggle with correct markup and a11y attributes" do
+    it "renders the range selector with data-so-range-select" do
       visit "/solid_observer"
-
-      expect(page).to have_css("label.so-toggle.so-toggle--pill")
-      expect(page).not_to have_css("label.so-toggle--on")
-      expect(page).to have_css(".so-toggle__label", text: "Live")
-      expect(page).to have_css(".so-toggle__sep", text: "·")
-      expect(page).to have_css(".so-toggle__cadence", text: "off")
-      expect(page).to have_css('.so-toggle__cadence[aria-live="polite"]')
-      expect(page).to have_css('.so-toggle__track[aria-hidden="true"]')
-      expect(page).to have_css('.so-toggle__sep[aria-hidden="true"]')
-      expect(page).to have_css('.so-toggle__dot[aria-hidden="true"]')
+      expect(page).to have_css("[data-so-range-select]")
     end
 
-    it "renders the chart strip with three sparkline figures" do
+    it "renders Refresh data button" do
       visit "/solid_observer"
+      expect(page).to have_css("[data-so-refresh]", text: "Refresh data")
+    end
 
+    it "renders help button with aria-expanded" do
+      visit "/solid_observer"
+      expect(page).to have_css("[data-so-help-btn][aria-expanded]")
+    end
+
+    it "renders chart strip with three sparkline figures" do
+      visit "/solid_observer"
       expect(page).to have_css('[data-so-spark="performed"]')
       expect(page).to have_css('[data-so-spark="failed"]')
       expect(page).to have_css('[data-so-spark="ready"]')
     end
 
-    it "renders each sparkline figure with baseline and polyline" do
-      visit "/solid_observer"
-
-      within('[data-so-spark="performed"]') do
-        expect(page).to have_css(".so-spark__baseline")
-        expect(page).to have_css(".so-spark__line")
-      end
-      within('[data-so-spark="failed"]') do
-        expect(page).to have_css(".so-spark__baseline")
-        expect(page).to have_css(".so-spark__line")
-      end
-      within('[data-so-spark="ready"]') do
-        expect(page).to have_css(".so-spark__baseline")
-        expect(page).to have_css(".so-spark__line")
-      end
-    end
-
-    it "renders card value elements with data-so-card-value attributes" do
-      visit "/solid_observer"
-
-      expect(page).to have_css('[data-so-card-value="ready"]')
-      expect(page).to have_css('[data-so-card-value="scheduled"]')
-      expect(page).to have_css('[data-so-card-value="claimed"]')
-      expect(page).to have_css('[data-so-card-value="workers"]')
-      expect(page).to have_css('[data-so-card-value="failed"]')
-      expect(page).to have_css('[data-so-card-value="enqueue_rate_per_min"]')
-    end
-
     it "renders chart polylines with non-empty points on first paint" do
       visit "/solid_observer"
-
       within('[data-so-spark="performed"]') do
         polyline = find(".so-spark__line")
         expect(polyline["points"]).not_to be_empty
       end
-      within('[data-so-spark="failed"]') do
-        polyline = find(".so-spark__line")
-        expect(polyline["points"]).not_to be_empty
-      end
-      within('[data-so-spark="ready"]') do
-        polyline = find(".so-spark__line")
-        expect(polyline["points"]).not_to be_empty
-      end
+    end
+
+    it "keeps selected range for a valid range param" do
+      visit "/solid_observer?range=15m"
+      expect(page).to have_select("Range", selected: "15m")
+    end
+
+    it "falls back selected range for an invalid range param" do
+      visit "/solid_observer?range=bogus"
+      expect(page).to have_select("Range", selected: "15m")
+    end
+
+    it "does not render turbo frame wrappers" do
+      visit "/solid_observer"
+      expect(page).not_to have_css("turbo-frame")
+    end
+
+    it "renders Zone A toolbar with left and right groups" do
+      visit "/solid_observer"
+      expect(page).to have_css(".so-dashboard-toolbar__left")
+      expect(page).to have_css(".so-dashboard-toolbar__right")
+    end
+
+    it "renders Zone B section heading" do
+      visit "/solid_observer"
+      expect(page).to have_css("h2", text: "Right now")
+    end
+
+    it "renders Zone C section heading with range subtitle" do
+      visit "/solid_observer"
+      expect(page).to have_css("h2", text: "Throughput in selected range")
+    end
+
+    it "renders Zone D chart section" do
+      visit "/solid_observer"
+      expect(page).to have_css('[data-so-zone="chart"]')
+      expect(page).to have_css("h2", text: "Charts")
+    end
+
+    it "renders freshness text area" do
+      visit "/solid_observer"
+      expect(page).to have_css("[data-so-freshness]")
     end
   end
 
@@ -197,7 +215,7 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_content("Real-time")
     end
 
-    it "does not show Enqueue rate card or Stability in realtime mode" do
+    it "does not show throughput cards or Stability in realtime mode" do
       allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
         ready: 1,
         scheduled: 0,
@@ -211,11 +229,11 @@ RSpec.describe "Dashboard", type: :feature do
 
       visit "/solid_observer"
 
-      expect(page).not_to have_css('[data-so-card-value="enqueue_rate_per_min"]')
+      expect(page).not_to have_css('[data-so-zone="throughput"]')
       expect(page).not_to have_content("Stability")
     end
 
-    it "renders five-card grid without turbo frames in realtime mode" do
+    it "renders live-state cards in realtime mode" do
       allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
         ready: 1,
         scheduled: 0,
@@ -235,7 +253,6 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_css('[data-so-card-value="claimed"]')
       expect(page).to have_css('[data-so-card-value="workers"]')
       expect(page).to have_css('[data-so-card-value="failed"]')
-      expect(page).not_to have_css('[data-so-card-value="enqueue_rate_per_min"]')
       expect(page).to have_select("Range", selected: "15m")
     end
 
@@ -256,27 +273,6 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_css('[data-so-spark="ready"]')
       expect(page).not_to have_css('[data-so-spark="performed"]')
       expect(page).not_to have_css('[data-so-spark="failed"]')
-    end
-
-    it "renders card value elements with data-so-card-value attributes in realtime mode" do
-      allow(SolidObserver::QueueStats).to receive(:snapshot).and_return(
-        ready: 1,
-        scheduled: 0,
-        claimed: 0,
-        failed: 0,
-        workers: 1,
-        queues: {},
-        available: true,
-        range: "15m"
-      )
-
-      visit "/solid_observer"
-
-      expect(page).to have_css('[data-so-card-value="ready"]')
-      expect(page).to have_css('[data-so-card-value="scheduled"]')
-      expect(page).to have_css('[data-so-card-value="claimed"]')
-      expect(page).to have_css('[data-so-card-value="workers"]')
-      expect(page).to have_css('[data-so-card-value="failed"]')
     end
   end
 

--- a/spec/models/solid_observer/queue_event_spec.rb
+++ b/spec/models/solid_observer/queue_event_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "SolidObserver::QueueEvent" do
         t.string :event_type, null: false, limit: 50
         t.string :job_class, limit: 100
         t.string :queue_name, limit: 50
+        t.float :duration
         t.datetime :recorded_at, null: false
       end
     end
@@ -103,6 +104,7 @@ RSpec.describe "SolidObserver::QueueEvent" do
         t.string :event_type, null: false, limit: 50
         t.string :job_class, limit: 100
         t.string :queue_name, limit: 50
+        t.float :duration
         t.datetime :recorded_at, null: false
       end
     end
@@ -220,6 +222,64 @@ RSpec.describe "SolidObserver::QueueEvent" do
               bucket_seconds: 60
             )
           end
+        end
+      end
+    end
+
+    describe ".enqueued_count_last" do
+      it "counts enqueued events within the provided window" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_enqueued", recorded_at: 10.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_enqueued", recorded_at: 2.hours.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", recorded_at: 5.minutes.ago)
+
+          expect(SolidObserver::QueueEvent.enqueued_count_last(1.hour)).to eq(1)
+        end
+      end
+    end
+
+    describe ".avg_duration_last" do
+      it "returns average duration of completed events in the window" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", duration: 2.5, recorded_at: 5.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", duration: 7.5, recorded_at: 10.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", duration: nil, recorded_at: 15.minutes.ago)
+
+          expect(SolidObserver::QueueEvent.avg_duration_last(1.hour)).to eq(5.0)
+        end
+      end
+
+      it "returns 0.0 when there are no completed events" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_failed", duration: 1.0, recorded_at: 5.minutes.ago)
+
+          expect(SolidObserver::QueueEvent.avg_duration_last(1.hour)).to eq(0.0)
+        end
+      end
+    end
+
+    describe ".count_by_queue_and_event_type" do
+      it "returns counts grouped by queue name for the given event type" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", queue_name: "default", recorded_at: 5.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", queue_name: "default", recorded_at: 10.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", queue_name: "mailers", recorded_at: 5.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", queue_name: nil, recorded_at: 5.minutes.ago)
+          SolidObserver::QueueEvent.create!(event_type: "job_failed", queue_name: "default", recorded_at: 5.minutes.ago)
+
+          result = SolidObserver::QueueEvent.count_by_queue_and_event_type(window: 1.hour, event_type: "job_completed")
+
+          expect(result).to eq("default" => 2, "mailers" => 1)
+        end
+      end
+
+      it "excludes events outside the window" do
+        travel_to(Time.utc(2026, 1, 21, 12, 0, 0)) do
+          SolidObserver::QueueEvent.create!(event_type: "job_completed", queue_name: "default", recorded_at: 2.hours.ago)
+
+          result = SolidObserver::QueueEvent.count_by_queue_and_event_type(window: 1.hour, event_type: "job_completed")
+
+          expect(result).to eq({})
         end
       end
     end

--- a/spec/solid_observer/application_layout_spec.rb
+++ b/spec/solid_observer/application_layout_spec.rb
@@ -164,13 +164,14 @@ RSpec.describe "SolidObserver application layout" do
       expect(template_source).to include(".so-toggle--on .so-toggle__dot")
     end
 
-    it "includes so-pulse keyframe animation for the toggle dot" do
-      expect(template_source).to include("@keyframes so-pulse")
+    it "includes static 6px success dot for live-on state (no infinite pulse)" do
+      expect(template_source).to include(".so-toggle__dot")
+      expect(template_source).to include(".so-toggle--on .so-toggle__dot")
+      expect(template_source).not_to include("@keyframes so-pulse")
     end
 
-    it "includes prefers-reduced-motion media query for toggle animations" do
+    it "includes prefers-reduced-motion media query for toggle transitions" do
       expect(template_source).to include("@media (prefers-reduced-motion: reduce)")
-      expect(template_source).to include("animation: none")
       expect(template_source).to include("transition: none")
     end
 

--- a/spec/solid_observer/dashboard_controller_spec.rb
+++ b/spec/solid_observer/dashboard_controller_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe SolidObserver::DashboardController do
         ready: [{t: 100, v: 3}, {t: 200, v: 7}]
       }
       allow(SolidObserver::QueueStats).to receive(:chart_data).and_return(chart_data)
+      allow(SolidObserver::QueueEvent).to receive(:recent).with(10).and_return([])
       SolidObserver.config.storage_mode = :persistence
       controller.index
 
@@ -326,7 +327,14 @@ RSpec.describe SolidObserver::DashboardController do
           claimed: 0,
           workers: 1,
           failed: 2,
-          enqueue_rate_per_min: 1.2
+          enqueue_rate_per_min: 1.2,
+          performed_in_range: 34,
+          failed_in_range: 2,
+          enqueued_in_range: 40,
+          avg_duration_in_range: 1.2,
+          queues: {"default" => 3},
+          performed_by_queue: {"default" => 30},
+          failed_by_queue: {"default" => 2}
         }
       )
       allow(SolidObserver::QueueStats).to receive(:chart_data).with(window: 15.minutes).and_return(
@@ -342,9 +350,10 @@ RSpec.describe SolidObserver::DashboardController do
 
       expect(status).to eq(200)
       expect(headers["Content-Type"]).to include("application/json")
-      expect(payload.keys.sort).to eq(%i[chart mode snapshot])
+      expect(payload.keys.sort).to eq(%i[chart mode range_label snapshot])
       expect(payload[:mode]).to eq("persistence")
-      expect(payload[:snapshot].keys.sort).to eq(%i[claimed enqueue_rate_per_min failed ready scheduled workers])
+      expect(payload[:range_label]).to eq("in last 15m")
+      expect(payload[:snapshot]).to include(:ready, :scheduled, :claimed, :workers, :failed, :enqueue_rate_per_min, :performed_in_range, :failed_in_range, :enqueued_in_range, :avg_duration_in_range, :queues, :performed_by_queue, :failed_by_queue)
       expect(payload[:chart].keys.sort).to eq(%i[failed performed ready])
     end
 
@@ -411,6 +420,29 @@ RSpec.describe SolidObserver::DashboardController do
 
       expect(status).to eq(404)
       expect(body).to include("Not Found")
+    end
+
+    it "returns lightweight tick payload with chart nil when tick=true" do
+      SolidObserver.config.storage_mode = :persistence
+      allow(SolidObserver::QueueStats).to receive(:solid_queue_available?).and_return(true)
+
+      tick_snapshot = {
+        ready: 5,
+        scheduled: 1,
+        claimed: 2,
+        workers: 3,
+        failed: 0
+      }
+      allow(SolidObserver::QueueStats).to receive(:snapshot_for_tick).and_return(tick_snapshot)
+
+      status, _, body = call_controller_action(:poll_data, "/solid_observer/poll_data?range=15m&tick=true")
+      payload = parse_json(body)
+
+      expect(status).to eq(200)
+      expect(payload[:mode]).to eq("persistence")
+      expect(payload[:snapshot]).to include(:ready, :scheduled, :claimed, :workers, :failed)
+      expect(payload[:snapshot]).not_to include(:performed_in_range, :failed_in_range, :enqueued_in_range, :avg_duration_in_range, :queues, :performed_by_queue, :failed_by_queue)
+      expect(payload[:chart]).to be_nil
     end
 
     context "with HTTP basic auth configured" do

--- a/spec/solid_observer/queue_stats_spec.rb
+++ b/spec/solid_observer/queue_stats_spec.rb
@@ -145,10 +145,14 @@ RSpec.describe SolidObserver::QueueStats do
           SolidObserver.config.storage_mode = :persistence
           allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(15.minutes).and_return(34)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(15.minutes).and_return(2)
+          allow(SolidObserver::QueueEvent).to receive(:enqueued_count_last).with(15.minutes).and_return(40)
+          allow(SolidObserver::QueueEvent).to receive(:avg_duration_last).with(15.minutes).and_return(1.2)
           allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 15.minutes).and_return(9.1)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(1.hour).and_return(0)
           allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
           allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(1).and_return([])
+          allow(SolidObserver::QueueEvent).to receive(:count_by_queue_and_event_type).with(window: 15.minutes, event_type: "job_completed").and_return({"default" => 30})
+          allow(SolidObserver::QueueEvent).to receive(:count_by_queue_and_event_type).with(window: 15.minutes, event_type: "job_failed").and_return({"default" => 2})
         end
 
         it "returns snapshot with throughput statistics for the default range" do
@@ -164,10 +168,14 @@ RSpec.describe SolidObserver::QueueStats do
             available: true,
             performed_in_range: 34,
             failed_in_range: 2,
+            enqueued_in_range: 40,
+            avg_duration_in_range: 1.2,
             failed_last_24h: 7,
             failed_last_hour: 0,
             latest_failure_at: nil,
             enqueue_rate_per_min: 9.1,
+            performed_by_queue: {"default" => 30},
+            failed_by_queue: {"default" => 2},
             range: "15m"
           )
         end
@@ -178,6 +186,8 @@ RSpec.describe SolidObserver::QueueStats do
           expect(result).to include(
             performed_in_range: 34,
             failed_in_range: 2,
+            enqueued_in_range: 40,
+            avg_duration_in_range: 1.2,
             enqueue_rate_per_min: 9.1,
             range: "15m"
           )
@@ -298,18 +308,38 @@ RSpec.describe SolidObserver::QueueStats do
     context "in persistence mode" do
       before { SolidObserver.config.storage_mode = :persistence }
 
-      it "returns six-key snapshot including enqueue rate" do
+      it "returns full snapshot including enqueue rate and per-queue aggregates" do
         allow(SolidObserver::QueueEvent).to receive(:enqueue_rate_per_minute).with(window: 15.minutes).and_return(1.6)
+        allow(SolidObserver::QueueEvent).to receive(:performed_count_last).with(15.minutes).and_return(34)
+        allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(15.minutes).and_return(2)
+        allow(SolidObserver::QueueEvent).to receive(:enqueued_count_last).with(15.minutes).and_return(40)
+        allow(SolidObserver::QueueEvent).to receive(:avg_duration_last).with(15.minutes).and_return(1.2)
+        allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(1.hour).and_return(0)
+        allow(SolidObserver::QueueEvent).to receive(:failed_count_last).with(24.hours).and_return(7)
+        allow(SolidObserver::QueueEvent).to receive(:recent_failures).with(1).and_return([])
+        allow(SolidObserver::QueueEvent).to receive(:count_by_queue_and_event_type).with(window: 15.minutes, event_type: "job_completed").and_return({"default" => 30, "mailers" => 4})
+        allow(SolidObserver::QueueEvent).to receive(:count_by_queue_and_event_type).with(window: 15.minutes, event_type: "job_failed").and_return({"default" => 2})
+
+        group_double = double
+        allow(ready_execution).to receive(:group).with(:queue_name).and_return(group_double)
+        allow(group_double).to receive(:count).and_return({"default" => 6})
 
         result = queue_stats.snapshot_for_poll("15m")
 
-        expect(result).to eq(
+        expect(result).to include(
           ready: 6,
           scheduled: 2,
           claimed: 1,
           workers: 4,
           failed: 3,
-          enqueue_rate_per_min: 1.6
+          enqueue_rate_per_min: 1.6,
+          performed_in_range: 34,
+          failed_in_range: 2,
+          enqueued_in_range: 40,
+          avg_duration_in_range: 1.2,
+          queues: {"default" => 6},
+          performed_by_queue: {"default" => 30, "mailers" => 4},
+          failed_by_queue: {"default" => 2}
         )
       end
     end
@@ -331,6 +361,74 @@ RSpec.describe SolidObserver::QueueStats do
           enqueue_rate_per_min: nil
         )
       end
+    end
+  end
+
+  describe "#snapshot_for_tick" do
+    let(:queue_stats) { described_class.new }
+    let(:ready_execution) { double("ReadyExecution") }
+    let(:scheduled_execution) { double("ScheduledExecution") }
+    let(:claimed_execution) { double("ClaimedExecution") }
+    let(:failed_execution) { double("FailedExecution") }
+    let(:process_model) { double("Process") }
+
+    before do
+      stub_const("SolidQueue", Module.new)
+      stub_const("SolidQueue::Job", Class.new)
+      stub_const("SolidQueue::ReadyExecution", ready_execution)
+      stub_const("SolidQueue::ScheduledExecution", scheduled_execution)
+      stub_const("SolidQueue::ClaimedExecution", claimed_execution)
+      stub_const("SolidQueue::FailedExecution", failed_execution)
+      stub_const("SolidQueue::Process", process_model)
+      allow(described_class).to receive(:solid_queue_available?).and_return(true)
+
+      allow(ready_execution).to receive(:count).and_return(6)
+      allow(scheduled_execution).to receive(:count).and_return(2)
+      allow(claimed_execution).to receive(:count).and_return(1)
+      allow(failed_execution).to receive(:count).and_return(3)
+      allow(process_model).to receive(:where).with(kind: "Worker").and_return(double(count: 4))
+    end
+
+    it "returns lightweight live-state snapshot without throughput or per-queue data" do
+      SolidObserver.config.storage_mode = :persistence
+
+      expect(SolidObserver::QueueEvent).not_to receive(:enqueue_rate_per_minute)
+      expect(SolidObserver::QueueEvent).not_to receive(:performed_count_last)
+      expect(SolidObserver::QueueEvent).not_to receive(:failed_count_last)
+      expect(SolidObserver::QueueEvent).not_to receive(:count_by_queue_and_event_type)
+
+      result = queue_stats.snapshot_for_tick
+
+      expect(result).to eq(
+        ready: 6,
+        scheduled: 2,
+        claimed: 1,
+        workers: 4,
+        failed: 3
+      )
+    end
+
+    it "returns empty snapshot when SolidQueue is not available" do
+      allow(described_class).to receive(:solid_queue_available?).and_return(false)
+
+      result = queue_stats.snapshot_for_tick
+
+      expect(result).to eq(
+        ready: 0,
+        scheduled: 0,
+        claimed: 0,
+        workers: 0,
+        failed: 0
+      )
+    end
+
+    it "returns the frozen TICK_EMPTY_SNAPSHOT constant when SolidQueue is not available" do
+      allow(described_class).to receive(:solid_queue_available?).and_return(false)
+
+      result = queue_stats.snapshot_for_tick
+
+      expect(result).to eq(described_class::TICK_EMPTY_SNAPSHOT)
+      expect(described_class::TICK_EMPTY_SNAPSHOT).to be_frozen
     end
   end
 


### PR DESCRIPTION
## Summary of changes
- Rework the dashboard into live-state, throughput, charts, per-queue, stability, and recent-events zones.
- Add async range changes, Refresh data, lightweight `tick=true` live polling, per-queue throughput, and accessible empty/freshness states.
- Add QueueEvent/QueueStats aggregates plus specs and visual/a11y polish from Designer reviews.