### PR TITLE
[SO-071][FEAT] Add cache telemetry foundation

### DIFF
--- a/app/models/solid_observer/cache_event.rb
+++ b/app/models/solid_observer/cache_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CacheEvent < BaseEvent
+    self.table_name = "solid_observer_cache_events"
+
+    validates :event_type, presence: true
+    validates :key_digest, presence: true
+    validates :recorded_at, presence: true
+
+    scope :errored, -> { where.not(error_class: nil) }
+    scope :slow, ->(threshold = SolidObserver.config.cache_slow_threshold) { where("duration >= ?", threshold) }
+    scope :recent, ->(limit = 10) { order(recorded_at: :desc).limit(limit) }
+  end
+end

--- a/db/migrate/20260601000001_create_solid_observer_cache_events.rb
+++ b/db/migrate/20260601000001_create_solid_observer_cache_events.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateSolidObserverCacheEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_observer_cache_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :key_digest, null: false, limit: 64
+      t.boolean :hit
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+
+      t.index :recorded_at
+      t.index :event_type
+      t.index :key_digest
+      t.index :hit
+      t.index :error_class
+    end
+  end
+end

--- a/lib/solid_observer/cache_event_buffer.rb
+++ b/lib/solid_observer/cache_event_buffer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+module SolidObserver
+  class CacheEventBuffer
+    include Singleton
+
+    def initialize
+      @mutex = Mutex.new
+      @buffer = []
+    end
+
+    def push(event_data)
+      return unless SolidObserver.config.persistence_mode?
+
+      should_flush = @mutex.synchronize do
+        @buffer << event_data
+        @buffer.size >= SolidObserver.config.buffer_size
+      end
+      flush! if should_flush
+    end
+
+    def flush!
+      events = @mutex.synchronize do
+        buffered_events = @buffer.dup
+        @buffer.clear
+        buffered_events
+      end
+      return if events.empty?
+
+      Services::FlushCacheEventBuffer.call(events)
+    rescue => error
+      @mutex.synchronize { @buffer = events + @buffer }
+      Rails.logger&.error("[SolidObserver] Cache buffer flush failed: #{error.message}") if defined?(Rails)
+    end
+
+    def size
+      @mutex.synchronize { @buffer.size }
+    end
+
+    def clear
+      @mutex.synchronize { @buffer.clear }
+    end
+  end
+end

--- a/lib/solid_observer/cache_subscriber.rb
+++ b/lib/solid_observer/cache_subscriber.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CacheSubscriber
+    EVENTS = %w[
+      cache_read.active_support
+      cache_write.active_support
+      cache_delete.active_support
+      cache_exist?.active_support
+      cache_read_multi.active_support
+      cache_write_multi.active_support
+      cache_delete_multi.active_support
+    ].freeze
+
+    class << self
+      def subscribe!
+        return unless subscription_allowed?
+
+        @subscriptions = EVENTS.map { |event_name| subscribe_to(event_name) }
+      end
+
+      def unsubscribe!
+        return unless @subscriptions
+
+        @subscriptions.each { |subscription| ActiveSupport::Notifications.unsubscribe(subscription) }
+        @subscriptions = []
+      end
+
+      def subscribed?
+        !!@subscriptions&.any?
+      end
+
+      private
+
+      def subscription_allowed?
+        SolidObserver.config.solid_cache_enabled? && !subscribed? && defined?(ActiveSupport::Notifications)
+      end
+
+      def subscribe_to(event_name)
+        ActiveSupport::Notifications.subscribe(event_name) do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+          Services::RecordCacheEvent.call(event: event, buffer: CacheEventBuffer.instance)
+        end
+      end
+    end
+  end
+end

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -25,7 +25,9 @@ module SolidObserver
     # @note Cache and Cable observers are not yet implemented
     attr_accessor :observe_cache,
       :observe_cable,
-      :cache_sampling_rate
+      :cache_sampling_rate,
+      :cache_slow_threshold,
+      :cache_store_errors
 
     # Retention Settings
     attr_accessor :event_retention
@@ -56,12 +58,13 @@ module SolidObserver
       @ui_enabled, @ui_base_controller, @ui_username, @ui_password,
         @storage_mode, @observe_queue, @observe_cache, @observe_cable,
         @event_retention, @metrics_retention, @max_db_size, @warning_threshold,
-        @sampling_rate, @cache_sampling_rate, @buffer_size, @flush_interval,
+        @sampling_rate, @cache_sampling_rate, @cache_slow_threshold, @cache_store_errors,
+        @buffer_size, @flush_interval,
         @max_buffer_size, @buffer_overflow_strategy, @filter_cache_ttl,
         @correlation_id_generator = !production?, "::ApplicationController", nil, nil,
           :persistence, true, false, false,
           30.days, 90.days, 1.gigabyte, 0.8,
-          1.0, 0.1, 1000, 10.seconds,
+          1.0, 0.1, 0.1, true, 1000, 10.seconds,
           10_000, :drop_old, 1.minute,
           nil
     end

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "cache_event_buffer"
+require_relative "cache_subscriber"
+require_relative "services/record_cache_event"
+require_relative "services/flush_cache_event_buffer"
+
 module SolidObserver
   class Engine < ::Rails::Engine
     isolate_namespace SolidObserver
@@ -38,10 +43,11 @@ module SolidObserver
 
       def activate_subscribers
         return activate_subscribers_in_realtime if SolidObserver.config.realtime_mode?
-        return if activation_skipped_for_table_status?
+        return if activation_skipped_for_table_status_for_enabled_components?
 
         Rails.logger.info "[SolidObserver] Activating event subscribers"
-        Subscriber.subscribe!
+        Subscriber.subscribe! if should_activate_queue_subscriber?
+        CacheSubscriber.subscribe! if should_activate_cache_subscriber?
       end
 
       private
@@ -64,13 +70,22 @@ module SolidObserver
 
       def activate_subscribers_in_realtime
         Rails.logger.info "[SolidObserver] Starting in real-time mode (no persistence)"
-        Subscriber.subscribe!
+        Subscriber.subscribe! if should_activate_queue_subscriber?
+        CacheSubscriber.subscribe! if should_activate_cache_subscriber?
       end
 
-      def activation_skipped_for_table_status?
-        case table_status("solid_observer_queue_events")
+      def activation_skipped_for_table_status_for_enabled_components?
+        enabled_tables = []
+        enabled_tables << "solid_observer_queue_events" if should_activate_queue_subscriber?
+        enabled_tables << "solid_observer_cache_events" if should_activate_cache_subscriber?
+
+        enabled_tables.any? { |table_name| skip_activation_for_missing_table?(table_name) }
+      end
+
+      def skip_activation_for_missing_table?(table_name)
+        case table_status(table_name)
         when :absent
-          log_activation_skip("Tables not found. Run: rails solid_observer:install:migrations && rails db:migrate")
+          log_activation_skip("Tables not found (missing: #{table_name}). Run: rails solid_observer:install:migrations && rails db:migrate")
           true
         when :unknown
           log_activation_skip("Database not reachable at boot. Skipping subscriber activation.")
@@ -78,6 +93,14 @@ module SolidObserver
         else
           false
         end
+      end
+
+      def should_activate_queue_subscriber?
+        SolidObserver.config.solid_queue_enabled?
+      end
+
+      def should_activate_cache_subscriber?
+        SolidObserver.config.solid_cache_enabled?
       end
 
       def log_activation_skip(message)

--- a/lib/solid_observer/services/flush_cache_event_buffer.rb
+++ b/lib/solid_observer/services/flush_cache_event_buffer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    class FlushCacheEventBuffer
+      BATCH_SIZE = 100
+
+      def self.call(events)
+        new(events).call
+      end
+
+      def initialize(events)
+        @events = events
+      end
+
+      def call
+        return 0 if @events.empty?
+
+        CacheEvent.transaction { CacheEvent.insert_all!(@events) }
+        @events.size
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => error
+        Rails.logger&.error("[SolidObserver] Cache bulk insert failed, retrying in batches: #{error.message}") if defined?(Rails)
+        @events.each_slice(BATCH_SIZE).sum { |batch| insert_batch(batch) }
+      end
+
+      private
+
+      def insert_batch(batch)
+        CacheEvent.insert_all(batch, returning: false)
+        batch.size
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => error
+        Rails.logger&.warn("[SolidObserver] Failed to insert cache batch of #{batch.size} events: #{error.message}") if defined?(Rails)
+        0
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/record_cache_event.rb
+++ b/lib/solid_observer/services/record_cache_event.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module SolidObserver
+  module Services
+    class RecordCacheEvent
+      def self.call(event:, buffer:)
+        new(event, buffer).call
+      end
+
+      def initialize(event, buffer)
+        @event = event
+        @buffer = buffer
+      end
+
+      def call
+        return unless should_store_event?
+
+        @buffer.push(build_event_data)
+      rescue => error
+        Rails.logger&.warn("[SolidObserver] Cache event recording failed: #{error.message}") if defined?(Rails)
+      end
+
+      private
+
+      def should_store_event?
+        sampled? || slow? || errored?
+      end
+
+      def sampled?
+        rand <= SolidObserver.config.cache_sampling_rate
+      end
+
+      def slow?
+        duration_in_seconds && duration_in_seconds >= SolidObserver.config.cache_slow_threshold
+      end
+
+      def errored?
+        return false unless SolidObserver.config.cache_store_errors
+
+        !exception_data.compact.empty?
+      end
+
+      def build_event_data
+        {
+          event_type: cache_operation,
+          key_digest: key_digest,
+          hit: hit_value,
+          duration: duration_in_seconds,
+          error_class: exception_data[:error_class],
+          error_message: exception_data[:error_message],
+          metadata: metadata.to_json,
+          recorded_at: Time.current
+        }
+      end
+
+      def cache_operation
+        @event.name.delete_suffix(".active_support")
+      end
+
+      def duration_in_seconds
+        @event.duration&./(1000.0)
+      end
+
+      def key_digest
+        Digest::SHA256.hexdigest(normalized_key_string)
+      end
+
+      def normalized_key_string
+        key = payload[:key]
+
+        case key
+        when Hash
+          key.keys.map(&:to_s).sort.join(",")
+        when Array
+          key.map(&:to_s).sort.join(",")
+        else
+          key.to_s
+        end
+      end
+
+      def hit_value
+        return payload[:hit] unless payload[:hit].nil?
+        return nil unless payload[:hits].is_a?(Array)
+
+        payload[:hits].any?
+      end
+
+      def metadata
+        {
+          super_operation: payload[:super_operation]&.to_s,
+          key_size: key_size,
+          hits_count: hits_count
+        }.compact.merge(exception_data).compact
+      end
+
+      def key_size
+        key = payload[:key]
+        return key.keys.size if key.is_a?(Hash)
+        return key.size if key.is_a?(Array)
+
+        key.to_s.bytesize
+      end
+
+      def hits_count
+        hits = payload[:hits]
+        return nil unless hits.is_a?(Array)
+
+        hits.size
+      end
+
+      def exception_data
+        @exception_data ||= begin
+          exception_obj = payload[:exception_object]
+          if exception_obj
+            {error_class: exception_obj.class.name, error_message: exception_obj.message}
+          elsif payload[:exception].is_a?(Array)
+            {error_class: payload[:exception].first, error_message: payload[:exception].last}
+          else
+            {}
+          end
+        end
+      end
+
+      def payload
+        @event.payload || {}
+      end
+    end
+  end
+end

--- a/spec/lib/solid_observer/cache_event_buffer_spec.rb
+++ b/spec/lib/solid_observer/cache_event_buffer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CacheEventBuffer do
+  subject(:buffer) { described_class.instance }
+
+  before do
+    buffer.clear
+    allow(SolidObserver::Services::FlushCacheEventBuffer).to receive(:call)
+  end
+
+  after { buffer.clear }
+
+  it "buffers and flushes events" do
+    allow(SolidObserver.config).to receive(:buffer_size).and_return(2)
+
+    buffer.push({event_type: "cache_read", recorded_at: Time.current})
+    buffer.push({event_type: "cache_write", recorded_at: Time.current})
+
+    expect(SolidObserver::Services::FlushCacheEventBuffer).to have_received(:call).once
+    expect(buffer.size).to eq(0)
+  end
+
+  it "does not buffer in realtime mode" do
+    allow(SolidObserver.config).to receive(:persistence_mode?).and_return(false)
+
+    buffer.push({event_type: "cache_read", recorded_at: Time.current})
+
+    expect(buffer.size).to eq(0)
+  end
+end

--- a/spec/lib/solid_observer/cache_subscriber_spec.rb
+++ b/spec/lib/solid_observer/cache_subscriber_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CacheSubscriber do
+  before do
+    described_class.unsubscribe!
+    allow(SolidObserver::Services::RecordCacheEvent).to receive(:call)
+  end
+
+  after { described_class.unsubscribe! }
+
+  it "subscribes only when solid cache is enabled" do
+    allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(false)
+
+    described_class.subscribe!
+
+    expect(described_class.subscribed?).to be(false)
+  end
+
+  it "subscribes to configured cache events" do
+    allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(true)
+
+    described_class.subscribe!
+    ActiveSupport::Notifications.instrument("cache_read.active_support", {key: "secret-key", hit: true})
+
+    expect(SolidObserver::Services::RecordCacheEvent).to have_received(:call).with(
+      hash_including(buffer: SolidObserver::CacheEventBuffer.instance, event: be_a(ActiveSupport::Notifications::Event))
+    )
+  end
+
+  it "unsubscribes from all notifications" do
+    allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(true)
+
+    described_class.subscribe!
+    described_class.unsubscribe!
+
+    expect(described_class.subscribed?).to be(false)
+  end
+end

--- a/spec/lib/solid_observer/services/flush_cache_event_buffer_spec.rb
+++ b/spec/lib/solid_observer/services/flush_cache_event_buffer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Services::FlushCacheEventBuffer do
+  let(:events) { [{event_type: "cache_read", key_digest: "abc", recorded_at: Time.current, metadata: "{}"}] }
+
+  it "bulk inserts cache events" do
+    allow(SolidObserver::CacheEvent).to receive(:transaction).and_yield
+    allow(SolidObserver::CacheEvent).to receive(:insert_all!)
+
+    described_class.call(events)
+
+    expect(SolidObserver::CacheEvent).to have_received(:insert_all!).with(events)
+  end
+
+  it "falls back to smaller batches on statement failure" do
+    allow(SolidObserver::CacheEvent).to receive(:transaction).and_yield
+    allow(SolidObserver::CacheEvent).to receive(:insert_all!).and_raise(ActiveRecord::StatementInvalid, "boom")
+    allow(SolidObserver::CacheEvent).to receive(:insert_all).and_return(true)
+    allow(Rails).to receive(:logger).and_return(instance_double(Logger, error: nil, warn: nil))
+
+    described_class.call(events)
+
+    expect(SolidObserver::CacheEvent).to have_received(:insert_all).at_least(:once)
+  end
+end

--- a/spec/lib/solid_observer/services/record_cache_event_spec.rb
+++ b/spec/lib/solid_observer/services/record_cache_event_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Services::RecordCacheEvent do
+  let(:buffer) { instance_double(SolidObserver::CacheEventBuffer, push: nil) }
+  let(:payload) { {key: "user:42", hit: true, super_operation: :fetch} }
+  let(:event) { ActiveSupport::Notifications::Event.new("cache_read.active_support", Time.current, Time.current + 0.01, "id", payload) }
+
+  it "stores safe metadata and a non-raw key digest" do
+    allow(Kernel).to receive(:rand).and_return(1.0)
+    allow(SolidObserver.config).to receive_messages(cache_sampling_rate: 1.0, cache_slow_threshold: 1.0, cache_store_errors: true)
+
+    described_class.call(event: event, buffer: buffer)
+
+    expect(buffer).to have_received(:push).with(hash_including(
+      event_type: "cache_read",
+      key_digest: Digest::SHA256.hexdigest("user:42"),
+      hit: true,
+      duration: be > 0,
+      error_class: nil,
+      error_message: nil,
+      metadata: satisfy { |json| JSON.parse(json).keys.none? { |key| key == "key" || key == "value" } }
+    ))
+  end
+
+  it "stores unsampled events when slow" do
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive_messages(cache_sampling_rate: 0.0, cache_slow_threshold: 0.001, cache_store_errors: true)
+
+    described_class.call(event: event, buffer: buffer)
+
+    expect(buffer).to have_received(:push)
+  end
+
+  it "skips unsampled fast non-error events" do
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive_messages(cache_sampling_rate: 0.0, cache_slow_threshold: 10.0, cache_store_errors: true)
+
+    described_class.call(event: event, buffer: buffer)
+
+    expect(buffer).not_to have_received(:push)
+  end
+end

--- a/spec/models/solid_observer/cache_event_spec.rb
+++ b/spec/models/solid_observer/cache_event_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CacheEvent do
+  before(:all) do
+    connection = described_class.connection
+    next if connection.table_exists?(:solid_observer_cache_events)
+
+    connection.create_table :solid_observer_cache_events do |t|
+      t.string :event_type, null: false
+      t.string :key_digest, null: false
+      t.boolean :hit
+      t.float :duration
+      t.string :error_class
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before { described_class.delete_all }
+
+  it "inherits from BaseEvent" do
+    expect(described_class.superclass).to eq(SolidObserver::BaseEvent)
+  end
+
+  it "uses solid_observer_cache_events table" do
+    expect(described_class.table_name).to eq("solid_observer_cache_events")
+  end
+
+  it "validates required fields" do
+    record = described_class.new
+
+    expect(record).not_to be_valid
+    expect(record.errors[:event_type]).to be_present
+    expect(record.errors[:key_digest]).to be_present
+    expect(record.errors[:recorded_at]).to be_present
+  end
+end


### PR DESCRIPTION
## Summary of changes
- Add guarded cache subscriber activation for Rails/SolidCache cache notifications.
- Persist safe cache event telemetry with hashed key identifiers and no raw keys/values.
- Add cache event buffering, flush service, model, migration, and specs.