### PR TITLE
[SO-068][FIX] Fix dashboard chart totals and help hover

### DIFF
--- a/app/assets/javascripts/solid_observer/live_poll.js
+++ b/app/assets/javascripts/solid_observer/live_poll.js
@@ -7,7 +7,8 @@
   var INTERVAL_SEC = 5;
 
   // Shared state — IIFE-level so all functions can access them
-  var checkbox, rangeSelect, refreshBtn, helpBtn, helpPanel, freshnessEl;
+  var checkbox, rangeSelect, refreshBtn, helpBtn, helpPanel, helpWrapper, freshnessEl;
+  var hoverActive = false;
   var sparks = {};
   var url = "/solid_observer/poll_data";
   var inFlight = false;
@@ -27,6 +28,7 @@
     refreshBtn = wrapper.querySelector("[data-so-refresh]");
     helpBtn = wrapper.querySelector("[data-so-help-btn]");
     helpPanel = wrapper.querySelector("[data-so-help-panel]");
+    helpWrapper = wrapper.querySelector("[data-so-help-wrapper]");
     freshnessEl = wrapper.querySelector("[data-so-freshness]");
 
     sparks = collectSparks();
@@ -53,6 +55,10 @@
     if (helpBtn && helpPanel) {
       helpBtn.addEventListener("click", function () {
         var expanded = helpBtn.getAttribute("aria-expanded") === "true";
+        // Don't close on click if hover is active — mouseleave will handle closing
+        if (expanded && hoverActive) {
+          return;
+        }
         helpBtn.setAttribute("aria-expanded", String(!expanded));
         helpPanel.hidden = expanded;
       });
@@ -83,6 +89,19 @@
           helpPanel.hidden = true;
         }
       });
+      // Hover show/hide for mouse users
+      if (helpWrapper) {
+        helpWrapper.addEventListener("mouseenter", function () {
+          hoverActive = true;
+          helpBtn.setAttribute("aria-expanded", "true");
+          helpPanel.hidden = false;
+        });
+        helpWrapper.addEventListener("mouseleave", function () {
+          hoverActive = false;
+          helpBtn.setAttribute("aria-expanded", "false");
+          helpPanel.hidden = true;
+        });
+      }
     }
 
     // --- Live toggle ---
@@ -177,11 +196,13 @@
     patchZoneValues("live-state", snapshot);
     // Patch throughput values (Zone C) — value nodes only, preserve suffix/range-copy
     patchZoneValues("throughput", snapshot);
+    // Patch chart indicator values (Zone D) — range totals, not latest bucket
+    patchZoneValues("chart", snapshot);
     // Patch queue table (Zone E)
     patchQueueTable(snapshot);
     // Patch stability (Zone F)
     patchStability(snapshot);
-    // Update chart (Zone D)
+    // Update chart sparklines (Zone D)
     var chart = data.chart || {};
     Object.keys(sparks).forEach(function (key) {
       var series = chart[key];
@@ -314,7 +335,6 @@
 
   function Sparkline(figureEl) {
     this.line = figureEl.querySelector(".so-spark__line");
-    this.valueEl = figureEl.querySelector("[data-so-spark-value]");
   }
 
   Sparkline.prototype.render = function (series) {
@@ -335,9 +355,6 @@
       points.push(x.toFixed(1) + "," + y.toFixed(1));
     }
     this.line.setAttribute("points", points.join(" "));
-    if (this.valueEl) {
-      this.valueEl.textContent = formatValue(series[series.length - 1].v);
-    }
   };
 
   function formatValue(v) {

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -132,7 +132,9 @@
     .so-btn--help { font-size: 0.75rem; padding: 0.2rem 0.5rem; border: 1px solid var(--so-border); border-radius: var(--so-radius); background: var(--so-card-bg); color: var(--so-text-muted); cursor: pointer; }
     .so-btn--help:hover { background: var(--so-surface-muted); }
     .so-btn--help:focus-visible { outline: 2px solid var(--so-info); outline-offset: 2px; box-shadow: 0 0 0 3px var(--so-focus-ring); }
-    .so-help-panel { font-size: 0.8rem; color: var(--so-text-muted); padding: 0.5rem 0.75rem; border: 1px solid var(--so-border); border-radius: var(--so-radius); background: var(--so-card-bg); margin-top: 0.25rem; max-width: 420px; }
+    .so-help-wrapper { position: relative; }
+    .so-help-wrapper .so-help-panel { position: absolute; top: 100%; right: 0; z-index: 10; }
+    .so-help-panel { font-size: 0.8rem; color: var(--so-text-muted); padding: 0.5rem 0.75rem; border: 1px solid var(--so-border); border-radius: var(--so-radius); background: var(--so-card-bg); margin-top: 0.25rem; width: min(20rem, calc(100vw - 2rem)); max-width: 420px; }
     .so-toolbar-freshness { font-size: 0.75rem; color: var(--so-text-subtle); }
 
     /* SO-067 Focus rings */

--- a/app/views/solid_observer/dashboard/_chart.html.erb
+++ b/app/views/solid_observer/dashboard/_chart.html.erb
@@ -1,20 +1,20 @@
 <div class="so-chart-strip" data-so-zone="chart" data-so-chart>
   <% if SolidObserver.config.persistence_mode? %>
     <figure class="so-spark" data-so-spark="performed">
-      <figcaption class="so-spark__label">Performed/min <span data-so-range-copy><%= range_label(local_assigns[:range] || "15m") %></span></figcaption>
+      <figcaption class="so-spark__label">Performed total <span data-so-range-copy><%= range_label(local_assigns[:range] || "15m") %></span></figcaption>
       <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
         <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
         <polyline class="so-spark__line" points="<%= spark_points(@chart[:performed]) %>"/>
       </svg>
-      <span class="so-spark__value" data-so-spark-value><%= @chart[:performed].last&.dig(:v) || "—" %></span>
+      <span class="so-spark__value" data-so-card-value="performed_in_range"><%= number_with_delimiter(@stats[:performed_in_range].to_i) %></span>
     </figure>
     <figure class="so-spark" data-so-spark="failed">
-      <figcaption class="so-spark__label">Failed/min <span data-so-range-copy><%= range_label(local_assigns[:range] || "15m") %></span></figcaption>
+      <figcaption class="so-spark__label">Failed total <span data-so-range-copy><%= range_label(local_assigns[:range] || "15m") %></span></figcaption>
       <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
         <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
         <polyline class="so-spark__line" points="<%= spark_points(@chart[:failed]) %>"/>
       </svg>
-      <span class="so-spark__value" data-so-spark-value><%= @chart[:failed].last&.dig(:v) || "—" %></span>
+      <span class="so-spark__value" data-so-card-value="failed_in_range"><%= number_with_delimiter(@stats[:failed_in_range].to_i) %></span>
     </figure>
   <% end %>
   <figure class="so-spark" data-so-spark="ready">
@@ -23,6 +23,6 @@
       <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
       <polyline class="so-spark__line" points="<%= spark_points(@chart[:ready]) %>"/>
     </svg>
-    <span class="so-spark__value" data-so-spark-value><%= @chart[:ready].last&.dig(:v) || "—" %></span>
+    <span class="so-spark__value" data-so-card-value="ready"><%= number_with_delimiter(@stats[:ready].to_i) %></span>
   </figure>
 </div>

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -24,10 +24,12 @@
         <span class="so-toggle__cadence" aria-live="polite"><%= @live ? "5s" : "off" %></span>
         <span class="so-toggle__dot" aria-hidden="true"></span>
       </label>
-      <button type="button" class="so-btn so-btn--help" data-so-help-btn aria-expanded="false" aria-controls="so-help-panel">(?)
-      </button>
-      <div id="so-help-panel" class="so-help-panel" data-so-help-panel hidden>
-        <p>Live mode polls every 5 seconds for current queue state. Throughput and chart data update only on range change or manual refresh.</p>
+      <div class="so-help-wrapper" data-so-help-wrapper>
+        <button type="button" class="so-btn so-btn--help" data-so-help-btn aria-expanded="false" aria-controls="so-help-panel">(?)
+        </button>
+        <div id="so-help-panel" class="so-help-panel" data-so-help-panel hidden>
+          <p>Live mode polls every 5 seconds for current queue state. Throughput and chart data update only on range change or manual refresh.</p>
+        </div>
       </div>
     </div>
   </div>

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -138,11 +138,54 @@ RSpec.describe "Dashboard", type: :feature do
       expect(page).to have_css("[data-so-help-btn][aria-expanded]")
     end
 
+    it "renders help button and panel inside a hover wrapper" do
+      visit "/solid_observer"
+      expect(page).to have_css("[data-so-help-wrapper]")
+      expect(page).to have_css("[data-so-help-wrapper] [data-so-help-btn]")
+      expect(page).to have_css("[data-so-help-wrapper] [data-so-help-panel]", visible: false)
+    end
+
     it "renders chart strip with three sparkline figures" do
       visit "/solid_observer"
       expect(page).to have_css('[data-so-spark="performed"]')
       expect(page).to have_css('[data-so-spark="failed"]')
       expect(page).to have_css('[data-so-spark="ready"]')
+    end
+
+    it "renders chart indicators with range total values, not latest bucket values" do
+      visit "/solid_observer"
+      # Performed total shows performed_in_range (1200), not latest bucket (10)
+      within('[data-so-spark="performed"]') do
+        expect(page).to have_css('[data-so-card-value="performed_in_range"]', text: "1,200")
+      end
+      # Failed total shows failed_in_range (9), not latest bucket (1)
+      within('[data-so-spark="failed"]') do
+        expect(page).to have_css('[data-so-card-value="failed_in_range"]', text: "9")
+      end
+    end
+
+    it "renders chart labels as range totals, not per-minute rates" do
+      visit "/solid_observer"
+      within('[data-so-spark="performed"]') do
+        expect(page).to have_css(".so-spark__label", text: /Performed total/)
+        expect(page).not_to have_css(".so-spark__label", text: /Performed\/min/)
+      end
+      within('[data-so-spark="failed"]') do
+        expect(page).to have_css(".so-spark__label", text: /Failed total/)
+        expect(page).not_to have_css(".so-spark__label", text: /Failed\/min/)
+      end
+    end
+
+    it "renders Ready depth chart indicator with data-so-card-value" do
+      visit "/solid_observer"
+      within('[data-so-spark="ready"]') do
+        expect(page).to have_css('[data-so-card-value="ready"]')
+      end
+    end
+
+    it "does not use data-so-spark-value for chart indicator values" do
+      visit "/solid_observer"
+      expect(page).not_to have_css("[data-so-spark-value]")
     end
 
     it "renders chart polylines with non-empty points on first paint" do


### PR DESCRIPTION
## Summary of changes
- Show Charts zone indicators as selected-range totals while keeping sparkline polylines bucketed by minute.
- Patch chart indicators only on full fetch/range/Refresh, not on lightweight live ticks.
- Make the Live help affordance open on hover with a readable, viewport-clamped overlay while preserving keyboard/touch behavior.