### PR TITLE
[SO-074][FEAT] Add cache operational controls

### DIFF
--- a/app/controllers/solid_observer/cache_operations_controller.rb
+++ b/app/controllers/solid_observer/cache_operations_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CacheOperationsController < ApplicationController
+    def index
+      @cache_controls_available = SolidObserver::Services::CacheOperations.available?
+    end
+
+    def prune
+      redirect_with_result(SolidObserver::Services::CacheOperations.prune)
+    end
+
+    def clear
+      redirect_with_result(SolidObserver::Services::CacheOperations.clear)
+    end
+
+    private
+
+    def redirect_with_result(result)
+      flash_key = result[:ok] ? :notice : :alert
+      redirect_to cache_operations_path, flash_key => result[:message]
+    end
+  end
+end

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -154,6 +154,7 @@
     .so-toolbar-freshness { font-size: 0.75rem; color: var(--so-text-subtle); }
 
     /* SO-067 Focus rings */
+    .so-btn:focus-visible,
     select:focus-visible,
     .so-btn--refresh:focus-visible,
     .so-toggle--pill input:focus-visible + .so-toggle__track,
@@ -369,6 +370,48 @@
       .so-toggle__track, .so-toggle__thumb { transition: none; }
     }
 
+    .so-cache-controls { max-width: 820px; }
+    .so-cache-controls__intro {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      margin-top: 0.5rem;
+    }
+    .so-cache-controls__hint {
+      font-size: 0.875rem;
+      color: var(--so-text-subtle);
+      line-height: 1.5;
+    }
+    .so-cache-control-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 1rem;
+      align-items: center;
+      padding: 1rem 0;
+    }
+    .so-cache-control-row + .so-cache-control-row { border-top: 1px solid var(--so-border); }
+    .so-cache-control-row__copy { min-width: 0; }
+    .so-cache-control-row__title {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--so-text);
+    }
+    .so-cache-control-row__body {
+      margin-top: 0.35rem;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: var(--so-text-subtle);
+    }
+    .so-cache-control-row__action {
+      display: flex;
+      justify-content: flex-end;
+    }
+    .so-cache-control-row__action .so-form--inline {
+      display: flex;
+      justify-content: flex-end;
+    }
+
     .so-empty { text-align: center; padding: 3rem 1rem; color: var(--so-text-muted); }
     .so-empty__icon { font-size: 2rem; margin-bottom: 0.5rem; }
     .so-empty__message { font-size: 0.9rem; }
@@ -441,6 +484,10 @@
       .so-sidebar__mode { display: inline-block; padding: 0.5rem 1rem; border-top: none; margin-top: 0; font-size: 0.7rem; }
       .so-content { padding: 1rem; }
       .so-stat-cards { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+      .so-cache-control-row { grid-template-columns: 1fr; align-items: start; }
+      .so-cache-control-row__action,
+      .so-cache-control-row__action .so-form--inline { width: 100%; justify-content: stretch; }
+      .so-cache-control-row__action .so-btn { width: 100%; }
       .so-table { display: block; overflow-x: auto; }
     }
   </style>
@@ -463,6 +510,9 @@
         <% if SolidObserver.config.solid_cache_enabled? %>
           <div class="so-sidebar__section">Cache</div>
           <%= link_to "Overview", cache_dashboard_path, class: ("active" if controller_name == "dashboard" && @component.to_s == "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s == "cache" ? "page" : nil) %>
+          <% if SolidObserver::Services::CacheOperations.available? %>
+            <%= link_to "Controls", cache_operations_path, class: ("active" if controller_name == "cache_operations"), "aria-current": (controller_name == "cache_operations" ? "page" : nil) %>
+          <% end %>
         <% end %>
       </nav>
       <div class="so-sidebar__mode">
@@ -473,10 +523,10 @@
     <main class="so-content" aria-labelledby="so-main-heading">
       <h1 class="sr-only" id="so-main-heading">Dashboard</h1>
       <% if flash[:notice] %>
-        <div class="so-flash so-flash--notice"><%= flash[:notice] %></div>
+        <div class="so-flash so-flash--notice" role="status" aria-live="polite"><%= flash[:notice] %></div>
       <% end %>
       <% if flash[:alert] %>
-        <div class="so-flash so-flash--alert"><%= flash[:alert] %></div>
+        <div class="so-flash so-flash--alert" role="alert"><%= flash[:alert] %></div>
       <% end %>
       <%= yield %>
     </main>

--- a/app/views/solid_observer/cache_operations/_confirm_clear.html.erb
+++ b/app/views/solid_observer/cache_operations/_confirm_clear.html.erb
@@ -1,0 +1,6 @@
+<%= button_to "Clear cache",
+      clear_cache_operations_path,
+      method: :post,
+      class: "so-btn so-btn--danger",
+      form: {class: "so-form--inline"},
+      data: {confirm: SolidObserver::Services::CacheOperations.message(:clear, :confirmation)} %>

--- a/app/views/solid_observer/cache_operations/index.html.erb
+++ b/app/views/solid_observer/cache_operations/index.html.erb
@@ -1,0 +1,60 @@
+<% content_for :title, "Cache controls" %>
+<% cache_operations = SolidObserver::Services::CacheOperations %>
+<% status_class = @cache_controls_available ? "so-badge--success" : "so-badge--warning" %>
+
+<div class="so-dashboard so-cache-controls">
+  <div class="so-content__header">
+    <h1>Cache controls</h1>
+    <div class="so-cache-controls__intro">
+      <span class="so-badge so-badge--pill <%= status_class %>">
+        <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+          <circle r="3" cx="3" cy="3" fill="currentColor" />
+        </svg>
+        <%= @cache_controls_available ? "Available" : "Unavailable" %>
+      </span>
+      <p class="so-cache-controls__hint">Clear or prune SolidCache safely. Cache keys and values are never shown.</p>
+    </div>
+  </div>
+
+  <% if @cache_controls_available %>
+    <section class="so-card so-card--section" aria-labelledby="so-cache-controls-title">
+      <header class="so-dashboard-section__header">
+        <h2 id="so-cache-controls-title" class="so-dashboard-section__title">Operational controls</h2>
+      </header>
+
+      <div class="so-cache-control-row">
+        <div class="so-cache-control-row__copy">
+          <h3 class="so-cache-control-row__title">Prune expired entries</h3>
+          <p class="so-cache-control-row__body">Removes expired SolidCache records only. Active cache entries remain eligible for hits.</p>
+        </div>
+
+        <div class="so-cache-control-row__action">
+          <%= button_to "Prune expired entries",
+                prune_cache_operations_path,
+                method: :post,
+                class: "so-btn",
+                form: {class: "so-form--inline"} %>
+        </div>
+      </div>
+
+      <div class="so-cache-control-row">
+        <div class="so-cache-control-row__copy">
+          <h3 class="so-cache-control-row__title">Clear all cache</h3>
+          <p class="so-cache-control-row__body">Evicts all cached application data. Requests may slow while the cache rebuilds.</p>
+        </div>
+
+        <div class="so-cache-control-row__action">
+          <%= render "confirm_clear" %>
+        </div>
+      </div>
+    </section>
+  <% else %>
+    <section class="so-card so-card--section" aria-labelledby="so-cache-controls-unavailable-title">
+      <header class="so-dashboard-section__header">
+        <h2 id="so-cache-controls-unavailable-title" class="so-dashboard-section__title">Operational controls</h2>
+      </header>
+
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--idle"><%= cache_operations.unavailable_message %></p>
+    </section>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ SolidObserver::Engine.routes.draw do
   root "dashboard#index"
   get "queue", to: "dashboard#index", defaults: {component: "queue"}, as: :queue_dashboard
   get "cache", to: "dashboard#index", defaults: {component: "cache"}, as: :cache_dashboard
+  get "cache/controls", to: "cache_operations#index", as: :cache_operations
+  post "cache/controls/prune", to: "cache_operations#prune", as: :prune_cache_operations
+  post "cache/controls/clear", to: "cache_operations#clear", as: :clear_cache_operations
   get "poll_data", to: "dashboard#poll_data", as: :poll_data
   get "live_poll.js", to: "dashboard#live_poll", as: :live_poll_script
 

--- a/lib/generators/solid_observer/templates/initializer.rb.tt
+++ b/lib/generators/solid_observer/templates/initializer.rb.tt
@@ -19,7 +19,8 @@ SolidObserver.configure do |config|
   # === Queue Observability (v0.1.0) ===
   config.observe_queue = true
 
-  # === Cache Observability (Coming in v0.4.0+) ===
+  # === Cache Observability (v0.4.0) ===
+  # Enable SolidCache event capture and operational clear/prune controls
   # config.observe_cache = true
   # config.cache_sampling_rate = 0.1  # Sample 10% of cache operations
 

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -3,7 +3,10 @@
 require_relative "cache_event_buffer"
 require_relative "cache_subscriber"
 require_relative "services/record_cache_event"
+require_relative "services/record_cache_metric"
 require_relative "services/flush_cache_event_buffer"
+require_relative "services/cache_stats"
+require_relative "services/cache_operations"
 
 module SolidObserver
   class Engine < ::Rails::Engine

--- a/lib/solid_observer/services/cache_operations.rb
+++ b/lib/solid_observer/services/cache_operations.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    class CacheOperations
+      MESSAGES = {
+        clear: {
+          confirmation: "Clear all SolidCache entries? This evicts cached application data and may slow requests while the cache rebuilds. This cannot be undone.",
+          success: "Cache cleared successfully.",
+          failure: "Cache clear failed. SolidCache is unavailable or rejected the operation."
+        }.freeze,
+        prune: {
+          success: "Expired cache entries pruned successfully.",
+          failure: "Cache prune failed. SolidCache is unavailable or rejected the operation."
+        }.freeze,
+        unavailable: "Cache controls are unavailable because SolidCache is not enabled or not detected."
+      }.freeze
+
+      class << self
+        def available?
+          new.available?
+        end
+
+        def clear
+          new.clear
+        end
+
+        def prune
+          new.prune
+        end
+
+        def message(operation, key = nil)
+          return MESSAGES.fetch(:unavailable) if operation == :unavailable
+
+          MESSAGES.fetch(operation).fetch(key)
+        end
+
+        def unavailable_message
+          message(:unavailable)
+        end
+      end
+
+      def available?
+        SolidObserver.config.solid_cache_enabled? && compatible_store?
+      end
+
+      def clear
+        messages = self.class
+        return {ok: false, message: messages.unavailable_message} unless available?
+
+        perform_operation(
+          :clear,
+          success_message: messages.message(:clear, :success),
+          failure_message: messages.message(:clear, :failure)
+        ) do
+          cache_store.clear
+        end
+      end
+
+      def prune
+        messages = self.class
+        return {ok: false, message: messages.unavailable_message} unless available?
+
+        perform_operation(
+          :prune,
+          success_message: messages.message(:prune, :success),
+          failure_message: messages.message(:prune, :failure)
+        ) do
+          prune_with_fallback
+        end
+      end
+
+      private
+
+      def compatible_store?
+        defined?(::SolidCache::Store) && cache_store.is_a?(::SolidCache::Store)
+      end
+
+      def cache_store
+        Rails.cache
+      end
+
+      def perform_operation(name, success_message:, failure_message:)
+        yield
+        {ok: true, message: success_message}
+      rescue => error
+        log_failure(name, error)
+        {ok: false, message: failure_message}
+      end
+
+      def prune_with_fallback
+        cache_store.cleanup
+      rescue NotImplementedError
+        prune_with_solid_cache_fallback
+      end
+
+      def prune_with_solid_cache_fallback
+        cache_store.with_each_connection do
+          ::SolidCache::Entry.expire(
+            cache_store.expiry_batch_size,
+            max_age: cache_store.max_age,
+            max_entries: cache_store.max_entries,
+            max_size: cache_store.max_size
+          )
+        end
+      rescue NameError
+        raise "cleanup unsupported"
+      end
+
+      def log_failure(name, error)
+        Rails.logger&.warn("[SolidObserver] Cache #{name} failed: #{error.class}")
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/record_cache_event.rb
+++ b/lib/solid_observer/services/record_cache_event.rb
@@ -15,15 +15,20 @@ module SolidObserver
       end
 
       def call
-        SolidObserver::Services::RecordCacheMetric.call(event: @event)
-        return unless should_store_event?
-
-        @buffer.push(build_event_data)
+        record_metric_and_event
       rescue => error
+        raise error if error.is_a?(NameError)
         Rails.logger&.warn("[SolidObserver] Cache event recording failed: #{error.message}") if defined?(Rails)
       end
 
       private
+
+      def record_metric_and_event
+        SolidObserver::Services::RecordCacheMetric.call(event: @event)
+        return unless should_store_event?
+
+        @buffer.push(build_event_data)
+      end
 
       def should_store_event?
         sampled? || slow? || errored?

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -68,6 +68,35 @@ namespace :solid_observer do
     end
   end
 
+  namespace :cache do
+    desc "Clear all SolidCache entries after confirmation"
+    task clear: :environment do
+      if !SolidObserver::Services::CacheOperations.available?
+        puts SolidObserver::Services::CacheOperations.unavailable_message
+        next
+      end
+
+      print "#{SolidObserver::Services::CacheOperations.message(:clear, :confirmation)} (y/N) "
+      $stdout.flush
+
+      if $stdin.gets&.strip&.downcase == "y"
+        puts SolidObserver::Services::CacheOperations.clear[:message]
+      else
+        puts "Aborted"
+      end
+    end
+
+    desc "Prune expired SolidCache entries"
+    task prune: :environment do
+      if !SolidObserver::Services::CacheOperations.available?
+        puts SolidObserver::Services::CacheOperations.unavailable_message
+        next
+      end
+
+      puts SolidObserver::Services::CacheOperations.prune[:message]
+    end
+  end
+
   namespace :storage do
     desc "Run storage cleanup based on retention policy"
     task cleanup: :environment do

--- a/spec/lib/solid_observer/services/cache_operations_spec.rb
+++ b/spec/lib/solid_observer/services/cache_operations_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../../lib/solid_observer/services/cache_operations"
+
+RSpec.describe SolidObserver::Services::CacheOperations do
+  let(:logger) { instance_double(Logger, warn: nil) }
+  let(:entry_class) do
+    Class.new do
+      class << self
+        attr_reader :expire_calls
+
+        def expire(*args, **kwargs)
+          @expire_calls ||= []
+          @expire_calls << {args: args, kwargs: kwargs}
+        end
+      end
+    end
+  end
+  let(:store_class) do
+    Class.new do
+      attr_reader :cleanup_calls,
+        :clear_calls,
+        :connection_passes,
+        :expiry_batch_size,
+        :max_age,
+        :max_entries,
+        :max_size
+
+      def initialize
+        @cleanup_calls = 0
+        @clear_calls = 0
+        @connection_passes = 0
+        @expiry_batch_size = 12
+        @max_age = 300
+        @max_entries = 20
+        @max_size = 2048
+      end
+
+      def clear(_options = nil)
+        @clear_calls += 1
+      end
+
+      def cleanup(_options = nil)
+        @cleanup_calls += 1
+      end
+
+      def with_each_connection
+        @connection_passes += 1
+        yield
+      end
+    end
+  end
+  let(:cache_store) { store_class.new }
+
+  before do
+    stub_const("SolidCache", Module.new)
+    stub_const("SolidCache::Store", store_class)
+    stub_const("SolidCache::Entry", entry_class)
+    allow(Rails).to receive(:cache).and_return(cache_store)
+    allow(Rails).to receive(:logger).and_return(logger)
+    SolidObserver.config.observe_cache = true
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  describe ".available?" do
+    it "returns true for an enabled SolidCache store" do
+      expect(described_class.available?).to be(true)
+    end
+
+    it "returns false when cache observation is disabled" do
+      SolidObserver.config.observe_cache = false
+
+      expect(described_class.available?).to be(false)
+    end
+
+    it "returns false for a non-SolidCache store" do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
+
+      expect(described_class.available?).to be(false)
+    end
+  end
+
+  describe ".clear" do
+    it "clears the current SolidCache store" do
+      result = described_class.clear
+
+      expect(result).to eq(
+        ok: true,
+        message: described_class.message(:clear, :success)
+      )
+      expect(cache_store.clear_calls).to eq(1)
+    end
+
+    it "returns the unavailable copy when controls cannot run" do
+      SolidObserver.config.observe_cache = false
+
+      expect(described_class.clear).to eq(
+        ok: false,
+        message: described_class.unavailable_message
+      )
+    end
+
+    it "logs and sanitizes clear failures" do
+      allow(cache_store).to receive(:clear).and_raise(ActiveRecord::StatementInvalid.new("bad sql"))
+
+      result = described_class.clear
+
+      expect(result).to eq(
+        ok: false,
+        message: described_class.message(:clear, :failure)
+      )
+      expect(logger).to have_received(:warn).with(
+        "[SolidObserver] Cache clear failed: ActiveRecord::StatementInvalid"
+      )
+    end
+  end
+
+  describe ".prune" do
+    it "uses the public cleanup API when available" do
+      result = described_class.prune
+
+      expect(result).to eq(
+        ok: true,
+        message: described_class.message(:prune, :success)
+      )
+      expect(cache_store.cleanup_calls).to eq(1)
+      expect(entry_class.expire_calls).to be_nil
+    end
+
+    it "falls back to SolidCache expiry when cleanup is unsupported" do
+      allow(cache_store).to receive(:cleanup).and_raise(NotImplementedError)
+
+      result = described_class.prune
+
+      expect(result).to eq(
+        ok: true,
+        message: described_class.message(:prune, :success)
+      )
+      expect(cache_store.connection_passes).to eq(1)
+      expect(entry_class.expire_calls).to eq([
+        {
+          args: [12],
+          kwargs: {max_age: 300, max_entries: 20, max_size: 2048}
+        }
+      ])
+    end
+
+    it "returns the failure copy when no prune fallback is available" do
+      allow(cache_store).to receive(:cleanup).and_raise(NotImplementedError)
+      hide_const("SolidCache::Entry")
+
+      result = described_class.prune
+
+      expect(result).to eq(
+        ok: false,
+        message: described_class.message(:prune, :failure)
+      )
+      expect(logger).to have_received(:warn).with(
+        "[SolidObserver] Cache prune failed: RuntimeError"
+      )
+    end
+  end
+end

--- a/spec/lib/solid_observer/services/record_cache_event_spec.rb
+++ b/spec/lib/solid_observer/services/record_cache_event_spec.rb
@@ -52,4 +52,34 @@ RSpec.describe SolidObserver::Services::RecordCacheEvent do
 
     expect(buffer).not_to have_received(:push)
   end
+
+  it "re-raises NameError wiring failures" do
+    allow(SolidObserver::Services::RecordCacheMetric).to receive(:call).and_raise(
+      NameError.new("uninitialized constant SolidObserver::Services::RecordCacheMetric")
+    )
+
+    expect {
+      described_class.call(event: event, buffer: buffer)
+    }.to raise_error(NameError, /RecordCacheMetric/)
+
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "logs and swallows ordinary StandardError failures" do
+    logger = instance_double(Logger, warn: nil)
+
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(SolidObserver::Services::RecordCacheMetric).to receive(:call).and_raise(
+      ActiveRecord::StatementInvalid.new("missing table")
+    )
+
+    expect {
+      described_class.call(event: event, buffer: buffer)
+    }.not_to raise_error
+
+    expect(logger).to have_received(:warn).with(
+      "[SolidObserver] Cache event recording failed: missing table"
+    )
+    expect(buffer).not_to have_received(:push)
+  end
 end

--- a/spec/requests/solid_observer/cache_operations_spec.rb
+++ b/spec/requests/solid_observer/cache_operations_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidObserver cache operations", type: :request do
+  let(:store_class) do
+    Class.new do
+      attr_reader :expiry_batch_size, :max_age, :max_entries, :max_size
+
+      def initialize
+        @expiry_batch_size = 12
+        @max_age = 300
+        @max_entries = 20
+        @max_size = 2048
+      end
+
+      def clear(_options = nil)
+      end
+
+      def cleanup(_options = nil)
+      end
+
+      def with_each_connection
+        yield
+      end
+    end
+  end
+  let(:cache_store) { store_class.new }
+
+  around do |example|
+    previous_setting = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = false
+    example.run
+  ensure
+    ActionController::Base.allow_forgery_protection = previous_setting
+  end
+
+  before do
+    ensure_engine_view_path!
+    install_path_helpers!
+    stub_const("SolidCache", Module.new)
+    stub_const("SolidCache::Store", store_class)
+    allow(Rails).to receive(:cache).and_return(cache_store)
+    SolidObserver.config.ui_enabled = true
+    SolidObserver.config.observe_cache = true
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  def ensure_engine_view_path!
+    engine_views = SolidObserver::Engine.root.join("app/views").to_s
+    current_paths = SolidObserver::CacheOperationsController.view_paths.map(&:to_s)
+    return if current_paths.include?(engine_views)
+
+    SolidObserver::CacheOperationsController.prepend_view_path(engine_views)
+  end
+
+  def build_flash(messages)
+    ActionDispatch::Flash::FlashHash.new.tap do |flash_hash|
+      messages.each { |key, value| flash_hash[key] = value }
+    end
+  end
+
+  def install_path_helpers!
+    controller_class = SolidObserver::CacheOperationsController
+    return if controller_class.method_defined?(:cache_operations_path)
+
+    controller_class.class_eval do
+      helper_method :root_path,
+        :jobs_path,
+        :events_path,
+        :storage_path,
+        :cache_dashboard_path,
+        :cache_operations_path,
+        :prune_cache_operations_path,
+        :clear_cache_operations_path,
+        :live_poll_script_path
+
+      def root_path
+        "/solid_observer"
+      end
+
+      def jobs_path
+        "/solid_observer/jobs"
+      end
+
+      def events_path
+        "/solid_observer/events"
+      end
+
+      def storage_path
+        "/solid_observer/storage"
+      end
+
+      def cache_dashboard_path
+        "/solid_observer/cache"
+      end
+
+      def cache_operations_path
+        "/solid_observer/cache/controls"
+      end
+
+      def prune_cache_operations_path
+        "/solid_observer/cache/controls/prune"
+      end
+
+      def clear_cache_operations_path
+        "/solid_observer/cache/controls/clear"
+      end
+
+      def live_poll_script_path
+        "/solid_observer/live_poll.js"
+      end
+    end
+  end
+
+  def call_action(action_name, path, method: "GET", flash: {})
+    env = Rack::MockRequest.env_for(
+      path,
+      {
+        "action_dispatch.routes" => SolidObserver::Engine.routes,
+        "REQUEST_METHOD" => method,
+        "action_dispatch.request.flash_hash" => build_flash(flash)
+      }
+    )
+
+    status, headers, body = SolidObserver::CacheOperationsController.action(action_name).call(env)
+    response_body = +""
+    body.each { |chunk| response_body << chunk }
+    [status, headers, response_body]
+  end
+
+  it "defines cache controls routes" do
+    routes_source = File.read(File.expand_path("../../../config/routes.rb", __dir__))
+
+    expect(routes_source).to include('get "cache/controls", to: "cache_operations#index", as: :cache_operations')
+    expect(routes_source).to include('post "cache/controls/prune", to: "cache_operations#prune", as: :prune_cache_operations')
+    expect(routes_source).to include('post "cache/controls/clear", to: "cache_operations#clear", as: :clear_cache_operations')
+  end
+
+  it "renders the controls-only UI when cache operations are available" do
+    status, _headers, body = call_action(:index, "/solid_observer/cache/controls")
+
+    expect(status).to eq(200)
+    expect(body).to include("Cache controls")
+    expect(body).to include("Operational controls")
+    expect(body).to include("Prune expired entries")
+    expect(body).to include("Clear cache")
+    expect(body).to include("Available")
+    expect(body).to include('href="/solid_observer/cache/controls"')
+    expect(body).to include('action="/solid_observer/cache/controls/prune"')
+    expect(body).to include('action="/solid_observer/cache/controls/clear"')
+    expect(body).to include(SolidObserver::Services::CacheOperations.message(:clear, :confirmation))
+    expect(body).not_to include(SolidObserver::Services::CacheOperations.unavailable_message)
+  end
+
+  it "renders a single unavailable state when cache controls are disabled" do
+    SolidObserver.config.observe_cache = false
+
+    status, _headers, body = call_action(:index, "/solid_observer/cache/controls")
+
+    expect(status).to eq(200)
+    expect(body).to include("Cache controls")
+    expect(body).to include("Unavailable")
+    expect(body).to include(SolidObserver::Services::CacheOperations.unavailable_message)
+    expect(body).not_to include('href="/solid_observer/cache/controls"')
+    expect(body).not_to include('action="/solid_observer/cache/controls/prune"')
+    expect(body).not_to include('action="/solid_observer/cache/controls/clear"')
+  end
+
+  it "renders accessible flash announcement roles" do
+    status, _headers, body = call_action(
+      :index,
+      "/solid_observer/cache/controls",
+      flash: {
+        notice: SolidObserver::Services::CacheOperations.message(:clear, :success),
+        alert: SolidObserver::Services::CacheOperations.message(:prune, :failure)
+      }
+    )
+
+    expect(status).to eq(200)
+    expect(body).to include('role="status"')
+    expect(body).to include('aria-live="polite"')
+    expect(body).to include('role="alert"')
+  end
+
+  it "redirects prune requests back to the controls page" do
+    allow(SolidObserver::Services::CacheOperations).to receive(:prune).and_return(
+      {ok: true, message: SolidObserver::Services::CacheOperations.message(:prune, :success)}
+    )
+
+    status, headers, _body = call_action(:prune, "/solid_observer/cache/controls/prune", method: "POST")
+
+    expect(status).to eq(302)
+    expect(headers["Location"]).to eq("http://example.org/solid_observer/cache/controls")
+  end
+end

--- a/spec/tasks/solid_observer_cache_tasks_spec.rb
+++ b/spec/tasks/solid_observer_cache_tasks_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "solid_observer cache rake tasks" do
+  let(:task_source) do
+    File.read(File.expand_path("../../lib/tasks/solid_observer.rake", __dir__))
+  end
+
+  it "defines the cache clear task with confirmation" do
+    expect(task_source).to include("namespace :cache do")
+    expect(task_source).to include("task clear: :environment do")
+    expect(task_source).to include("SolidObserver::Services::CacheOperations.message(:clear, :confirmation)")
+    expect(task_source).to include('puts "Aborted"')
+  end
+
+  it "defines the cache prune task" do
+    expect(task_source).to include("task prune: :environment do")
+    expect(task_source).to include("puts SolidObserver::Services::CacheOperations.prune[:message]")
+  end
+
+  it "uses the shared unavailable message guard for both cache tasks" do
+    expect(task_source.scan("SolidObserver::Services::CacheOperations.unavailable_message").size).to eq(2)
+  end
+end


### PR DESCRIPTION
## Summary of changes
- Adds guarded SolidCache clear/prune operations for UI and Rake tasks.
- Fixes cache pipeline boot wiring and regression coverage for recorder failure behavior.
- Adds controls-only UI with confirmation, unavailable states, sanitized messaging, and inline layout styling.
- Updates initializer messaging for v0.4.0 cache readiness while leaving the full dashboard to #138 