### PR TITLE
[SO-076][FIX] Fix SolidCache storage snapshot TypeError

### DIFF
--- a/lib/solid_observer/services/storage_info_snapshot.rb
+++ b/lib/solid_observer/services/storage_info_snapshot.rb
@@ -5,7 +5,7 @@ require_relative "database_size"
 module SolidObserver
   module Services
     class StorageInfoSnapshot
-      Component = Struct.new(:key, :label, :table_name, :record_label, :model, :enabled, keyword_init: true) do
+      Component = Struct.new(:key, :label, :record_label, :model, :enabled, keyword_init: true) do
         def enabled?
           enabled.call
         end
@@ -18,11 +18,11 @@ module SolidObserver
           model.call
         end
 
-        def data_source_exists?(connection)
+        def data_source_exists?(connection, table_name)
           connection.data_source_exists?(table_name)
         end
 
-        def database_size(connection)
+        def database_size(connection, table_name)
           DatabaseSize.call(connection: connection, table_name: table_name)
         end
 
@@ -31,7 +31,7 @@ module SolidObserver
           return unavailable_snapshot(reason: "SolidCache is unavailable") if unavailable_solid_cache?
 
           existing_data_source_snapshot
-        rescue *StorageInfoSnapshot::CONNECTION_ERRORS
+        rescue *StorageInfoSnapshot::CONNECTION_ERRORS, TypeError
           unavailable_snapshot(reason: "Storage unavailable")
         end
 
@@ -64,18 +64,23 @@ module SolidObserver
         private
 
         def unavailable_solid_cache?
-          solid_cache? && !defined?(::SolidCache::Record)
+          solid_cache? && !defined?(::SolidCache::Entry)
         end
 
         def existing_data_source_snapshot
           record_model = storage_model
           connection = record_model.connection
-          return unavailable_snapshot(reason: "Table unavailable") unless data_source_exists?(connection)
+          table_name = record_model.table_name.to_s
+          return table_unavailable_snapshot if table_name.empty? || !data_source_exists?(connection, table_name)
 
           available_snapshot(
-            db_size_bytes: database_size(connection),
+            db_size_bytes: database_size(connection, table_name),
             event_count: record_model.count
           )
+        end
+
+        def table_unavailable_snapshot
+          unavailable_snapshot(reason: "Table unavailable")
         end
       end
 
@@ -83,7 +88,6 @@ module SolidObserver
         Component.new(
           key: "queue_observer",
           label: "Queue observer",
-          table_name: "solid_observer_queue_events",
           record_label: "observer events",
           model: -> { SolidObserver::QueueEvent },
           enabled: -> { SolidObserver.config.solid_queue_enabled? }
@@ -91,7 +95,6 @@ module SolidObserver
         Component.new(
           key: "cache_observer",
           label: "Cache observer",
-          table_name: "solid_observer_cache_events",
           record_label: "observer events",
           model: -> { SolidObserver::CacheEvent },
           enabled: -> { SolidObserver.config.solid_cache_enabled? }
@@ -99,9 +102,8 @@ module SolidObserver
         Component.new(
           key: "solid_cache",
           label: "SolidCache",
-          table_name: "solid_cache_entries",
           record_label: "cache rows",
-          model: -> { ::SolidCache::Record },
+          model: -> { ::SolidCache::Entry },
           enabled: -> { SolidObserver.config.solid_cache_enabled? }
         )
       ].freeze

--- a/spec/requests/solid_observer/cache_dashboard_spec.rb
+++ b/spec/requests/solid_observer/cache_dashboard_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
     install_path_helpers!
 
     stub_const("SolidCache", Module.new)
-    stub_const("SolidCache::Record", Class.new(ActiveRecord::Base) do
+    stub_const("SolidCache::Entry", Class.new(ActiveRecord::Base) do
       self.table_name = "solid_cache_entries"
     end)
 
@@ -63,7 +63,7 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
 
     SolidObserver::CacheMetric.delete_all
     SolidObserver::CacheEvent.delete_all
-    SolidCache::Record.delete_all
+    SolidCache::Entry.delete_all
   end
 
   after { SolidObserver.reset_configuration! }
@@ -190,7 +190,7 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
         metadata: "{}",
         recorded_at: 2.hours.ago
       )
-      SolidCache::Record.create!(key: "cache-key", value: "cached")
+      SolidCache::Entry.create!(key: "cache-key", value: "cached")
 
       status, _headers, body = call_action("/solid_observer/cache?range=15m")
 
@@ -244,5 +244,17 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
     expect(status).to eq(200)
     expect(body).to include("No sampled cache events in the selected range yet. Slow, sampled, or errored cache operations will appear here.")
     expect(body).not_to include("missing table")
+  end
+
+  it "keeps the cache dashboard request successful when SolidCache metrics raise PostgreSQL-style TypeError" do
+    allow(SolidCache::Entry).to receive(:count).and_raise(TypeError, "no implicit conversion of nil into String")
+
+    status, _headers, body = call_action("/solid_observer/cache?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include("Cache overview")
+    expect(body).to include("Summary in selected range")
+    expect(body).to include("Storage unavailable")
+    expect(body).not_to include("TypeError")
   end
 end

--- a/spec/requests/solid_observer/storages_spec.rb
+++ b/spec/requests/solid_observer/storages_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidObserver storages page", type: :request do
+  before(:all) do
+    connection = SolidObserver::CacheEvent.connection
+
+    next if connection.table_exists?(:solid_observer_cache_events)
+
+    connection.create_table :solid_observer_cache_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :key_digest, null: false, limit: 64
+      t.boolean :hit
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before(:all) do
+    connection = ActiveRecord::Base.connection
+
+    next if connection.table_exists?(:solid_cache_entries)
+
+    connection.create_table :solid_cache_entries do |t|
+      t.string :key
+      t.text :value
+    end
+  end
+
+  around do |example|
+    previous_layout = SolidObserver::StoragesController.send(:_layout)
+    SolidObserver::StoragesController.layout false
+    example.run
+  ensure
+    SolidObserver::StoragesController.layout previous_layout
+  end
+
+  before do
+    SolidObserver::StoragesController.prepend_view_path(SolidObserver::Engine.root.join("app/views"))
+
+    stub_const("SolidCache", Module.new)
+    stub_const("SolidCache::Entry", Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_cache_entries"
+    end)
+
+    SolidObserver.config.ui_enabled = true
+    SolidObserver.config.observe_queue = false
+    SolidObserver.config.observe_cache = true
+    SolidObserver.config.storage_mode = :persistence
+
+    allow(SolidObserver::StorageInfo).to receive(:recent).with(20).and_return([])
+
+    SolidObserver::CacheEvent.delete_all
+    SolidCache::Entry.delete_all
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  def call_action(path = "/solid_observer/storage")
+    env = Rack::MockRequest.env_for(path, {"action_dispatch.routes" => SolidObserver::Engine.routes})
+    status, headers, body = SolidObserver::StoragesController.action(:show).call(env)
+    response_body = +""
+    body.each { |chunk| response_body << chunk }
+    [status, headers, response_body]
+  end
+
+  it "keeps the storages page request successful when SolidCache metrics raise PostgreSQL-style TypeError" do
+    allow(SolidCache::Entry).to receive(:count).and_raise(TypeError, "no implicit conversion of nil into String")
+
+    status, _headers, body = call_action
+
+    expect(status).to eq(200)
+    expect(body).to include("Storage")
+    expect(body).to include("Component health")
+    expect(body).to include("SolidCache")
+    expect(body).to include("Storage unavailable")
+    expect(body).not_to include("TypeError")
+  end
+end

--- a/spec/solid_observer/services/storage_info_snapshot_spec.rb
+++ b/spec/solid_observer/services/storage_info_snapshot_spec.rb
@@ -5,6 +5,32 @@ require "spec_helper"
 RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
   let(:queue_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
   let(:cache_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:solid_cache_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:solid_cache_entry_class) do
+    Class.new do
+      class << self
+        def connection
+        end
+
+        def table_name
+        end
+
+        def count
+        end
+      end
+    end
+  end
+  let(:solid_cache_record_class) do
+    Class.new do
+      class << self
+        def connection
+        end
+
+        def count
+        end
+      end
+    end
+  end
 
   before do
     allow(SolidObserver.config).to receive(:solid_queue_enabled?).and_return(true)
@@ -86,5 +112,62 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
       event_count: nil,
       unavailable_reason: "Storage unavailable"
     )
+  end
+
+  context "when SolidCache::Entry is available" do
+    before do
+      allow(SolidObserver.config).to receive(:solid_queue_enabled?).and_return(false)
+
+      stub_const("SolidCache", Module.new)
+      stub_const("SolidCache::Entry", solid_cache_entry_class)
+      stub_const("SolidCache::Record", solid_cache_record_class)
+
+      allow(SolidCache::Entry).to receive(:connection).and_return(solid_cache_connection)
+      allow(SolidCache::Entry).to receive(:table_name).and_return("host_app_cache_entries")
+      allow(SolidCache::Entry).to receive(:count).and_return(7)
+      allow(solid_cache_connection).to receive(:data_source_exists?).with("host_app_cache_entries").and_return(true)
+      allow(SolidObserver::Services::DatabaseSize).to receive(:call)
+        .with(connection: solid_cache_connection, table_name: "host_app_cache_entries")
+        .and_return(300)
+
+      allow(SolidCache::Record).to receive(:connection)
+      allow(SolidCache::Record).to receive(:count)
+    end
+
+    it "uses SolidCache::Entry with its dynamic table name for storage metrics" do
+      snapshots = described_class.call
+      solid_cache = snapshots.find { |snapshot| snapshot[:component] == "solid_cache" }
+
+      expect(solid_cache).to include(
+        label: "SolidCache",
+        available: true,
+        db_size_bytes: 300,
+        event_count: 7,
+        record_label: "cache rows",
+        unavailable_reason: nil
+      )
+      expect(solid_cache_connection).to have_received(:data_source_exists?).with("host_app_cache_entries")
+      expect(SolidObserver::Services::DatabaseSize).to have_received(:call)
+        .with(connection: solid_cache_connection, table_name: "host_app_cache_entries")
+      expect(SolidCache::Record).not_to have_received(:connection)
+      expect(SolidCache::Record).not_to have_received(:count)
+    end
+
+    it "returns an unavailable solid cache snapshot when the concrete model raises PostgreSQL-style TypeError" do
+      allow(SolidCache::Entry).to receive(:count).and_raise(TypeError, "no implicit conversion of nil into String")
+
+      snapshots = described_class.call
+      solid_cache = snapshots.find { |snapshot| snapshot[:component] == "solid_cache" }
+
+      expect(solid_cache).to include(
+        label: "SolidCache",
+        available: false,
+        db_size_bytes: nil,
+        event_count: nil,
+        record_label: "cache rows",
+        recorded_at: nil,
+        unavailable_reason: "Storage unavailable"
+      )
+    end
   end
 end


### PR DESCRIPTION
## Summary of changes
- Fixes PostgreSQL host-app crashes by using concrete `SolidCache::Entry` for SolidCache storage metrics.
- Resolves storage existence/size checks through the concrete model table name, including custom host-app table names.
- Adds simulated PostgreSQL nil-table-name regression coverage for Cache dashboard and Storages paths without adding PostgreSQL CI.