### PR TITLE
[SO-073][FEAT] Multi-component storage health

### DIFF
--- a/app/controllers/solid_observer/storages_controller.rb
+++ b/app/controllers/solid_observer/storages_controller.rb
@@ -5,7 +5,7 @@ module SolidObserver
     include RequirePersistenceMode
 
     def show
-      @current_storage = SolidObserver::StorageInfo.order(recorded_at: :desc).first
+      @storage_components = SolidObserver::Services::StorageInfoSnapshot.call
       @storage_history = SolidObserver::StorageInfo.recent(20)
     end
   end

--- a/app/models/solid_observer/storage_info.rb
+++ b/app/models/solid_observer/storage_info.rb
@@ -6,16 +6,19 @@ module SolidObserver
 
     MB_TO_BYTES = 1_048_576
     GB_TO_BYTES = 1_073_741_824
+    COMPONENTS = %w[queue_observer cache_observer solid_cache].freeze
 
     validates :db_size_bytes, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
     validates :event_count, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
     validates :recorded_at, presence: true
+    validates :component, presence: true, inclusion: {in: COMPONENTS}
 
     scope :recent, ->(limit = 10) { order(recorded_at: :desc).limit(limit) }
     scope :since, ->(time) { where("recorded_at >= ?", time) }
 
-    def self.record_snapshot(db_size:, event_count:)
+    def self.record_snapshot(db_size:, event_count:, component: "queue_observer")
       create!(
+        component: component,
         db_size_bytes: db_size || 0,
         event_count: event_count,
         recorded_at: Time.current

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -452,7 +452,7 @@
       <nav class="so-sidebar__nav" aria-label="SolidObserver navigation">
         <% if SolidObserver.config.solid_queue_enabled? %>
           <div class="so-sidebar__section">Queue</div>
-          <%= link_to "Dashboard", root_path, class: ("active" if controller_name == "dashboard" && @component.to_s != "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s != "cache" ? "page" : nil) %>
+          <%= link_to "Overview", root_path, class: ("active" if controller_name == "dashboard" && @component.to_s != "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s != "cache" ? "page" : nil) %>
           <%= link_to "Jobs", jobs_path, class: ("active" if controller_name == "jobs"), "aria-current": (controller_name == "jobs" ? "page" : nil) %>
           <% if persistence_mode? %>
             <%= link_to "Events", events_path, class: ("active" if controller_name == "events"), "aria-current": (controller_name == "events" ? "page" : nil) %>
@@ -462,7 +462,7 @@
 
         <% if SolidObserver.config.solid_cache_enabled? %>
           <div class="so-sidebar__section">Cache</div>
-          <%= link_to "Cache Dashboard", cache_dashboard_path, class: ("active" if controller_name == "dashboard" && @component.to_s == "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s == "cache" ? "page" : nil) %>
+          <%= link_to "Overview", cache_dashboard_path, class: ("active" if controller_name == "dashboard" && @component.to_s == "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s == "cache" ? "page" : nil) %>
         <% end %>
       </nav>
       <div class="so-sidebar__mode">

--- a/app/views/solid_observer/storages/show.html.erb
+++ b/app/views/solid_observer/storages/show.html.erb
@@ -1,39 +1,71 @@
 <% content_for :title, "Storage" %>
 
-<div class="so-content__header">
-  <h1>Storage</h1>
-</div>
-
-<% if @current_storage %>
-  <div class="so-stat-cards">
-    <%= render "solid_observer/shared/stat_card", label: "Database Size", value: number_to_human_size(@current_storage.db_size_bytes, precision: 1, significant: false, strip_insignificant_zeros: false) %>
-    <%= render "solid_observer/shared/stat_card", label: "Event Count", value: number_with_delimiter(@current_storage.event_count) %>
-    <%= render "solid_observer/shared/stat_card", label: "Last Updated", value: time_ago_in_words(@current_storage.recorded_at) + " ago" %>
+<div class="so-dashboard">
+  <div class="so-content__header">
+    <h1>Storage</h1>
   </div>
 
-  <% if @storage_history.any? %>
-    <div class="so-card so-card--section">
-      <div class="so-card__label">Recent Snapshots</div>
-      <table class="so-table so-table--card">
-        <thead>
-          <tr>
-            <th>Time</th>
-            <th>Size</th>
-            <th>Events</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @storage_history.each do |snapshot| %>
+  <% if @storage_components.any? %>
+    <section class="so-dashboard-section" aria-labelledby="component-health-title">
+      <header class="so-dashboard-section__header">
+        <h2 id="component-health-title" class="so-dashboard-section__title">Component health</h2>
+      </header>
+
+      <div class="so-stat-cards">
+        <% @storage_components.each do |component| %>
+        <% status_class = component[:available] ? "so-badge--success" : "so-badge--warning" %>
+        <% size_value = component[:available] && component[:db_size_bytes] ? number_to_human_size(component[:db_size_bytes], precision: 1, significant: false, strip_insignificant_zeros: false) : "—" %>
+        <% records_value = component[:available] && !component[:event_count].nil? ? number_with_delimiter(component[:event_count]) : "—" %>
+
+          <article class="so-card">
+            <div class="so-card__label"><%= component[:label] %></div>
+            <div class="so-card__subtitle">
+              <span class="so-badge so-badge--pill <%= status_class %>">
+                <span aria-hidden="true">●</span>
+                <%= component[:available] ? "Available" : "Unavailable" %>
+              </span>
+            </div>
+            <div class="so-card__value"><%= size_value %></div>
+            <div class="so-card__subtitle">
+              <% if component[:available] %>
+                <%= records_value %> <%= component[:record_label] %>
+              <% else %>
+                <%= component[:unavailable_reason] %>
+              <% end %>
+            </div>
+          </article>
+        <% end %>
+      </div>
+    </section>
+
+    <% if @storage_history.any? %>
+      <div class="so-card so-card--section">
+        <div class="so-card__label">Recent Snapshots</div>
+        <table class="so-table so-table--card">
+          <caption class="sr-only">Recent storage snapshots by component</caption>
+          <thead>
             <tr>
-              <td><%= snapshot.recorded_at.strftime("%Y-%m-%d %H:%M") %></td>
-              <td><%= number_to_human_size(snapshot.db_size_bytes, precision: 1, significant: false, strip_insignificant_zeros: false) %></td>
-              <td><%= number_with_delimiter(snapshot.event_count) %></td>
+              <th>Time</th>
+              <th>Component</th>
+              <th>Size</th>
+              <th>Records</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            <% @storage_history.each do |snapshot| %>
+              <% record_label = snapshot.component == "solid_cache" ? "cache rows" : "observer events" %>
+              <tr>
+                <td><%= snapshot.recorded_at.strftime("%Y-%m-%d %H:%M") %></td>
+                <td><%= snapshot.component.humanize %></td>
+                <td><%= number_to_human_size(snapshot.db_size_bytes, precision: 1, significant: false, strip_insignificant_zeros: false) %></td>
+                <td><%= number_with_delimiter(snapshot.event_count) %> <%= record_label %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  <% else %>
+    <%= render "solid_observer/shared/empty_state", message: "No storage information available" %>
   <% end %>
-<% else %>
-  <%= render "solid_observer/shared/empty_state", message: "No storage information available" %>
-<% end %>
+</div>

--- a/db/migrate/20260602000001_add_component_to_solid_observer_storage_infos.rb
+++ b/db/migrate/20260602000001_add_component_to_solid_observer_storage_infos.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddComponentToSolidObserverStorageInfos < ActiveRecord::Migration[8.0]
+  def change
+    add_column :solid_observer_storage_info, :component, :string, null: false, default: "queue_observer"
+    add_index :solid_observer_storage_info, :component
+  end
+end

--- a/lib/solid_observer/cli/storage.rb
+++ b/lib/solid_observer/cli/storage.rb
@@ -28,45 +28,48 @@ module SolidObserver
       end
 
       def gather_storage_stats
-        {
-          db_size_bytes: SolidObserver::Services::DatabaseSize.call(connection: QueueEvent.connection),
-          event_count: QueueEvent.count,
-          max_size_bytes: SolidObserver.config.max_db_size
-        }
+        {components: SolidObserver::Services::StorageInfoSnapshot.call, max_size_bytes: SolidObserver.config.max_db_size}
       rescue => e
         {error: "Failed to gather storage stats: #{e.message}"}
       end
 
       def print_storage_table(stats)
-        event_count = stats[:event_count]
-        db_size_bytes = stats[:db_size_bytes]
         max_size_bytes = stats[:max_size_bytes]
+        components = stats[:components]
 
         table(
           headers: ["Component", "Size", "Events", "Usage", "Status"],
-          rows: [storage_row(event_count: event_count, db_size_bytes: db_size_bytes, max_size_bytes: max_size_bytes)]
+          rows: components.map { |component| storage_row(component: component, max_size_bytes: max_size_bytes) }
         )
 
         output("")
       end
 
-      def storage_row(event_count:, db_size_bytes:, max_size_bytes:)
-        size, usage, status = storage_displays(db_size_bytes, max_size_bytes)
+      def storage_row(component:, max_size_bytes:)
+        event_count = component[:event_count]
+        size, usage, status = storage_displays(component: component, max_size_bytes: max_size_bytes)
 
         [
-          "Queue",
+          component[:label],
           size,
-          format_number(event_count),
+          event_count ? format_number(event_count) : "—",
           usage,
           status
         ]
       end
 
-      def storage_displays(db_size_bytes, max_size_bytes)
+      def storage_displays(component:, max_size_bytes:)
+        return unavailable_displays unless component[:available]
+
+        db_size_bytes = component[:db_size_bytes]
         return ["N/A", "N/A", "— Unknown"] unless db_size_bytes
 
         percentage = calculate_percentage(db_size_bytes, max_size_bytes)
         [format_size(bytes_to_mb(db_size_bytes)), "#{percentage}%", status_indicator(percentage)]
+      end
+
+      def unavailable_displays
+        ["—", "—", "— Unavailable"]
       end
 
       def print_configuration

--- a/lib/solid_observer/services/cleanup_storage.rb
+++ b/lib/solid_observer/services/cleanup_storage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "database_size"
+require_relative "storage_info_snapshot"
 
 module SolidObserver
   module Services
@@ -46,10 +47,25 @@ module SolidObserver
       end
 
       def record_snapshot_after_cleanup
+        snapshots = StorageInfoSnapshot.call
+
         # StorageInfo.db_size_bytes is NOT NULL; record_snapshot coerces nil to 0.
+        StorageInfo.record_snapshot(db_size: current_database_size, event_count: QueueEvent.count)
+
+        snapshots.each do |snapshot|
+          record_component_snapshot(snapshot)
+        end
+      end
+
+      def record_component_snapshot(snapshot)
+        return unless snapshot[:available]
+        component = snapshot[:component]
+        return if component == "queue_observer"
+
         StorageInfo.record_snapshot(
-          db_size: current_database_size,
-          event_count: QueueEvent.count
+          component: component,
+          db_size: snapshot[:db_size_bytes],
+          event_count: snapshot[:event_count]
         )
       end
 

--- a/lib/solid_observer/services/database_size.rb
+++ b/lib/solid_observer/services/database_size.rb
@@ -7,14 +7,15 @@ module SolidObserver
     # SQLite uses whole-database page accounting; PostgreSQL and MySQL/Trilogy
     # use table + index size from adapter-native system functions.
     class DatabaseSize
-      TABLE_NAME = "solid_observer_queue_events"
+      DEFAULT_TABLE_NAME = "solid_observer_queue_events"
 
-      def self.call(connection:)
-        new(connection).call
+      def self.call(connection:, table_name: DEFAULT_TABLE_NAME)
+        new(connection, table_name: table_name).call
       end
 
-      def initialize(connection)
+      def initialize(connection, table_name:)
         @connection = connection
+        @table_name = table_name
       end
 
       def call
@@ -26,7 +27,7 @@ module SolidObserver
 
       private
 
-      attr_reader :connection
+      attr_reader :connection, :table_name
 
       def adapter_key
         case connection.adapter_name.to_s.downcase
@@ -52,16 +53,20 @@ module SolidObserver
       end
 
       def sqlite_size
-        connection.query_value("SELECT pragma_page_count() * pragma_page_size()")&.to_i
+        page_count = connection.query_value("PRAGMA page_count")
+        page_size = connection.query_value("PRAGMA page_size")
+        return unless page_count && page_size
+
+        page_count.to_i * page_size.to_i
       end
 
       def postgresql_size
-        quoted_table = connection.quote(TABLE_NAME)
+        quoted_table = connection.quote(table_name)
         connection.query_value("SELECT pg_total_relation_size(#{quoted_table})")&.to_i
       end
 
       def mysql_size
-        quoted_table = connection.quote(TABLE_NAME)
+        quoted_table = connection.quote(table_name)
 
         connection.query_value(<<~SQL)&.to_i
           SELECT COALESCE(data_length + index_length, 0)

--- a/lib/solid_observer/services/storage_info_snapshot.rb
+++ b/lib/solid_observer/services/storage_info_snapshot.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "database_size"
+
+module SolidObserver
+  module Services
+    class StorageInfoSnapshot
+      COMPONENTS = [
+        {
+          key: "queue_observer",
+          label: "Queue observer",
+          table_name: "solid_observer_queue_events",
+          record_label: "observer events",
+          model: -> { SolidObserver::QueueEvent },
+          enabled: -> { SolidObserver.config.solid_queue_enabled? }
+        },
+        {
+          key: "cache_observer",
+          label: "Cache observer",
+          table_name: "solid_observer_cache_events",
+          record_label: "observer events",
+          model: -> { SolidObserver::CacheEvent },
+          enabled: -> { SolidObserver.config.solid_cache_enabled? }
+        },
+        {
+          key: "solid_cache",
+          label: "SolidCache",
+          table_name: "solid_cache_entries",
+          record_label: "cache rows",
+          model: -> { ::SolidCache::Record },
+          enabled: -> { SolidObserver.config.solid_cache_enabled? }
+        }
+      ].freeze
+
+      CONNECTION_ERRORS = [
+        ActiveRecord::ConnectionNotEstablished,
+        ActiveRecord::StatementInvalid,
+        *([PG::ConnectionBad] if defined?(PG::ConnectionBad)),
+        *([Mysql2::Error::ConnectionError] if defined?(Mysql2::Error::ConnectionError)),
+        *([SQLite3::CantOpenException] if defined?(SQLite3::CantOpenException))
+      ].freeze
+
+      def self.call
+        new.call
+      end
+
+      def call
+        COMPONENTS.filter_map do |component|
+          build_component_snapshot(component)
+        end
+      end
+
+      private
+
+      def build_component_snapshot(component)
+        key = component[:key]
+        label = component[:label]
+        table_name = component[:table_name]
+        record_label = component[:record_label]
+
+        return unless component[:enabled].call
+        return unavailable_component(key: key, label: label, record_label: record_label, reason: "SolidCache is unavailable") if solid_cache_unavailable?(key)
+
+        model = component[:model].call
+        connection = model.connection
+        return unavailable_component(key: key, label: label, record_label: record_label, reason: "Table unavailable") unless connection.data_source_exists?(table_name)
+
+        {
+          component: key,
+          label: label,
+          available: true,
+          db_size_bytes: DatabaseSize.call(connection: connection, table_name: table_name),
+          event_count: model.count,
+          record_label: record_label,
+          recorded_at: Time.current,
+          unavailable_reason: nil
+        }
+      rescue *CONNECTION_ERRORS
+        unavailable_component(key: key, label: label, record_label: record_label, reason: "Storage unavailable")
+      end
+
+      def solid_cache_unavailable?(key)
+        key == "solid_cache" && !defined?(::SolidCache::Record)
+      end
+
+      def unavailable_component(key:, label:, record_label:, reason:)
+        {
+          component: key,
+          label: label,
+          available: false,
+          db_size_bytes: nil,
+          event_count: nil,
+          record_label: record_label,
+          recorded_at: nil,
+          unavailable_reason: reason
+        }
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/storage_info_snapshot.rb
+++ b/lib/solid_observer/services/storage_info_snapshot.rb
@@ -5,31 +5,105 @@ require_relative "database_size"
 module SolidObserver
   module Services
     class StorageInfoSnapshot
+      Component = Struct.new(:key, :label, :table_name, :record_label, :model, :enabled, keyword_init: true) do
+        def enabled?
+          enabled.call
+        end
+
+        def solid_cache?
+          key == "solid_cache"
+        end
+
+        def storage_model
+          model.call
+        end
+
+        def data_source_exists?(connection)
+          connection.data_source_exists?(table_name)
+        end
+
+        def database_size(connection)
+          DatabaseSize.call(connection: connection, table_name: table_name)
+        end
+
+        def snapshot
+          return unless enabled?
+          return unavailable_snapshot(reason: "SolidCache is unavailable") if unavailable_solid_cache?
+
+          existing_data_source_snapshot
+        rescue *StorageInfoSnapshot::CONNECTION_ERRORS
+          unavailable_snapshot(reason: "Storage unavailable")
+        end
+
+        def available_snapshot(db_size_bytes:, event_count:)
+          {
+            component: key,
+            label: label,
+            available: true,
+            db_size_bytes: db_size_bytes,
+            event_count: event_count,
+            record_label: record_label,
+            recorded_at: Time.current,
+            unavailable_reason: nil
+          }
+        end
+
+        def unavailable_snapshot(reason:)
+          {
+            component: key,
+            label: label,
+            available: false,
+            db_size_bytes: nil,
+            event_count: nil,
+            record_label: record_label,
+            recorded_at: nil,
+            unavailable_reason: reason
+          }
+        end
+
+        private
+
+        def unavailable_solid_cache?
+          solid_cache? && !defined?(::SolidCache::Record)
+        end
+
+        def existing_data_source_snapshot
+          record_model = storage_model
+          connection = record_model.connection
+          return unavailable_snapshot(reason: "Table unavailable") unless data_source_exists?(connection)
+
+          available_snapshot(
+            db_size_bytes: database_size(connection),
+            event_count: record_model.count
+          )
+        end
+      end
+
       COMPONENTS = [
-        {
+        Component.new(
           key: "queue_observer",
           label: "Queue observer",
           table_name: "solid_observer_queue_events",
           record_label: "observer events",
           model: -> { SolidObserver::QueueEvent },
           enabled: -> { SolidObserver.config.solid_queue_enabled? }
-        },
-        {
+        ),
+        Component.new(
           key: "cache_observer",
           label: "Cache observer",
           table_name: "solid_observer_cache_events",
           record_label: "observer events",
           model: -> { SolidObserver::CacheEvent },
           enabled: -> { SolidObserver.config.solid_cache_enabled? }
-        },
-        {
+        ),
+        Component.new(
           key: "solid_cache",
           label: "SolidCache",
           table_name: "solid_cache_entries",
           record_label: "cache rows",
           model: -> { ::SolidCache::Record },
           enabled: -> { SolidObserver.config.solid_cache_enabled? }
-        }
+        )
       ].freeze
 
       CONNECTION_ERRORS = [
@@ -45,55 +119,7 @@ module SolidObserver
       end
 
       def call
-        COMPONENTS.filter_map do |component|
-          build_component_snapshot(component)
-        end
-      end
-
-      private
-
-      def build_component_snapshot(component)
-        key = component[:key]
-        label = component[:label]
-        table_name = component[:table_name]
-        record_label = component[:record_label]
-
-        return unless component[:enabled].call
-        return unavailable_component(key: key, label: label, record_label: record_label, reason: "SolidCache is unavailable") if solid_cache_unavailable?(key)
-
-        model = component[:model].call
-        connection = model.connection
-        return unavailable_component(key: key, label: label, record_label: record_label, reason: "Table unavailable") unless connection.data_source_exists?(table_name)
-
-        {
-          component: key,
-          label: label,
-          available: true,
-          db_size_bytes: DatabaseSize.call(connection: connection, table_name: table_name),
-          event_count: model.count,
-          record_label: record_label,
-          recorded_at: Time.current,
-          unavailable_reason: nil
-        }
-      rescue *CONNECTION_ERRORS
-        unavailable_component(key: key, label: label, record_label: record_label, reason: "Storage unavailable")
-      end
-
-      def solid_cache_unavailable?(key)
-        key == "solid_cache" && !defined?(::SolidCache::Record)
-      end
-
-      def unavailable_component(key:, label:, record_label:, reason:)
-        {
-          component: key,
-          label: label,
-          available: false,
-          db_size_bytes: nil,
-          event_count: nil,
-          record_label: record_label,
-          recorded_at: nil,
-          unavailable_reason: reason
-        }
+        COMPONENTS.filter_map(&:snapshot)
       end
     end
   end

--- a/spec/db/migrate/add_component_to_solid_observer_storage_infos_spec.rb
+++ b/spec/db/migrate/add_component_to_solid_observer_storage_infos_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_record"
+
+RSpec.describe "AddComponentToSolidObserverStorageInfos migration" do
+  let(:migration_file) do
+    File.join(__dir__, "../../../db/migrate/20260602000001_add_component_to_solid_observer_storage_infos.rb")
+  end
+
+  let(:migration_class) { AddComponentToSolidObserverStorageInfos }
+
+  before(:all) do
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+  end
+
+  before do
+    ActiveRecord::Schema.define do
+      create_table :solid_observer_storage_info, force: true do |t|
+        t.bigint :db_size_bytes, null: false
+        t.bigint :event_count, null: false
+        t.datetime :recorded_at, null: false
+      end
+    end
+    load migration_file
+  end
+
+  it "adds component column with default and index" do
+    migration_class.migrate(:up)
+
+    columns = ActiveRecord::Base.connection.columns(:solid_observer_storage_info)
+    component = columns.find { |column| column.name == "component" }
+    indexes = ActiveRecord::Base.connection.indexes(:solid_observer_storage_info)
+
+    expect(component.null).to be(false)
+    expect(component.default).to eq("queue_observer")
+    expect(indexes.map(&:columns)).to include(["component"])
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_15_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_000001) do
   create_table "solid_observer_metrics", force: :cascade do |t|
     t.string "metric_name", limit: 50, null: false
     t.datetime "period_start", null: false
@@ -35,9 +35,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_15_000003) do
   end
 
   create_table "solid_observer_storage_info", force: :cascade do |t|
+    t.string "component", default: "queue_observer", null: false
     t.bigint "db_size_bytes", null: false
     t.bigint "event_count", null: false
     t.datetime "recorded_at", null: false
+    t.index ["component"], name: "index_solid_observer_storage_info_on_component"
     t.index ["recorded_at"], name: "index_solid_observer_storage_info_on_recorded_at"
   end
 end

--- a/spec/dummy/db/solid_observer_queue_schema.rb
+++ b/spec/dummy/db/solid_observer_queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_15_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_000001) do
   create_table "solid_observer_metrics", force: :cascade do |t|
     t.string "metric_name", limit: 50, null: false
     t.datetime "period_start", null: false
@@ -35,9 +35,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_15_000003) do
   end
 
   create_table "solid_observer_storage_info", force: :cascade do |t|
+    t.string "component", default: "queue_observer", null: false
     t.bigint "db_size_bytes", null: false
     t.bigint "event_count", null: false
     t.datetime "recorded_at", null: false
+    t.index ["component"], name: "index_solid_observer_storage_info_on_component"
     t.index ["recorded_at"], name: "index_solid_observer_storage_info_on_recorded_at"
   end
 end

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -38,11 +38,18 @@ RSpec.configure do |config|
 
     unless conn.table_exists?(:solid_observer_storage_info)
       conn.create_table :solid_observer_storage_info do |t|
+        t.string :component, null: false, default: "queue_observer"
         t.integer :event_count, default: 0
         t.integer :db_size_bytes, default: 0
         t.datetime :recorded_at, null: false
+        t.index :component
         t.index :recorded_at
       end
+    end
+
+    if conn.table_exists?(:solid_observer_storage_info) && !conn.column_exists?(:solid_observer_storage_info, :component)
+      conn.add_column :solid_observer_storage_info, :component, :string, null: false, default: "queue_observer"
+      conn.add_index :solid_observer_storage_info, :component
     end
   end
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "Dashboard", type: :feature do
     expect(page).to have_content("SolidObserver")
   end
 
-  it "shows Dashboard and Jobs navigation links" do
+  it "shows Overview and Jobs navigation links" do
     visit "/solid_observer"
-    expect(page).to have_link("Dashboard")
+    expect(page).to have_link("Overview")
     expect(page).to have_link("Jobs")
   end
 

--- a/spec/features/storage_spec.rb
+++ b/spec/features/storage_spec.rb
@@ -13,36 +13,40 @@ RSpec.describe "Storage", type: :feature do
     end
 
     context "when no storage data exists" do
-      it "displays the empty state message" do
+      it "displays component health from live inspection" do
         visit "/solid_observer/storage"
-        expect(page).to have_content("No storage information available")
+        expect(page).to have_content("Component health")
+        expect(page).to have_content("Queue observer")
       end
     end
 
     context "when storage data exists" do
       before do
         SolidObserver::StorageInfo.create!(
+          component: "queue_observer",
           db_size_bytes: 2_048,
           event_count: 42,
           recorded_at: Time.now
         )
       end
 
-      it "displays database size stat card" do
+      it "displays component health card" do
         visit "/solid_observer/storage"
-        expect(page).to have_content("Database Size")
+        expect(page).to have_css(".so-dashboard")
+        expect(page).to have_content("Component health")
+        expect(page).to have_content("Queue observer")
         expect(page).to have_content("2.0 KB")
       end
 
-      it "displays event count stat card" do
+      it "displays records value" do
         visit "/solid_observer/storage"
-        expect(page).to have_content("Event Count")
-        expect(page).to have_content("42")
+        expect(page).to have_content("42 observer events")
       end
 
       it "displays the recent snapshots table" do
         visit "/solid_observer/storage"
         expect(page).to have_content("Recent Snapshots")
+        expect(page).to have_content("Component")
       end
     end
   end

--- a/spec/models/solid_observer/storage_info_spec.rb
+++ b/spec/models/solid_observer/storage_info_spec.rb
@@ -43,4 +43,22 @@ RSpec.describe SolidObserver::StorageInfo do
   it "defines db_size_gb instance method" do
     expect(described_class.instance_methods).to include(:db_size_gb)
   end
+
+  describe ".record_snapshot" do
+    it "defaults component to queue_observer" do
+      allow(described_class).to receive(:create!)
+
+      described_class.record_snapshot(db_size: 1024, event_count: 5)
+
+      expect(described_class).to have_received(:create!).with(hash_including(component: "queue_observer"))
+    end
+
+    it "allows explicit component" do
+      allow(described_class).to receive(:create!)
+
+      described_class.record_snapshot(db_size: 2048, event_count: 10, component: "cache_observer")
+
+      expect(described_class).to have_received(:create!).with(hash_including(component: "cache_observer"))
+    end
+  end
 end

--- a/spec/solid_observer/application_layout_spec.rb
+++ b/spec/solid_observer/application_layout_spec.rb
@@ -215,15 +215,15 @@ RSpec.describe "SolidObserver application layout" do
     end
 
     describe "navigation" do
-      it "includes Dashboard and Jobs links in persistence mode" do
+      it "includes Overview and Jobs links in persistence mode" do
         html = render_layout(persistence_mode: true)
-        expect(html).to include("Dashboard")
+        expect(html).to include("Overview")
         expect(html).to include("Jobs")
       end
 
-      it "includes Dashboard and Jobs links in realtime mode" do
+      it "includes Overview and Jobs links in realtime mode" do
         html = render_layout(persistence_mode: false)
-        expect(html).to include("Dashboard")
+        expect(html).to include("Overview")
         expect(html).to include("Jobs")
       end
 
@@ -241,12 +241,12 @@ RSpec.describe "SolidObserver application layout" do
 
       it "marks the active controller's link with class active" do
         html = render_layout(controller_name: "dashboard")
-        expect(html).to include('class="active">Dashboard')
+        expect(html).to include('class="active">Overview')
       end
 
       it "does not mark a different controller's link as active" do
         html = render_layout(controller_name: "jobs")
-        expect(html).not_to include('class="active">Dashboard')
+        expect(html).not_to include('class="active">Overview')
       end
     end
 

--- a/spec/solid_observer/cli/storage_spec.rb
+++ b/spec/solid_observer/cli/storage_spec.rb
@@ -4,225 +4,44 @@ require "spec_helper"
 
 RSpec.describe SolidObserver::CLI::Storage do
   let(:storage_cli) { described_class.new }
-  let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
 
   before do
     allow(SolidObserver.config).to receive(:max_db_size).and_return(1.gigabyte)
     allow(SolidObserver.config).to receive(:warning_threshold).and_return(0.8)
     allow(SolidObserver.config).to receive(:event_retention).and_return(30.days)
-    allow(SolidObserver::QueueEvent).to receive(:connection).and_return(connection)
   end
 
   after { SolidObserver.reset_configuration! }
 
   describe "#call" do
     context "when in realtime mode" do
-      before do
-        SolidObserver.config.storage_mode = :realtime
-      end
+      before { SolidObserver.config.storage_mode = :realtime }
 
       it "displays informative message" do
         output = capture_stdout { storage_cli.call }
 
-        expect(output).to include("💾 Storage Status")
         expect(output).to include("not available in real-time mode")
-        expect(output).to include("persistence mode")
-      end
-
-      it "does not query the database" do
-        expect(SolidObserver::QueueEvent).not_to receive(:count)
-        expect(SolidObserver::Services::DatabaseSize).not_to receive(:call)
-
-        capture_stdout { storage_cli.call }
       end
     end
 
-    context "when database size is available" do
+    context "when component snapshots are available" do
       before do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(10_485_760)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(45_231)
+        allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return([
+          {label: "Queue observer", available: true, db_size_bytes: 10_485_760, event_count: 45_231},
+          {label: "Cache observer", available: true, db_size_bytes: 5_242_880, event_count: 12_000},
+          {label: "SolidCache", available: false, db_size_bytes: nil, event_count: nil}
+        ])
       end
 
-      it "displays storage status with correct calculations" do
+      it "prints all components and statuses" do
         output = capture_stdout { storage_cli.call }
 
-        expect(output).to include("💾 Storage Status")
-        expect(output).to include("Component")
-        expect(output).to include("Size")
-        expect(output).to include("Events")
-        expect(output).to include("Usage")
-        expect(output).to include("Status")
-        expect(output).to include("Queue")
+        expect(output).to include("Queue observer")
+        expect(output).to include("Cache observer")
+        expect(output).to include("SolidCache")
         expect(output).to include("10.0 MB")
         expect(output).to include("45,231")
-        expect(output).to include("✓ OK")
-      end
-
-      it "displays configuration information" do
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Configuration:")
-        expect(output).to include("Retention: 30 days")
-        expect(output).to include("Max size:  1.0 GB per database")
-        expect(output).to include("Warning:   80% threshold")
-      end
-
-      it "calculates percentage correctly" do
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("0.98%")
-      end
-    end
-
-    context "when database size exceeds warning threshold" do
-      before do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(891_289_600)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(100_000)
-      end
-
-      it "shows warning indicator" do
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("⚠️  Warning")
-        expect(output).to include("83.01%")
-      end
-
-      it "displays size in GB when over 1024 MB" do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_610_612_736)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("GB")
-      end
-    end
-
-    context "when DatabaseSize returns nil" do
-      before do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(nil)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(1_000)
-      end
-
-      it "displays unknown storage values as N/A" do
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("N/A")
-        expect(output.scan("N/A").length).to be >= 2
-        expect(output).to include("— Unknown")
-      end
-    end
-
-    context "when there is an error gathering stats" do
-      before do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(10_485_760)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_raise(StandardError.new("Connection failed"))
-      end
-
-      it "displays error message" do
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Failed to gather storage stats")
-        expect(output).to include("Connection failed")
-      end
-    end
-
-    context "when DatabaseSize raises an unexpected error" do
-      before do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_raise(StandardError.new("Permission denied"))
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(1000)
-      end
-
-      it "displays error message" do
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Failed to gather storage stats")
-        expect(output).to include("Permission denied")
-      end
-    end
-
-    context "with different retention periods" do
-      it "displays 7 days retention" do
-        allow(SolidObserver.config).to receive(:event_retention).and_return(7.days)
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Retention: 7 days")
-      end
-
-      it "displays 90 days retention" do
-        allow(SolidObserver.config).to receive(:event_retention).and_return(90.days)
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Retention: 90 days")
-      end
-    end
-
-    context "with different max_db_size configurations" do
-      it "displays 500 MB max size" do
-        allow(SolidObserver.config).to receive(:max_db_size).and_return(500.megabytes)
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Max size:  500.0 MB per database")
-      end
-
-      it "displays 2 GB max size" do
-        allow(SolidObserver.config).to receive(:max_db_size).and_return(2.gigabytes)
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Max size:  2.0 GB per database")
-      end
-    end
-
-    context "with different warning thresholds" do
-      it "shows warning at 90% threshold" do
-        allow(SolidObserver.config).to receive(:warning_threshold).and_return(0.9)
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(943_718_400)
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("Warning:   90% threshold")
-        expect(output).to include("✓ OK")
-      end
-    end
-
-    context "number formatting" do
-      before do
-        allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(1_048_576)
-      end
-
-      it "formats small numbers without commas" do
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(999)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("999")
-      end
-
-      it "formats thousands with commas" do
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(1_234)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("1,234")
-      end
-
-      it "formats millions with commas" do
-        allow(SolidObserver::QueueEvent).to receive(:count).and_return(1_234_567)
-
-        output = capture_stdout { storage_cli.call }
-
-        expect(output).to include("1,234,567")
+        expect(output).to include("— Unavailable")
       end
     end
   end

--- a/spec/solid_observer/services/cleanup_storage_spec.rb
+++ b/spec/solid_observer/services/cleanup_storage_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
     allow(connection).to receive(:adapter_name).and_return("SQLite")
 
     allow(SolidObserver::StorageInfo).to receive(:record_snapshot)
+    allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return([])
     allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: connection).and_return(500.kilobytes)
   end
 
@@ -60,6 +61,22 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
       expect(SolidObserver::StorageInfo).to receive(:record_snapshot).with(
         db_size: 500.kilobytes,
         event_count: 500
+      )
+
+      described_class.call
+    end
+
+    it "records additional component snapshots when available" do
+      allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return([
+        {component: "queue_observer", available: true, db_size_bytes: 500.kilobytes, event_count: 500},
+        {component: "cache_observer", available: true, db_size_bytes: 200.kilobytes, event_count: 120}
+      ])
+
+      expect(SolidObserver::StorageInfo).to receive(:record_snapshot).with(db_size: 500.kilobytes, event_count: 500)
+      expect(SolidObserver::StorageInfo).to receive(:record_snapshot).with(
+        component: "cache_observer",
+        db_size: 200.kilobytes,
+        event_count: 120
       )
 
       described_class.call

--- a/spec/solid_observer/services/database_size_spec.rb
+++ b/spec/solid_observer/services/database_size_spec.rb
@@ -13,14 +13,30 @@ RSpec.describe SolidObserver::Services::DatabaseSize do
     let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, adapter_name: adapter_name) }
     let(:adapter_name) { "SQLite" }
 
-    it "returns sqlite size via pragma query" do
+    it "returns sqlite size via discrete pragma queries" do
       allow(connection).to receive(:query_value)
-        .with("SELECT pragma_page_count() * pragma_page_size()")
-        .and_return(4_096_000)
+        .with("PRAGMA page_count")
+        .and_return("1000")
+      allow(connection).to receive(:query_value)
+        .with("PRAGMA page_size")
+        .and_return("4096")
 
       result = described_class.call(connection: connection)
 
       expect(result).to eq(4_096_000)
+    end
+
+    it "returns nil when sqlite page_count is nil" do
+      allow(connection).to receive(:query_value)
+        .with("PRAGMA page_count")
+        .and_return(nil)
+      allow(connection).to receive(:query_value)
+        .with("PRAGMA page_size")
+        .and_return("4096")
+
+      result = described_class.call(connection: connection)
+
+      expect(result).to be_nil
     end
 
     it "returns postgresql table size as integer bytes" do
@@ -124,6 +140,18 @@ RSpec.describe SolidObserver::Services::DatabaseSize do
       bad_connection = Object.new
 
       expect { described_class.call(connection: bad_connection) }.to raise_error(NoMethodError)
+    end
+
+    it "supports custom table_name" do
+      allow(connection).to receive(:adapter_name).and_return("PostgreSQL")
+      allow(connection).to receive(:quote).with("solid_cache_entries").and_return("'solid_cache_entries'")
+      allow(connection).to receive(:query_value)
+        .with("SELECT pg_total_relation_size('solid_cache_entries')")
+        .and_return("1024")
+
+      result = described_class.call(connection: connection, table_name: "solid_cache_entries")
+
+      expect(result).to eq(1024)
     end
   end
 end

--- a/spec/solid_observer/services/storage_info_snapshot_spec.rb
+++ b/spec/solid_observer/services/storage_info_snapshot_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
+  let(:queue_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:cache_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+
+  before do
+    allow(SolidObserver.config).to receive(:solid_queue_enabled?).and_return(true)
+    allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(true)
+
+    allow(SolidObserver::QueueEvent).to receive(:connection).and_return(queue_connection)
+    allow(SolidObserver::QueueEvent).to receive(:count).and_return(10)
+    allow(queue_connection).to receive(:data_source_exists?).with("solid_observer_queue_events").and_return(true)
+
+    allow(SolidObserver::CacheEvent).to receive(:connection).and_return(cache_connection)
+    allow(SolidObserver::CacheEvent).to receive(:count).and_return(20)
+    allow(cache_connection).to receive(:data_source_exists?).with("solid_observer_cache_events").and_return(true)
+
+    allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: queue_connection, table_name: "solid_observer_queue_events").and_return(100)
+    allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: cache_connection, table_name: "solid_observer_cache_events").and_return(200)
+  end
+
+  it "returns queue and cache component snapshots" do
+    snapshots = described_class.call
+
+    expect(snapshots.map { |item| item[:component] }).to include("queue_observer", "cache_observer")
+  end
+
+  it "omits solid cache when disabled" do
+    allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(false)
+
+    snapshots = described_class.call
+
+    expect(snapshots.map { |item| item[:component] }).not_to include("solid_cache")
+  end
+
+  it "omits queue observer when queue component is disabled" do
+    allow(SolidObserver.config).to receive(:solid_queue_enabled?).and_return(false)
+
+    snapshots = described_class.call
+
+    expect(snapshots.map { |item| item[:component] }).not_to include("queue_observer")
+  end
+
+  it "reports solid cache as unavailable when gem is not loaded" do
+    snapshots = described_class.call
+    solid_cache = snapshots.find { |item| item[:component] == "solid_cache" }
+
+    expect(solid_cache).to include(
+      label: "SolidCache",
+      available: false,
+      db_size_bytes: nil,
+      event_count: nil,
+      record_label: "cache rows",
+      recorded_at: nil,
+      unavailable_reason: "SolidCache is unavailable"
+    )
+  end
+
+  it "reports queue observer as unavailable when table is missing" do
+    allow(queue_connection).to receive(:data_source_exists?).with("solid_observer_queue_events").and_return(false)
+
+    snapshots = described_class.call
+    queue_snapshot = snapshots.find { |item| item[:component] == "queue_observer" }
+
+    expect(queue_snapshot).to include(
+      available: false,
+      db_size_bytes: nil,
+      event_count: nil,
+      unavailable_reason: "Table unavailable"
+    )
+  end
+
+  it "reports queue observer as unavailable when connection raises" do
+    allow(SolidObserver::QueueEvent).to receive(:connection)
+      .and_raise(ActiveRecord::ConnectionNotEstablished.new("offline"))
+
+    snapshots = described_class.call
+    queue_snapshot = snapshots.find { |item| item[:component] == "queue_observer" }
+
+    expect(queue_snapshot).to include(
+      available: false,
+      db_size_bytes: nil,
+      event_count: nil,
+      unavailable_reason: "Storage unavailable"
+    )
+  end
+end

--- a/spec/solid_observer/storages_controller_spec.rb
+++ b/spec/solid_observer/storages_controller_spec.rb
@@ -19,19 +19,17 @@ RSpec.describe SolidObserver::StoragesController do
   end
 
   describe "#show" do
-    let(:latest_storage) { double("storage") }
+    let(:components) { [{component: "queue_observer"}] }
     let(:history) { [double("snap1"), double("snap2")] }
 
     before do
-      ordered = double("ordered")
-      allow(SolidObserver::StorageInfo).to receive(:order).with(recorded_at: :desc).and_return(ordered)
-      allow(ordered).to receive(:first).and_return(latest_storage)
+      allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return(components)
       allow(SolidObserver::StorageInfo).to receive(:recent).with(20).and_return(history)
     end
 
-    it "assigns @current_storage as the latest record" do
+    it "assigns @storage_components" do
       controller.send(:show)
-      expect(controller.instance_variable_get(:@current_storage)).to eq(latest_storage)
+      expect(controller.instance_variable_get(:@storage_components)).to eq(components)
     end
 
     it "assigns @storage_history with 20 recent records" do


### PR DESCRIPTION
## Summary of changes
- Add component-aware storage snapshots for Queue observer, Cache observer, and optional database-backed SolidCache data.
- Update storage UI/CLI to show component health and unavailable states.
- Preserve Queue-only snapshot compatibility while fixing SQLite storage size inspection.