### PR TITLE
[SO-075][FEAT] Add cache dashboard

### DIFF
--- a/app/controllers/solid_observer/cache_dashboard_controller.rb
+++ b/app/controllers/solid_observer/cache_dashboard_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "dashboard_controller"
+
+module SolidObserver
+  class CacheDashboardController < DashboardController
+    CACHE_STORAGE_COMPONENTS = %w[solid_cache cache_observer].freeze
+
+    class << self
+      def cache_dashboard_assignments(range_param:)
+        return unavailable_assignments unless SolidObserver.config.solid_cache_enabled?
+
+        range = SolidObserver::Services::CacheStats.parse_range(range_param)
+        window = SolidObserver::Services::CacheStats.range_duration(range)
+
+        {
+          cache_dashboard_available: true,
+          range: range,
+          stats: SolidObserver::Services::CacheStats.call(window: window),
+          storage_components: cache_storage_components,
+          recent_events: recent_events(window)
+        }
+      end
+
+      private
+
+      def unavailable_assignments
+        {
+          cache_dashboard_available: false,
+          storage_components: [],
+          recent_events: []
+        }
+      end
+
+      def cache_storage_components
+        SolidObserver::Services::StorageInfoSnapshot.call.select do |snapshot|
+          CACHE_STORAGE_COMPONENTS.include?(snapshot[:component])
+        end
+      end
+
+      def recent_events(window)
+        current_time = Time.current
+        SolidObserver::CacheEvent.where(recorded_at: (current_time - window)..current_time).recent(10)
+      rescue ActiveRecord::StatementInvalid
+        []
+      end
+    end
+
+    def index
+      @component = "cache"
+      assign_cache_dashboard
+    end
+  end
+end

--- a/app/controllers/solid_observer/dashboard_controller.rb
+++ b/app/controllers/solid_observer/dashboard_controller.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
+require_relative "../../helpers/solid_observer/application_helper"
+
 module SolidObserver
   class DashboardController < ApplicationController
+    helper SolidObserver::ApplicationHelper
+
     skip_forgery_protection only: :live_poll
     skip_after_action :verify_same_origin_request, only: :live_poll
 
     def index
       @component = selected_component
-      @queue_available_for_render = queue_dashboard_renderable?
-      if @component == "queue" && @queue_available_for_render
-        assign_range_and_stats
-        load_persistence_data if persistence_mode?
-      end
+      return assign_cache_dashboard if @component == "cache"
+
+      return unless @component == "queue" && SolidObserver.config.solid_queue_enabled?
+
+      assign_range_and_stats
+      load_persistence_data if persistence_mode?
     end
 
     def live_poll
@@ -47,6 +52,12 @@ module SolidObserver
 
     def load_persistence_data
       @recent_events = QueueEvent.recent(10)
+    end
+
+    def assign_cache_dashboard
+      SolidObserver::CacheDashboardController.cache_dashboard_assignments(range_param: request_range_param).each do |name, value|
+        instance_variable_set("@#{name}", value)
+      end
     end
 
     def request_range_param
@@ -106,10 +117,6 @@ module SolidObserver
       return "queue" if path.end_with?("/queue")
 
       ""
-    end
-
-    def queue_dashboard_renderable?
-      @component == "queue" && SolidObserver.config.solid_queue_enabled?
     end
   end
 end

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -23,6 +23,21 @@ module SolidObserver
       degraded: {label: "Degraded", tone: "warning"},
       critical: {label: "Critical", tone: "danger"}
     }.freeze
+    CACHE_OUTCOME_STATES = {
+      hit: {label: "Hit", tone: "success"},
+      miss: {label: "Miss", tone: "info"},
+      error: {label: "Error", tone: "danger"},
+      recorded: {label: "Recorded", tone: "recorded"}
+    }.freeze
+    CACHE_RANGE_LABELS = {
+      "15m" => "in last 15m",
+      "30m" => "in last 30m",
+      "1h" => "in last hour",
+      "7h" => "in last 7h",
+      "1d" => "in last day",
+      "7d" => "in last 7d",
+      "14d" => "in last 14d"
+    }.freeze
 
     def execution_status(execution)
       ExecutionPresenter.new(execution).status
@@ -81,6 +96,47 @@ module SolidObserver
       end
     end
 
+    def cache_ratio_percent(value)
+      number_to_percentage(value.to_f * 100, precision: 1, strip_insignificant_zeros: true)
+    end
+
+    def cache_storage_summary(storage_components)
+      snapshots = Array(storage_components)
+      reason = cache_storage_unavailable_reason(snapshots)
+      return {value: "—", subtitle: "— #{reason}"} if reason
+
+      {
+        value: number_to_human_size(cache_storage_total_bytes(snapshots), precision: 1, significant: false, strip_insignificant_zeros: false),
+        subtitle: "SolidCache + cache observer"
+      }
+    end
+
+    def cache_event_outcome_badge(event)
+      meta = cache_event_outcome_meta(event)
+      dot = tag.svg(
+        tag.circle(r: 3, cx: 3, cy: 3, fill: "currentColor"),
+        class: "so-badge__dot",
+        viewBox: "0 0 6 6",
+        "aria-hidden": "true"
+      )
+
+      tag.span(class: "so-badge so-badge--pill so-badge--#{meta[:tone]}") do
+        safe_join([dot, meta[:label]], " ")
+      end
+    end
+
+    def cache_event_digest(key_digest, visible_chars: 10)
+      digest = key_digest.to_s
+      return "—" if digest.empty?
+      return digest if digest.length <= visible_chars
+
+      "#{digest.first(visible_chars)}…"
+    end
+
+    def cache_range_label(range_key)
+      CACHE_RANGE_LABELS.fetch(range_key.to_s, "in selected range")
+    end
+
     def stability_detail(stats)
       failures_24h = stats[:failed_last_24h].to_i
       return "No failures in the last 24h" if failures_24h.zero?
@@ -103,6 +159,28 @@ module SolidObserver
     def dashboard_section_active?(component)
       current_component = @component.presence || "queue"
       controller_name == "dashboard" && current_component == component.to_s
+    end
+
+    private
+
+    def cache_storage_total_bytes(snapshots)
+      snapshots.sum { |snapshot| snapshot[:db_size_bytes].to_i }
+    end
+
+    def cache_storage_unavailable_reason(snapshots)
+      return "Storage snapshot unavailable" unless snapshots.size == 2
+
+      snapshots.find { |snapshot| !snapshot[:available] }&.[](:unavailable_reason)
+    end
+
+    def cache_event_outcome_meta(event)
+      hit = event.hit
+
+      return CACHE_OUTCOME_STATES.fetch(:error) if event.error_class.present?
+      return CACHE_OUTCOME_STATES.fetch(:hit) if hit == true
+      return CACHE_OUTCOME_STATES.fetch(:miss) if hit == false
+
+      CACHE_OUTCOME_STATES.fetch(:recorded)
     end
   end
 end

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -139,6 +139,8 @@
 
     /* SO-067 Metric card anatomy — separated value/suffix/range-copy */
     .so-metric { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.15rem; }
+    .so-metric .so-card__label,
+    .so-metric .so-card__subtitle { flex-basis: 100%; }
     .so-metric__value { font-size: 1.625rem; font-weight: 600; color: var(--so-text); }
     .so-metric__suffix { font-size: 0.75rem; color: var(--so-text-muted); }
 
@@ -267,6 +269,7 @@
     .so-badge--danger { background: #fee2e2; color: #991b1b; }
     .so-badge--info { background: #dbeafe; color: #1e40af; }
     .so-badge--default { background: var(--so-surface-muted); color: var(--so-text-muted); }
+    .so-badge--recorded { background: var(--so-surface-muted); color: var(--so-text); }
 
     .so-badge--pill {
       display: inline-flex;
@@ -371,6 +374,7 @@
     }
 
     .so-cache-controls { max-width: 820px; }
+    .so-cache-dashboard__intro,
     .so-cache-controls__intro {
       display: flex;
       flex-wrap: wrap;
@@ -378,10 +382,31 @@
       gap: 0.75rem;
       margin-top: 0.5rem;
     }
+    .so-cache-dashboard__hint,
     .so-cache-controls__hint {
       font-size: 0.875rem;
       color: var(--so-text-subtle);
       line-height: 1.5;
+    }
+    .so-cache-dashboard__range-form {
+      align-items: center;
+      margin-bottom: 2rem;
+    }
+    .so-cache-dashboard__range-form select {
+      padding: 0.4rem 0.6rem;
+      border: 1px solid var(--so-border);
+      border-radius: var(--so-radius);
+      font-size: 0.85rem;
+      background: var(--so-card-bg);
+      color: var(--so-text);
+    }
+    .so-cache-dashboard__chart-empty {
+      max-width: 420px;
+      margin-bottom: 0;
+    }
+    .so-cache-dashboard__digest {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      white-space: nowrap;
     }
     .so-cache-control-row {
       display: grid;
@@ -509,7 +534,7 @@
 
         <% if SolidObserver.config.solid_cache_enabled? %>
           <div class="so-sidebar__section">Cache</div>
-          <%= link_to "Overview", cache_dashboard_path, class: ("active" if controller_name == "dashboard" && @component.to_s == "cache"), "aria-current": (controller_name == "dashboard" && @component.to_s == "cache" ? "page" : nil) %>
+          <%= link_to "Overview", cache_dashboard_path, class: ("active" if controller_name == "cache_dashboard"), "aria-current": (controller_name == "cache_dashboard" ? "page" : nil) %>
           <% if SolidObserver::Services::CacheOperations.available? %>
             <%= link_to "Controls", cache_operations_path, class: ("active" if controller_name == "cache_operations"), "aria-current": (controller_name == "cache_operations" ? "page" : nil) %>
           <% end %>

--- a/app/views/solid_observer/cache_dashboard/_charts.html.erb
+++ b/app/views/solid_observer/cache_dashboard/_charts.html.erb
@@ -1,0 +1,11 @@
+<section class="so-dashboard-section" aria-labelledby="so-cache-charts-heading">
+  <header class="so-dashboard-section__header">
+    <h2 id="so-cache-charts-heading" class="so-dashboard-section__title">Activity trends</h2>
+  </header>
+
+  <div class="so-chart-strip">
+    <div class="so-card so-cache-dashboard__chart-empty">
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-range">No chart data in the selected range yet. Summary metrics still use bounded cache stats.</p>
+    </div>
+  </div>
+</section>

--- a/app/views/solid_observer/cache_dashboard/_recent_events.html.erb
+++ b/app/views/solid_observer/cache_dashboard/_recent_events.html.erb
@@ -1,0 +1,34 @@
+<section class="so-card so-card--section" aria-labelledby="so-cache-events-heading">
+  <header class="so-dashboard-section__header">
+    <h2 id="so-cache-events-heading" class="so-dashboard-section__title">Sampled recent events</h2>
+    <span class="so-dashboard-section__meta">debug context only · no raw keys or values</span>
+  </header>
+
+  <% if recent_events.present? %>
+    <table class="so-table so-table--card">
+      <caption class="sr-only">Sampled cache events without raw cache keys or values</caption>
+      <thead>
+        <tr>
+          <th>Event</th>
+          <th>Key digest</th>
+          <th>Outcome</th>
+          <th>Duration</th>
+          <th>Recorded</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% recent_events.each do |event| %>
+          <tr>
+            <td><%= event.event_type.to_s.humanize %></td>
+            <td><span class="so-cache-dashboard__digest"><%= cache_event_digest(event.key_digest) %></span></td>
+            <td><%= cache_event_outcome_badge(event) %></td>
+            <td><%= event.duration ? format_duration(event.duration) : "—" %></td>
+            <td><span title="<%= event.recorded_at.utc.strftime("%Y-%m-%d %H:%M:%S UTC") %>"><%= time_ago_in_words(event.recorded_at) %> ago</span></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-events">No sampled cache events in the selected range yet. Slow, sampled, or errored cache operations will appear here.</p>
+  <% end %>
+</section>

--- a/app/views/solid_observer/cache_dashboard/_summary.html.erb
+++ b/app/views/solid_observer/cache_dashboard/_summary.html.erb
@@ -1,0 +1,39 @@
+<% storage_summary = cache_storage_summary(storage_components) %>
+
+<section class="so-dashboard-section" aria-labelledby="so-cache-summary-heading">
+  <header class="so-dashboard-section__header">
+    <h2 id="so-cache-summary-heading" class="so-dashboard-section__title">Summary in selected range</h2>
+  </header>
+
+  <div class="so-stat-cards so-cache-dashboard__summary">
+    <article class="so-card so-metric">
+      <div class="so-card__label">Hit rate</div>
+      <div class="so-metric__value"><%= cache_ratio_percent(stats[:hit_rate]) %></div>
+      <div class="so-card__subtitle">hits / read outcomes</div>
+    </article>
+
+    <article class="so-card so-metric">
+      <div class="so-card__label">Operations</div>
+      <div class="so-metric__value"><%= number_with_delimiter(stats[:operations_count].to_i) %></div>
+      <div class="so-card__subtitle">selected window</div>
+    </article>
+
+    <article class="<%= ["so-card", "so-metric", ("so-card--accent-danger" if stats[:errors_count].to_i.positive?)].compact.join(" ") %>">
+      <div class="so-card__label">Error rate</div>
+      <div class="so-metric__value"><%= cache_ratio_percent(stats[:error_rate]) %></div>
+      <div class="so-card__subtitle">errors / operations</div>
+    </article>
+
+    <article class="so-card so-metric">
+      <div class="so-card__label">Avg duration</div>
+      <div class="so-metric__value"><%= format_duration(stats[:avg_duration].to_f) %></div>
+      <div class="so-card__subtitle">operation latency</div>
+    </article>
+
+    <article class="so-card so-metric">
+      <div class="so-card__label">Storage footprint</div>
+      <div class="so-metric__value"><%= storage_summary[:value] %></div>
+      <div class="so-card__subtitle"><%= storage_summary[:subtitle] %></div>
+    </article>
+  </div>
+</section>

--- a/app/views/solid_observer/cache_dashboard/index.html.erb
+++ b/app/views/solid_observer/cache_dashboard/index.html.erb
@@ -1,0 +1,52 @@
+<% content_for :title, "Cache overview" %>
+<% status_class = @cache_dashboard_available ? "so-badge--success" : "so-badge--warning" %>
+
+<div class="so-dashboard so-cache-dashboard">
+  <span class="sr-only">Cache Dashboard</span>
+
+  <div class="so-content__header">
+    <h1>Cache overview</h1>
+
+    <% if @cache_dashboard_available %>
+      <div class="so-cache-dashboard__intro">
+        <span class="so-badge so-badge--pill <%= status_class %>">
+          <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+            <circle r="3" cx="3" cy="3" fill="currentColor" />
+          </svg>
+          Available
+        </span>
+        <p class="so-cache-dashboard__hint">Selected range: <%= cache_range_label(@range) %> · keys and values are never shown.</p>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @cache_dashboard_available %>
+    <form action="<%= request.path %>" method="get" class="so-dashboard-toolbar so-cache-dashboard__range-form">
+      <label for="so-cache-range" class="so-card__label so-filters__label">Range</label>
+      <select id="so-cache-range" name="range">
+        <% SolidObserver::Services::CacheStats::RANGES.each_key do |key| %>
+          <option value="<%= key %>" <%= "selected" if key == @range %>><%= cache_range_label(key) %></option>
+        <% end %>
+      </select>
+      <button type="submit" class="so-btn">Apply range</button>
+    </form>
+
+    <%= render "solid_observer/cache_dashboard/summary", stats: @stats, storage_components: @storage_components %>
+    <%= render "solid_observer/cache_dashboard/charts" %>
+    <%= render "solid_observer/cache_dashboard/recent_events", recent_events: @recent_events %>
+  <% else %>
+    <section class="so-card so-card--section" aria-labelledby="so-cache-unavailable-heading">
+      <header class="so-dashboard-section__header">
+        <h2 id="so-cache-unavailable-heading" class="so-dashboard-section__title">Cache dashboard unavailable</h2>
+        <span class="so-badge so-badge--pill <%= status_class %>">
+          <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+            <circle r="3" cx="3" cy="3" fill="currentColor" />
+          </svg>
+          Unavailable
+        </span>
+      </header>
+
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">Cache dashboard is unavailable because SolidCache support is disabled or not detected. Metrics are unavailable.</p>
+    </section>
+  <% end %>
+</div>

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -1,12 +1,9 @@
 <% content_for :title, "Dashboard" %>
 
+<% if @component == "cache" %>
+  <%= render template: "solid_observer/cache_dashboard/index" %>
+<% else %>
 <div class="so-dashboard">
-  <% if @component == "cache" %>
-    <section class="so-card so-card--section" aria-labelledby="so-cache-heading">
-      <h2 id="so-cache-heading">Dashboard</h2>
-      <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">SolidCache integration is enabled, but cache metrics are not part of this release.</p>
-    </section>
-  <% else %>
   <% if !SolidObserver.config.solid_queue_enabled? %>
     <section class="so-card so-card--section" aria-labelledby="so-queue-unavailable-heading">
       <h2 id="so-queue-unavailable-heading">Queue Unavailable</h2>
@@ -123,5 +120,5 @@
     <% end %>
   <% end %>
   <% end %>
-  <% end %>
 </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 SolidObserver::Engine.routes.draw do
   root "dashboard#index"
   get "queue", to: "dashboard#index", defaults: {component: "queue"}, as: :queue_dashboard
-  get "cache", to: "dashboard#index", defaults: {component: "cache"}, as: :cache_dashboard
+  get "cache", to: "cache_dashboard#index", as: :cache_dashboard
   get "cache/controls", to: "cache_operations#index", as: :cache_operations
   post "cache/controls/prune", to: "cache_operations#prune", as: :prune_cache_operations
   post "cache/controls/clear", to: "cache_operations#clear", as: :clear_cache_operations

--- a/lib/solid_observer/services/cache_stats.rb
+++ b/lib/solid_observer/services/cache_stats.rb
@@ -3,6 +3,28 @@
 module SolidObserver
   module Services
     class CacheStats
+      RANGES = {
+        "15m" => 15.minutes,
+        "30m" => 30.minutes,
+        "1h" => 1.hour,
+        "7h" => 7.hours,
+        "1d" => 1.day,
+        "7d" => 7.days,
+        "14d" => 14.days
+      }.freeze
+      DEFAULT_RANGE = "15m"
+
+      class << self
+        def parse_range(value, fallback: DEFAULT_RANGE)
+          range_key = value.to_s
+          RANGES.key?(range_key) ? range_key : fallback
+        end
+
+        def range_duration(value, fallback: DEFAULT_RANGE)
+          RANGES.fetch(parse_range(value, fallback: fallback))
+        end
+      end
+
       def self.call(window:)
         new.call(window: window)
       end

--- a/spec/lib/solid_observer/services/cache_stats_spec.rb
+++ b/spec/lib/solid_observer/services/cache_stats_spec.rb
@@ -21,6 +21,26 @@ RSpec.describe SolidObserver::Services::CacheStats do
 
   before { SolidObserver::CacheMetric.delete_all }
 
+  describe ".parse_range" do
+    it "returns the requested range when it is supported" do
+      expect(described_class.parse_range("1h")).to eq("1h")
+    end
+
+    it "falls back to the default range for unsupported values" do
+      expect(described_class.parse_range("bogus")).to eq("15m")
+    end
+  end
+
+  describe ".range_duration" do
+    it "returns the configured duration for a range key" do
+      expect(described_class.range_duration("1h")).to eq(1.hour)
+    end
+
+    it "uses the default duration for unsupported values" do
+      expect(described_class.range_duration("bogus")).to eq(15.minutes)
+    end
+  end
+
   it "returns dashboard-ready aggregated cache stats for window" do
     now = Time.current
     SolidObserver::CacheMetric.create!(

--- a/spec/requests/solid_observer/cache_dashboard_spec.rb
+++ b/spec/requests/solid_observer/cache_dashboard_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidObserver cache dashboard", type: :request do
+  before(:all) do
+    connection = SolidObserver::CacheMetric.connection
+
+    next if connection.table_exists?(:solid_observer_cache_metrics)
+
+    connection.create_table :solid_observer_cache_metrics do |t|
+      t.string :event_type, null: false, limit: 64
+      t.datetime :period_start, null: false
+      t.bigint :operations_count, null: false, default: 0
+      t.bigint :hits_count, null: false, default: 0
+      t.bigint :misses_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+      t.float :duration_total, null: false, default: 0.0
+    end
+  end
+
+  before(:all) do
+    connection = SolidObserver::CacheEvent.connection
+
+    next if connection.table_exists?(:solid_observer_cache_events)
+
+    connection.create_table :solid_observer_cache_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :key_digest, null: false, limit: 64
+      t.boolean :hit
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before(:all) do
+    connection = ActiveRecord::Base.connection
+
+    next if connection.table_exists?(:solid_cache_entries)
+
+    connection.create_table :solid_cache_entries do |t|
+      t.string :key
+      t.text :value
+    end
+  end
+
+  before do
+    ensure_engine_view_path!
+    install_path_helpers!
+
+    stub_const("SolidCache", Module.new)
+    stub_const("SolidCache::Record", Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_cache_entries"
+    end)
+
+    SolidObserver.config.ui_enabled = true
+    SolidObserver.config.observe_queue = false
+    SolidObserver.config.observe_cache = true
+    SolidObserver.config.storage_mode = :persistence
+
+    SolidObserver::CacheMetric.delete_all
+    SolidObserver::CacheEvent.delete_all
+    SolidCache::Record.delete_all
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  def ensure_engine_view_path!
+    engine_views = SolidObserver::Engine.root.join("app/views").to_s
+    current_paths = SolidObserver::CacheDashboardController.view_paths.map(&:to_s)
+    return if current_paths.include?(engine_views)
+
+    SolidObserver::CacheDashboardController.prepend_view_path(engine_views)
+  end
+
+  def install_path_helpers!
+    controller_class = SolidObserver::CacheDashboardController
+    return if controller_class.method_defined?(:cache_dashboard_path)
+
+    controller_class.class_eval do
+      helper_method :root_path,
+        :jobs_path,
+        :events_path,
+        :storage_path,
+        :cache_dashboard_path,
+        :cache_operations_path,
+        :live_poll_script_path
+
+      def root_path
+        "/solid_observer"
+      end
+
+      def jobs_path
+        "/solid_observer/jobs"
+      end
+
+      def events_path
+        "/solid_observer/events"
+      end
+
+      def storage_path
+        "/solid_observer/storage"
+      end
+
+      def cache_dashboard_path
+        "/solid_observer/cache"
+      end
+
+      def cache_operations_path
+        "/solid_observer/cache/controls"
+      end
+
+      def live_poll_script_path
+        "/solid_observer/live_poll.js"
+      end
+    end
+  end
+
+  def call_action(path)
+    env = Rack::MockRequest.env_for(path, {"action_dispatch.routes" => SolidObserver::Engine.routes})
+    status, headers, body = SolidObserver::CacheDashboardController.action(:index).call(env)
+    response_body = +""
+    body.each { |chunk| response_body << chunk }
+    [status, headers, response_body]
+  end
+
+  it "defines the cache overview route on CacheDashboardController" do
+    routes_source = File.read(File.expand_path("../../../config/routes.rb", __dir__))
+
+    expect(routes_source).to include('get "cache", to: "cache_dashboard#index", as: :cache_dashboard')
+  end
+
+  it "renders the cache overview with bounded summary data, chart empty state, and sampled events" do
+    fixed_time = Time.utc(2026, 6, 2, 12, 0, 0)
+
+    travel_to(fixed_time) do
+      SolidObserver::CacheMetric.create!(
+        event_type: "cache_read",
+        period_start: fixed_time.beginning_of_minute,
+        operations_count: 40,
+        hits_count: 30,
+        misses_count: 10,
+        errors_count: 4,
+        duration_total: 5.2
+      )
+      SolidObserver::CacheMetric.create!(
+        event_type: "cache_read",
+        period_start: 2.hours.ago.beginning_of_minute,
+        operations_count: 500,
+        hits_count: 400,
+        misses_count: 100,
+        errors_count: 0,
+        duration_total: 50.0
+      )
+
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_read",
+        key_digest: "abcdef1234567890",
+        hit: true,
+        duration: 0.003,
+        metadata: "{}",
+        recorded_at: 5.minutes.ago
+      )
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_write",
+        key_digest: "fedcba0987654321",
+        hit: nil,
+        duration: 1.2,
+        error_class: "RuntimeError",
+        error_message: "adapter internals should stay hidden",
+        metadata: "{}",
+        recorded_at: 3.minutes.ago
+      )
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_fetch",
+        key_digest: "1122334455667788",
+        hit: nil,
+        duration: nil,
+        metadata: "{}",
+        recorded_at: 2.minutes.ago
+      )
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_delete",
+        key_digest: "olddigest00000000",
+        hit: false,
+        duration: 0.001,
+        metadata: "{}",
+        recorded_at: 2.hours.ago
+      )
+      SolidCache::Record.create!(key: "cache-key", value: "cached")
+
+      status, _headers, body = call_action("/solid_observer/cache?range=15m")
+
+      expect(status).to eq(200)
+      expect(body).to include("Cache overview")
+      expect(body).to include("Available")
+      expect(body).to include("Selected range: in last 15m · keys and values are never shown.")
+      expect(body).to include("Apply range")
+      expect(body).to include("Summary in selected range")
+      expect(body).to include("75%")
+      expect(body).to include("40")
+      expect(body).to include("10%")
+      expect(body).to include("130ms")
+      expect(body).to include("SolidCache + cache observer")
+      expect(body).to include("Activity trends")
+      expect(body).to include("No chart data in the selected range yet. Summary metrics still use bounded cache stats.")
+      expect(body).to include("Sampled recent events")
+      expect(body).to include("debug context only · no raw keys or values")
+      expect(body).to include("abcdef1234…")
+      expect(body).to include("fedcba0987…")
+      expect(body).to include("1122334455…")
+      expect(body).to include("Hit")
+      expect(body).to include("Error")
+      expect(body).to include("so-badge--recorded")
+      expect(body).not_to include("olddigest0000")
+      expect(body).not_to include("adapter internals should stay hidden")
+      expect(body).not_to include("cache-key")
+    end
+  end
+
+  it "renders a guarded unavailable state and hides cache navigation when cache support is disabled" do
+    SolidObserver.config.observe_cache = false
+
+    status, _headers, body = call_action("/solid_observer/cache")
+
+    expect(status).to eq(200)
+    expect(body).to include("Cache dashboard unavailable")
+    expect(body).to include("Unavailable")
+    expect(body).to include("Cache dashboard is unavailable because SolidCache support is disabled or not detected. Metrics are unavailable.")
+    expect(body).not_to include("Apply range")
+    expect(body).not_to include("Summary in selected range")
+    expect(body).not_to include("Sampled recent events")
+    expect(body).not_to include('href="/solid_observer/cache"')
+  end
+
+  it "falls back to an empty recent-events state when sampled event queries fail" do
+    allow(SolidObserver::CacheEvent).to receive(:where).and_raise(ActiveRecord::StatementInvalid.new("missing table"))
+
+    status, _headers, body = call_action("/solid_observer/cache?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include("No sampled cache events in the selected range yet. Slow, sampled, or errored cache operations will appear here.")
+    expect(body).not_to include("missing table")
+  end
+end


### PR DESCRIPTION
## Summary of changes
- Adds a dedicated Cache dashboard with bounded summary metrics, storage footprint, chart empty state, and sampled recent events.
- Guards navigation/direct visits when Cache support is disabled or unavailable.
- Keeps sampled events sanitized by showing key digests only, never raw keys or values.
- Adds request/service coverage and WCAG-safe status badge styling.