### PR TITLE
[SO-070][FEAT] Add multi-component SolidObserver foundation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
-    erb (6.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)

--- a/app/assets/stylesheets/solid_observer/application.css
+++ b/app/assets/stylesheets/solid_observer/application.css
@@ -1,0 +1,18 @@
+.so-sidebar__nav .active {
+  font-weight: 600;
+}
+
+.so-sidebar__nav a:focus-visible {
+  outline: 2px solid var(--so-info);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px var(--so-focus-ring);
+}
+
+.so-sidebar__section {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--so-text-muted);
+  padding: 0.5rem 0.75rem 0.25rem;
+  margin: 0.5rem 0.75rem 0.25rem;
+}

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -6,8 +6,12 @@ module SolidObserver
     skip_after_action :verify_same_origin_request, only: :live_poll
 
     def index
-      assign_range_and_stats
-      load_persistence_data if persistence_mode?
+      @component = selected_component
+      @queue_available_for_render = queue_dashboard_renderable?
+      if @component == "queue" && @queue_available_for_render
+        assign_range_and_stats
+        load_persistence_data if persistence_mode?
+      end
     end
 
     def live_poll
@@ -32,7 +36,13 @@ module SolidObserver
       @range = range
       @live = request_live_param == "on"
       @stats = QueueStats.snapshot(range: range)
-      @chart = QueueStats.chart_data(window: QueueStats.range_duration(@range))
+      @chart = if @stats[:available]
+        QueueStats.chart_data(window: QueueStats.range_duration(@range))
+      else
+        {performed: [], failed: [], ready: []}
+      end
+    rescue
+      @chart = {performed: [], failed: [], ready: []}
     end
 
     def load_persistence_data
@@ -74,6 +84,32 @@ module SolidObserver
 
     def append_chart_buffer
       ChartBuffer.append(SolidQueue::ReadyExecution.count) if QueueStats.solid_queue_available?
+    end
+
+    def selected_component
+      requested = if request&.respond_to?(:path_parameters)
+        request.path_parameters&.[](:component).to_s
+      else
+        ""
+      end
+      requested = path_component if requested.empty?
+      return "cache" if requested == "cache" && SolidObserver.config.solid_cache_enabled?
+
+      "queue"
+    end
+
+    def path_component
+      return "" unless request&.respond_to?(:path)
+
+      path = request&.path.to_s
+      return "cache" if path.end_with?("/cache")
+      return "queue" if path.end_with?("/queue")
+
+      ""
+    end
+
+    def queue_dashboard_renderable?
+      @component == "queue" && SolidObserver.config.solid_queue_enabled?
     end
   end
 end

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -91,5 +91,18 @@ module SolidObserver
     def latest_failure_phrase(timestamp)
       timestamp ? "#{time_ago_in_words(timestamp)} ago" : "unknown"
     end
+
+    def queue_component_enabled?
+      SolidObserver.config.solid_queue_enabled?
+    end
+
+    def cache_component_enabled?
+      SolidObserver.config.solid_cache_enabled?
+    end
+
+    def dashboard_section_active?(component)
+      current_component = @component.presence || "queue"
+      controller_name == "dashboard" && current_component == component.to_s
+    end
   end
 end

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -93,6 +93,22 @@
     .so-sidebar__nav a.active {
       background: var(--so-sidebar-active-bg);
       color: var(--so-sidebar-active-text);
+      font-weight: 600;
+    }
+
+    .so-sidebar__nav a:focus-visible {
+      outline: 2px solid var(--so-info);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 3px var(--so-focus-ring);
+    }
+
+    .so-sidebar__section {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--so-text-muted);
+      padding: 0.5rem 0.75rem 0.25rem;
+      margin: 0.5rem 0.75rem 0.25rem;
     }
 
     .so-sidebar__mode {
@@ -433,12 +449,20 @@
   <div class="so-layout">
     <aside class="so-sidebar">
       <div class="so-sidebar__logo">SolidObserver</div>
-      <nav class="so-sidebar__nav">
-        <%= link_to "Dashboard", root_path, class: ("active" if controller_name == "dashboard") %>
-        <%= link_to "Jobs", jobs_path, class: ("active" if controller_name == "jobs") %>
-        <% if persistence_mode? %>
-          <%= link_to "Events", events_path, class: ("active" if controller_name == "events") %>
-          <%= link_to "Storage", storage_path, class: ("active" if controller_name == "storages") %>
+      <nav class="so-sidebar__nav" aria-label="SolidObserver navigation">
+        <% if SolidObserver.config.solid_queue_enabled? %>
+          <div class="so-sidebar__section">Queue</div>
+          <%= link_to "Dashboard", root_path, class: ("active" if controller_name == "dashboard" && @component.to_s != "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s != "cache" ? "page" : nil) %>
+          <%= link_to "Jobs", jobs_path, class: ("active" if controller_name == "jobs"), "aria-current": (controller_name == "jobs" ? "page" : nil) %>
+          <% if persistence_mode? %>
+            <%= link_to "Events", events_path, class: ("active" if controller_name == "events"), "aria-current": (controller_name == "events" ? "page" : nil) %>
+            <%= link_to "Storage", storage_path, class: ("active" if controller_name == "storages"), "aria-current": (controller_name == "storages" ? "page" : nil) %>
+          <% end %>
+        <% end %>
+
+        <% if SolidObserver.config.solid_cache_enabled? %>
+          <div class="so-sidebar__section">Cache</div>
+          <%= link_to "Cache Dashboard", cache_dashboard_path, class: ("active" if controller_name == "dashboard" && @component.to_s == "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s == "cache" ? "page" : nil) %>
         <% end %>
       </nav>
       <div class="so-sidebar__mode">

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -1,6 +1,18 @@
 <% content_for :title, "Dashboard" %>
 
 <div class="so-dashboard">
+  <% if @component == "cache" %>
+    <section class="so-card so-card--section" aria-labelledby="so-cache-heading">
+      <h2 id="so-cache-heading">Dashboard</h2>
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">SolidCache integration is enabled, but cache metrics are not part of this release.</p>
+    </section>
+  <% else %>
+  <% if !SolidObserver.config.solid_queue_enabled? %>
+    <section class="so-card so-card--section" aria-labelledby="so-queue-unavailable-heading">
+      <h2 id="so-queue-unavailable-heading">Queue Unavailable</h2>
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">Queue component is disabled or not installed. Enable SolidQueue to access dashboard controls.</p>
+    </section>
+  <% else %>
   <%# Zone A: Toolbar — range selector, Refresh, Live toggle, help disclosure %>
   <div class="so-dashboard-toolbar" data-so-live>
     <div class="so-dashboard-toolbar__left">
@@ -109,5 +121,7 @@
         <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-events">No recent events yet. Queue activity will appear here after jobs are enqueued, performed, or failed.</p>
       </div>
     <% end %>
+  <% end %>
+  <% end %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@
 
 SolidObserver::Engine.routes.draw do
   root "dashboard#index"
+  get "queue", to: "dashboard#index", defaults: {component: "queue"}, as: :queue_dashboard
+  get "cache", to: "dashboard#index", defaults: {component: "cache"}, as: :cache_dashboard
   get "poll_data", to: "dashboard#poll_data", as: :poll_data
   get "live_poll.js", to: "dashboard#live_poll", as: :live_poll_script
 

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -84,6 +84,22 @@ module SolidObserver
       @storage_mode == :realtime
     end
 
+    def solid_queue_available?
+      !!defined?(::SolidQueue)
+    end
+
+    def solid_cache_available?
+      !!defined?(::SolidCache)
+    end
+
+    def solid_queue_enabled?
+      observe_queue
+    end
+
+    def solid_cache_enabled?
+      observe_cache && solid_cache_available?
+    end
+
     def sampling_rate=(value)
       validate_rate!(:sampling_rate, value)
       @sampling_rate = value

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -4,15 +4,25 @@ module SolidObserver
   class Engine < ::Rails::Engine
     isolate_namespace SolidObserver
 
+    SOLID_QUEUE_AVAILABLE = defined?(::SolidQueue)
+    SOLID_CACHE_AVAILABLE = defined?(::SolidCache)
+
     middleware.use ActionDispatch::Cookies
     middleware.use ActionDispatch::Session::CookieStore, key: "_solid_observer_session"
     middleware.use ActionDispatch::Flash
 
     class << self
       def check_solid_queue_availability
-        return if defined?(SolidQueue)
+        return if defined?(::SolidQueue)
 
         Rails.logger.warn "[SolidObserver] SolidQueue not detected. Queue observability features will be limited."
+      end
+
+      def check_solid_cache_availability
+        return if defined?(::SolidCache)
+        return unless SolidObserver.config.observe_cache
+
+        Rails.logger.warn "[SolidObserver] SolidCache not detected. Cache observability features will be disabled."
       end
 
       def check_ui_authentication
@@ -109,6 +119,7 @@ module SolidObserver
 
     config.before_initialize do
       Engine.check_solid_queue_availability
+      Engine.check_solid_cache_availability
     end
 
     config.after_initialize do

--- a/spec/requests/solid_observer/dashboard_spec.rb
+++ b/spec/requests/solid_observer/dashboard_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidObserver dashboard routes", type: :request do
+  before do
+    @previous_layout = SolidObserver::DashboardController.send(:_layout)
+    SolidObserver::DashboardController.layout false
+    SolidObserver.config.ui_enabled = true
+    SolidObserver.config.observe_queue = true
+    SolidObserver.config.observe_cache = false
+    SolidObserver.config.storage_mode = :realtime
+    SolidObserver::DashboardController.prepend_view_path(SolidObserver::Engine.root.join("app/views"))
+  end
+
+  after do
+    SolidObserver::DashboardController.layout @previous_layout
+    SolidObserver.reset_configuration!
+  end
+
+  def call_action(path)
+    env = Rack::MockRequest.env_for(path, {"action_dispatch.routes" => SolidObserver::Engine.routes})
+    status, _headers, body = SolidObserver::DashboardController.action(:index).call(env)
+    response_body = +""
+    body.each { |chunk| response_body << chunk }
+    [status, response_body]
+  end
+
+  it "keeps the existing queue dashboard path" do
+    status, body = call_action("/solid_observer")
+
+    expect(status).to eq(200)
+    expect(body).to include("Right now")
+  end
+
+  it "supports explicit queue dashboard routing" do
+    status, body = call_action("/solid_observer/queue")
+
+    expect(status).to eq(200)
+    expect(body).to include("Right now")
+  end
+
+  it "supports cache dashboard route when cache component is enabled" do
+    stub_const("SolidCache", Module.new)
+    SolidObserver.config.observe_cache = true
+
+    status, body = call_action("/solid_observer/cache")
+
+    expect(status).to eq(200)
+    expect(body).to include("Dashboard")
+  end
+end

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -76,6 +76,33 @@ RSpec.describe SolidObserver::Configuration do
     end
   end
 
+  describe "component helpers" do
+    it "reports queue enabled by default when SolidQueue is available" do
+      stub_const("SolidQueue", Module.new)
+      config = described_class.new
+
+      expect(config.solid_queue_available?).to be(true)
+      expect(config.solid_queue_enabled?).to be(true)
+    end
+
+    it "reports cache disabled by default when SolidCache is absent" do
+      hide_const("SolidCache")
+      config = described_class.new
+
+      expect(config.solid_cache_available?).to be(false)
+      expect(config.solid_cache_enabled?).to be(false)
+    end
+
+    it "enables cache only when observe_cache and SolidCache are both present" do
+      stub_const("SolidCache", Module.new)
+      config = described_class.new
+      config.observe_cache = true
+
+      expect(config.solid_cache_available?).to be(true)
+      expect(config.solid_cache_enabled?).to be(true)
+    end
+  end
+
   describe "#max_buffer_size" do
     it "accepts positive integers greater than or equal to buffer_size" do
       config = described_class.new

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -72,6 +72,35 @@ RSpec.describe SolidObserver::Engine do
     end
   end
 
+  describe ".check_solid_cache_availability" do
+    it "warns when SolidCache is not defined and cache observation is enabled" do
+      hide_const("SolidCache")
+      SolidObserver.config.observe_cache = true
+
+      expect(logger).to receive(:warn).with(/SolidCache not detected/)
+
+      described_class.check_solid_cache_availability
+    end
+
+    it "does not warn when SolidCache is not defined and cache observation is disabled" do
+      hide_const("SolidCache")
+      SolidObserver.config.observe_cache = false
+
+      expect(logger).not_to receive(:warn).with(/SolidCache not detected/)
+
+      described_class.check_solid_cache_availability
+    end
+
+    it "does not warn when SolidCache is defined" do
+      stub_const("SolidCache", Module.new)
+      SolidObserver.config.observe_cache = true
+
+      expect(logger).not_to receive(:warn).with(/SolidCache not detected/)
+
+      described_class.check_solid_cache_availability
+    end
+  end
+
   describe ".check_ui_authentication" do
     after { SolidObserver.reset_configuration! }
 


### PR DESCRIPTION
## Summary of changes
- Add Queue/Cache component configuration and availability helpers with guarded optional constants.
- Prepare component-aware dashboard routing/navigation while preserving the existing Queue path.
- Update `erb` via `Gemfile.lock` to clear the bundler-audit advisory.
