### PR TITLE
[SO-077][FEAT] Cache overview activity trends and health parity

### DIFF
--- a/app/controllers/solid_observer/cache_dashboard_controller.rb
+++ b/app/controllers/solid_observer/cache_dashboard_controller.rb
@@ -12,11 +12,14 @@ module SolidObserver
 
         range = SolidObserver::Services::CacheStats.parse_range(range_param)
         window = SolidObserver::Services::CacheStats.range_duration(range)
+        stats = SolidObserver::Services::CacheStats.call(window: window)
 
         {
           cache_dashboard_available: true,
           range: range,
-          stats: SolidObserver::Services::CacheStats.call(window: window),
+          stats: stats,
+          activity_trends: stats[:activity_trends],
+          stability: stats[:stability],
           storage_components: cache_storage_components,
           recent_events: recent_events(window)
         }
@@ -28,7 +31,9 @@ module SolidObserver
         {
           cache_dashboard_available: false,
           storage_components: [],
-          recent_events: []
+          recent_events: [],
+          activity_trends: SolidObserver::Services::CacheStats::ACTIVITY_TREND_EMPTY,
+          stability: SolidObserver::Services::CacheStats::STABILITY_EMPTY
         }
       end
 

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "dashboard_helper"
+
 module SolidObserver
   module ApplicationHelper
+    include SolidObserver::DashboardHelper
+
     STATUS_COLORS = {
       "completed" => "success",
       "ready" => "success",
@@ -88,12 +92,11 @@ module SolidObserver
     end
 
     def stability_badge(stats)
-      meta = STABILITY_STATES.fetch(stability_state(stats))
-      dot = tag.svg(tag.circle(r: 3, cx: 3, cy: 3),
-        class: "so-badge__dot", viewBox: "0 0 6 6", "aria-hidden": "true")
-      tag.span(class: "so-badge so-badge--pill so-badge--#{meta[:tone]}") do
-        safe_join([dot, meta[:label]], " ")
-      end
+      stability_badge_for(stability_state(stats))
+    end
+
+    def cache_stability_badge(state)
+      stability_badge_for(state.to_sym)
     end
 
     def cache_ratio_percent(value)
@@ -137,6 +140,20 @@ module SolidObserver
       CACHE_RANGE_LABELS.fetch(range_key.to_s, "in selected range")
     end
 
+    def cache_stability_detail(stability)
+      state = (stability || {})[:state]&.to_sym
+      state = :stable unless STABILITY_STATES.key?(state)
+
+      case state
+      when :critical
+        critical_cache_stability_detail(stability)
+      when :degraded
+        degraded_cache_stability_detail(stability)
+      else
+        "No sampled cache errors or slow events in the selected range"
+      end
+    end
+
     def stability_detail(stats)
       failures_24h = stats[:failed_last_24h].to_i
       return "No failures in the last 24h" if failures_24h.zero?
@@ -162,6 +179,31 @@ module SolidObserver
     end
 
     private
+
+    def stability_badge_for(state)
+      meta = STABILITY_STATES.fetch(state)
+      dot = tag.svg(tag.circle(r: 3, cx: 3, cy: 3),
+        class: "so-badge__dot", viewBox: "0 0 6 6", "aria-hidden": "true")
+      tag.span(class: "so-badge so-badge--pill so-badge--#{meta[:tone]}") do
+        safe_join([dot, meta[:label]], " ")
+      end
+    end
+
+    def critical_cache_stability_detail(stability)
+      detail = pluralize(stability[:error_count].to_i, "sampled cache error")
+      slow_count = stability[:slow_count].to_i
+      detail = "#{detail} and #{pluralize(slow_count, "slow event")}" if slow_count.positive?
+      "#{detail} in the selected range#{cache_stability_latest_suffix(stability[:latest_recorded_at])}"
+    end
+
+    def degraded_cache_stability_detail(stability)
+      detail = pluralize(stability[:slow_count].to_i, "slow sampled cache event")
+      "#{detail} in the selected range#{cache_stability_latest_suffix(stability[:latest_recorded_at])}"
+    end
+
+    def cache_stability_latest_suffix(timestamp)
+      timestamp ? ", latest #{time_ago_in_words(timestamp)} ago" : ""
+    end
 
     def cache_storage_total_bytes(snapshots)
       snapshots.sum { |snapshot| snapshot[:db_size_bytes].to_i }

--- a/app/views/solid_observer/cache_dashboard/_charts.html.erb
+++ b/app/views/solid_observer/cache_dashboard/_charts.html.erb
@@ -4,8 +4,37 @@
   </header>
 
   <div class="so-chart-strip">
-    <div class="so-card so-cache-dashboard__chart-empty">
-      <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-range">No chart data in the selected range yet. Summary metrics still use bounded cache stats.</p>
-    </div>
+    <% if @activity_trends&.[](:available) %>
+      <figure class="so-spark" data-so-spark="cache-hit-rate">
+        <figcaption class="so-spark__label">Hit rate <span data-so-range-copy><%= cache_range_label(@range) %></span></figcaption>
+        <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+          <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+          <polyline class="so-spark__line" points="<%= spark_points(@activity_trends[:hit_rate]) %>"/>
+        </svg>
+        <span class="so-spark__value"><%= cache_ratio_percent(@stats[:hit_rate]) %></span>
+      </figure>
+
+      <figure class="so-spark" data-so-spark="cache-operations">
+        <figcaption class="so-spark__label">Operations total <span data-so-range-copy><%= cache_range_label(@range) %></span></figcaption>
+        <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+          <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+          <polyline class="so-spark__line" points="<%= spark_points(@activity_trends[:operations]) %>"/>
+        </svg>
+        <span class="so-spark__value"><%= number_with_delimiter(@stats[:operations_count].to_i) %></span>
+      </figure>
+
+      <figure class="so-spark" data-so-spark="cache-errors">
+        <figcaption class="so-spark__label">Errors total <span data-so-range-copy><%= cache_range_label(@range) %></span></figcaption>
+        <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+          <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+          <polyline class="so-spark__line" points="<%= spark_points(@activity_trends[:errors]) %>"/>
+        </svg>
+        <span class="so-spark__value"><%= number_with_delimiter(@stats[:errors_count].to_i) %></span>
+      </figure>
+    <% else %>
+      <div class="so-card so-cache-dashboard__chart-empty">
+        <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-range">No chart data in the selected range yet. Summary metrics still use bounded cache stats.</p>
+      </div>
+    <% end %>
   </div>
 </section>

--- a/app/views/solid_observer/cache_dashboard/index.html.erb
+++ b/app/views/solid_observer/cache_dashboard/index.html.erb
@@ -23,16 +23,26 @@
   <% if @cache_dashboard_available %>
     <form action="<%= request.path %>" method="get" class="so-dashboard-toolbar so-cache-dashboard__range-form">
       <label for="so-cache-range" class="so-card__label so-filters__label">Range</label>
-      <select id="so-cache-range" name="range">
+      <select id="so-cache-range" name="range" onchange="this.form.submit()">
         <% SolidObserver::Services::CacheStats::RANGES.each_key do |key| %>
           <option value="<%= key %>" <%= "selected" if key == @range %>><%= cache_range_label(key) %></option>
         <% end %>
       </select>
-      <button type="submit" class="so-btn">Apply range</button>
+      <input type="submit" value="Apply range" hidden aria-hidden="true">
     </form>
 
     <%= render "solid_observer/cache_dashboard/summary", stats: @stats, storage_components: @storage_components %>
     <%= render "solid_observer/cache_dashboard/charts" %>
+
+    <% if @stability&.[](:available) %>
+      <section class="so-stability" data-so-zone="cache-stability" aria-labelledby="so-cache-stability-heading">
+        <span class="so-stability__label" id="so-cache-stability-heading">Stability</span>
+        <%= cache_stability_badge(@stability[:state]) %>
+        <span class="so-stability__detail"><%= cache_stability_detail(@stability) %></span>
+        <a href="#so-cache-events-heading" class="so-stability__link">View sampled events →</a>
+      </section>
+    <% end %>
+
     <%= render "solid_observer/cache_dashboard/recent_events", recent_events: @recent_events %>
   <% else %>
     <section class="so-card so-card--section" aria-labelledby="so-cache-unavailable-heading">

--- a/lib/solid_observer/services/cache_stats.rb
+++ b/lib/solid_observer/services/cache_stats.rb
@@ -13,6 +13,191 @@ module SolidObserver
         "14d" => 14.days
       }.freeze
       DEFAULT_RANGE = "15m"
+      ACTIVITY_TREND_EMPTY = {
+        available: false,
+        hit_rate: [],
+        operations: [],
+        errors: []
+      }.freeze
+      STABILITY_EMPTY = {
+        available: false,
+        state: :stable,
+        error_count: 0,
+        slow_count: 0,
+        latest_recorded_at: nil
+      }.freeze
+      BUCKET_RULES = [
+        [2.hours.to_i, 1.minute.to_i],
+        [1.day.to_i, 15.minutes.to_i],
+        [7.days.to_i, 2.hours.to_i]
+      ].freeze
+
+      class TrendData
+        class BucketSnapshot
+          attr_reader :operations_count, :hits_count, :misses_count, :errors_count
+
+          def initialize
+            @operations_count = 0
+            @hits_count = 0
+            @misses_count = 0
+            @errors_count = 0
+          end
+
+          def add(row)
+            @operations_count += row[1].to_i
+            @hits_count += row[2].to_i
+            @misses_count += row[3].to_i
+            @errors_count += row[4].to_i
+          end
+
+          def hit_rate
+            read_outcomes = hits_count + misses_count
+            return 0.0 if read_outcomes.zero?
+
+            hits_count.to_f / read_outcomes
+          end
+
+          def value_for(key)
+            public_send(key)
+          end
+        end
+
+        def initialize(metric_rows:, window:, current_time:)
+          @metric_rows = metric_rows
+          @window = window
+          @current_time = current_time
+        end
+
+        def to_h
+          return CacheStats::ACTIVITY_TREND_EMPTY.dup if metric_rows.empty?
+
+          buckets = blank_buckets
+          metric_rows.each do |row|
+            buckets[align_bucket(row[0].to_i)]&.add(row)
+          end
+
+          {
+            available: true,
+            hit_rate: hit_rate_series(buckets),
+            operations: count_series(buckets, :operations_count),
+            errors: count_series(buckets, :errors_count)
+          }
+        end
+
+        private
+
+        attr_reader :metric_rows, :window, :current_time
+
+        def blank_buckets
+          start_bucket = align_bucket((current_time - window).to_i)
+          end_bucket = align_bucket(current_time.to_i)
+
+          start_bucket.step(end_bucket, bucket_seconds).each_with_object({}) do |timestamp, buckets|
+            buckets[timestamp] = BucketSnapshot.new
+          end
+        end
+
+        def hit_rate_series(buckets)
+          buckets.map do |timestamp, totals|
+            {t: timestamp, v: totals.hit_rate}
+          end
+        end
+
+        def count_series(buckets, key)
+          buckets.map do |timestamp, totals|
+            {t: timestamp, v: totals.value_for(key)}
+          end
+        end
+
+        def bucket_seconds
+          seconds = window.to_i
+          CacheStats::BUCKET_RULES.find { |limit, _bucket| seconds <= limit }&.last || 4.hours.to_i
+        end
+
+        def align_bucket(value)
+          (value / bucket_seconds) * bucket_seconds
+        end
+      end
+
+      class StabilityData
+        class EventCounts
+          attr_reader :error_count, :slow_count, :latest_recorded_at
+
+          def initialize
+            @error_count = 0
+            @slow_count = 0
+            @latest_recorded_at = nil
+          end
+
+          def record(recorded_at:, error_class:, duration:)
+            kind = event_kind(error_class: error_class, duration: duration)
+            return unless kind
+
+            @latest_recorded_at = [latest_recorded_at, recorded_at].compact.max
+            @error_count += 1 if kind == :error
+            @slow_count += 1 if kind == :slow
+          end
+
+          def state
+            return :critical if error_count.positive?
+            return :degraded if slow_count.positive?
+
+            :stable
+          end
+
+          def to_h
+            {
+              available: true,
+              state: state,
+              error_count: error_count,
+              slow_count: slow_count,
+              latest_recorded_at: latest_recorded_at
+            }
+          end
+
+          private
+
+          def event_kind(error_class:, duration:)
+            return :error if error_class.present?
+            return :slow if duration.to_f >= SolidObserver.config.cache_slow_threshold.to_f
+
+            nil
+          end
+        end
+
+        def initialize(window:, current_time:)
+          @window = window
+          @current_time = current_time
+        end
+
+        def to_h
+          event_counts.to_h
+        rescue ActiveRecord::StatementInvalid
+          CacheStats::STABILITY_EMPTY.dup
+        end
+
+        private
+
+        attr_reader :window, :current_time
+
+        def event_counts
+          counts = EventCounts.new
+
+          SolidObserver::CacheEvent.where(recorded_at: window_range).pluck(
+            :recorded_at,
+            :duration,
+            :error_class
+          ).each do |recorded_at, duration, error_class|
+            counts.record(recorded_at: recorded_at, error_class: error_class, duration: duration)
+          end
+
+          counts
+        end
+
+        def window_range
+          (current_time - window)..current_time
+        end
+      end
 
       class << self
         def parse_range(value, fallback: DEFAULT_RANGE)
@@ -30,8 +215,77 @@ module SolidObserver
       end
 
       def call(window:)
-        scope = SolidObserver::CacheMetric.where(period_start: window_start(window)..Time.current)
-        totals = scope.pick(
+        current_time = Time.current
+        dashboard_response(window: window, current_time: current_time)
+      rescue => error
+        error_response(error.message)
+      end
+
+      private
+
+      def dashboard_response(window:, current_time:)
+        time_window = (current_time - window)..current_time
+        metric_rows = metric_rows(time_window: time_window)
+
+        build_response(
+          window: window,
+          totals: metric_totals(time_window: time_window),
+          dashboard_data: dashboard_data(window: window, current_time: current_time, metric_rows: metric_rows)
+        )
+      end
+
+      def build_response(window:, totals:, dashboard_data:)
+        operations_count, hits_count, misses_count, errors_count, duration_total = totals.values_at(
+          :operations_count,
+          :hits_count,
+          :misses_count,
+          :errors_count,
+          :duration_total
+        )
+        read_outcomes_count = hits_count + misses_count
+        window_minutes = [window.to_f / 60.0, 1.0].max
+
+        {
+          hit_rate: ratio(hits_count, read_outcomes_count),
+          throughput: operations_count.to_f / window_minutes,
+          error_rate: ratio(errors_count, operations_count),
+          avg_duration: ratio(duration_total, operations_count),
+          operations_count: operations_count,
+          hits_count: hits_count,
+          misses_count: misses_count,
+          errors_count: errors_count,
+          duration_total: duration_total,
+          activity_trends: dashboard_data[:activity_trends],
+          stability: dashboard_data[:stability]
+        }
+      end
+
+      def dashboard_data(window:, current_time:, metric_rows:)
+        {
+          activity_trends: TrendData.new(
+            metric_rows: metric_rows,
+            window: window,
+            current_time: current_time
+          ).to_h,
+          stability: StabilityData.new(window: window, current_time: current_time).to_h
+        }
+      end
+
+      def metric_rows(time_window:)
+        SolidObserver::CacheMetric.where(period_start: time_window).pluck(
+          :period_start,
+          :operations_count,
+          :hits_count,
+          :misses_count,
+          :errors_count,
+          :duration_total
+        )
+      end
+
+      def metric_totals(time_window:)
+        operations_count, hits_count, misses_count, errors_count, duration_total = SolidObserver::CacheMetric.where(
+          period_start: time_window
+        ).pick(
           Arel.sql("COALESCE(SUM(operations_count), 0)"),
           Arel.sql("COALESCE(SUM(hits_count), 0)"),
           Arel.sql("COALESCE(SUM(misses_count), 0)"),
@@ -39,24 +293,7 @@ module SolidObserver
           Arel.sql("COALESCE(SUM(duration_total), 0.0)")
         )
 
-        build_response(window: window, totals: totals)
-      rescue => error
-        error_response(error.message)
-      end
-
-      private
-
-      def build_response(window:, totals:)
-        operations_count, hits_count, misses_count, errors_count, duration_total = totals
-        window_minutes = [window.to_f / 60.0, 1.0].max
-
-        read_outcomes_count = hits_count.to_i + misses_count.to_i
-
         {
-          hit_rate: ratio(hits_count, read_outcomes_count),
-          throughput: operations_count.to_f / window_minutes,
-          error_rate: ratio(errors_count, operations_count),
-          avg_duration: ratio(duration_total, operations_count),
           operations_count: operations_count,
           hits_count: hits_count,
           misses_count: misses_count,
@@ -71,10 +308,6 @@ module SolidObserver
         numerator.to_f / denominator
       end
 
-      def window_start(window)
-        Time.current - window
-      end
-
       def error_response(message)
         {
           hit_rate: 0.0,
@@ -86,6 +319,8 @@ module SolidObserver
           misses_count: 0,
           errors_count: 0,
           duration_total: 0.0,
+          activity_trends: ACTIVITY_TREND_EMPTY.dup,
+          stability: STABILITY_EMPTY.dup,
           error: message
         }
       end

--- a/spec/lib/solid_observer/services/cache_stats_spec.rb
+++ b/spec/lib/solid_observer/services/cache_stats_spec.rb
@@ -19,7 +19,28 @@ RSpec.describe SolidObserver::Services::CacheStats do
     end
   end
 
-  before { SolidObserver::CacheMetric.delete_all }
+  before(:all) do
+    connection = SolidObserver::CacheEvent.connection
+    next if connection.table_exists?(:solid_observer_cache_events)
+
+    connection.create_table :solid_observer_cache_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :key_digest, null: false, limit: 64
+      t.boolean :hit
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before do
+    SolidObserver::CacheMetric.delete_all
+    SolidObserver::CacheEvent.delete_all
+  end
+
+  after { SolidObserver.reset_configuration! }
 
   describe ".parse_range" do
     it "returns the requested range when it is supported" do
@@ -38,6 +59,127 @@ RSpec.describe SolidObserver::Services::CacheStats do
 
     it "uses the default duration for unsupported values" do
       expect(described_class.range_duration("bogus")).to eq(15.minutes)
+    end
+  end
+
+  describe described_class::TrendData do
+    let(:fixed_time) { Time.utc(2026, 6, 3, 12, 0, 0) }
+
+    it "returns the empty trend payload when no metric rows exist" do
+      result = described_class.new(metric_rows: [], window: 15.minutes, current_time: fixed_time).to_h
+
+      expect(result).to eq(SolidObserver::Services::CacheStats::ACTIVITY_TREND_EMPTY)
+      expect(result).not_to be(SolidObserver::Services::CacheStats::ACTIVITY_TREND_EMPTY)
+    end
+
+    it "buckets metric rows and builds hit-rate, operations, and errors series" do
+      result = described_class.new(
+        metric_rows: [
+          [fixed_time - 14.minutes + 45.seconds, 10, 7, 3, 1, 1.2],
+          [fixed_time - 14.minutes + 10.seconds, 2, 0, 0, 1, 0.4],
+          [fixed_time - 2.minutes + 30.seconds, 5, 4, 1, 0, 0.5]
+        ],
+        window: 15.minutes,
+        current_time: fixed_time
+      ).to_h
+
+      hit_rate_by_time = result[:hit_rate].to_h { |point| [point[:t], point[:v]] }
+      operations_by_time = result[:operations].to_h { |point| [point[:t], point[:v]] }
+      errors_by_time = result[:errors].to_h { |point| [point[:t], point[:v]] }
+
+      expect(result[:available]).to be(true)
+      expect(result[:hit_rate].size).to eq(16)
+      expect(hit_rate_by_time[(fixed_time - 14.minutes).to_i]).to eq(0.7)
+      expect(operations_by_time[(fixed_time - 14.minutes).to_i]).to eq(12)
+      expect(errors_by_time[(fixed_time - 14.minutes).to_i]).to eq(2)
+      expect(hit_rate_by_time[(fixed_time - 2.minutes).to_i]).to eq(0.8)
+      expect(operations_by_time[(fixed_time - 2.minutes).to_i]).to eq(5)
+      expect(errors_by_time[(fixed_time - 2.minutes).to_i]).to eq(0)
+      expect(hit_rate_by_time[(fixed_time - 13.minutes).to_i]).to eq(0.0)
+      expect(operations_by_time[(fixed_time - 13.minutes).to_i]).to eq(0)
+      expect(errors_by_time[(fixed_time - 13.minutes).to_i]).to eq(0)
+    end
+  end
+
+  describe described_class::StabilityData do
+    let(:fixed_time) { Time.utc(2026, 6, 3, 12, 0, 0) }
+
+    around do |example|
+      previous_threshold = SolidObserver.config.cache_slow_threshold
+      SolidObserver.config.cache_slow_threshold = 0.1
+
+      travel_to(fixed_time) { example.run }
+    ensure
+      SolidObserver.config.cache_slow_threshold = previous_threshold
+    end
+
+    def stability_data
+      described_class.new(window: 15.minutes, current_time: Time.current).to_h
+    end
+
+    it "classifies the range as stable when only fast successful events exist" do
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_read",
+        key_digest: "stable-event",
+        hit: true,
+        duration: 0.05,
+        metadata: "{}",
+        recorded_at: 5.minutes.ago
+      )
+
+      expect(stability_data).to include(
+        available: true,
+        state: :stable,
+        error_count: 0,
+        slow_count: 0,
+        latest_recorded_at: nil
+      )
+    end
+
+    it "classifies the range as degraded when slow events exist without errors" do
+      recorded_at = 4.minutes.ago
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_write",
+        key_digest: "slow-event",
+        duration: 0.25,
+        metadata: "{}",
+        recorded_at: recorded_at
+      )
+
+      expect(stability_data).to include(
+        available: true,
+        state: :degraded,
+        error_count: 0,
+        slow_count: 1,
+        latest_recorded_at: recorded_at
+      )
+    end
+
+    it "classifies the range as critical when error events are present" do
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_write",
+        key_digest: "slow-event",
+        duration: 0.25,
+        metadata: "{}",
+        recorded_at: 6.minutes.ago
+      )
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_fetch",
+        key_digest: "error-event",
+        duration: 0.02,
+        error_class: "RuntimeError",
+        error_message: "hidden from UI",
+        metadata: "{}",
+        recorded_at: 2.minutes.ago
+      )
+
+      expect(stability_data).to include(
+        available: true,
+        state: :critical,
+        error_count: 1,
+        slow_count: 1,
+        latest_recorded_at: 2.minutes.ago
+      )
     end
   end
 

--- a/spec/requests/solid_observer/cache_dashboard_spec.rb
+++ b/spec/requests/solid_observer/cache_dashboard_spec.rb
@@ -127,70 +127,100 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
     [status, headers, response_body]
   end
 
+  def seed_cache_dashboard_data(fixed_time)
+    SolidObserver::CacheMetric.create!(
+      event_type: "cache_read",
+      period_start: fixed_time.beginning_of_minute,
+      operations_count: 40,
+      hits_count: 30,
+      misses_count: 10,
+      errors_count: 4,
+      duration_total: 5.2
+    )
+    SolidObserver::CacheMetric.create!(
+      event_type: "cache_read",
+      period_start: 2.hours.ago.beginning_of_minute,
+      operations_count: 500,
+      hits_count: 400,
+      misses_count: 100,
+      errors_count: 0,
+      duration_total: 50.0
+    )
+
+    SolidObserver::CacheEvent.create!(
+      event_type: "cache_read",
+      key_digest: "abcdef1234567890",
+      hit: true,
+      duration: 0.003,
+      metadata: "{}",
+      recorded_at: 5.minutes.ago
+    )
+    SolidObserver::CacheEvent.create!(
+      event_type: "cache_write",
+      key_digest: "fedcba0987654321",
+      hit: nil,
+      duration: 1.2,
+      error_class: "RuntimeError",
+      error_message: "adapter internals should stay hidden",
+      metadata: "{}",
+      recorded_at: 3.minutes.ago
+    )
+    SolidObserver::CacheEvent.create!(
+      event_type: "cache_fetch",
+      key_digest: "1122334455667788",
+      hit: nil,
+      duration: nil,
+      metadata: "{}",
+      recorded_at: 2.minutes.ago
+    )
+    SolidObserver::CacheEvent.create!(
+      event_type: "cache_delete",
+      key_digest: "olddigest00000000",
+      hit: false,
+      duration: 0.001,
+      metadata: "{}",
+      recorded_at: 2.hours.ago
+    )
+    SolidCache::Entry.create!(key: "cache-key", value: "cached")
+  end
+
   it "defines the cache overview route on CacheDashboardController" do
     routes_source = File.read(File.expand_path("../../../config/routes.rb", __dir__))
 
     expect(routes_source).to include('get "cache", to: "cache_dashboard#index", as: :cache_dashboard')
   end
 
-  it "renders the cache overview with bounded summary data, chart empty state, and sampled events" do
+  it "exposes activity trends and stability from cache_dashboard_assignments" do
     fixed_time = Time.utc(2026, 6, 2, 12, 0, 0)
 
     travel_to(fixed_time) do
-      SolidObserver::CacheMetric.create!(
-        event_type: "cache_read",
-        period_start: fixed_time.beginning_of_minute,
-        operations_count: 40,
-        hits_count: 30,
-        misses_count: 10,
-        errors_count: 4,
-        duration_total: 5.2
-      )
-      SolidObserver::CacheMetric.create!(
-        event_type: "cache_read",
-        period_start: 2.hours.ago.beginning_of_minute,
-        operations_count: 500,
-        hits_count: 400,
-        misses_count: 100,
-        errors_count: 0,
-        duration_total: 50.0
-      )
+      seed_cache_dashboard_data(fixed_time)
 
-      SolidObserver::CacheEvent.create!(
-        event_type: "cache_read",
-        key_digest: "abcdef1234567890",
-        hit: true,
-        duration: 0.003,
-        metadata: "{}",
-        recorded_at: 5.minutes.ago
+      assignments = SolidObserver::CacheDashboardController.cache_dashboard_assignments(range_param: "15m")
+
+      expect(assignments).to include(cache_dashboard_available: true, range: "15m")
+      expect(assignments[:activity_trends]).to include(available: true)
+      expect(assignments[:stability]).to include(
+        available: true,
+        state: :critical,
+        error_count: 1,
+        slow_count: 0,
+        latest_recorded_at: 3.minutes.ago
       )
-      SolidObserver::CacheEvent.create!(
-        event_type: "cache_write",
-        key_digest: "fedcba0987654321",
-        hit: nil,
-        duration: 1.2,
-        error_class: "RuntimeError",
-        error_message: "adapter internals should stay hidden",
-        metadata: "{}",
-        recorded_at: 3.minutes.ago
-      )
-      SolidObserver::CacheEvent.create!(
-        event_type: "cache_fetch",
-        key_digest: "1122334455667788",
-        hit: nil,
-        duration: nil,
-        metadata: "{}",
-        recorded_at: 2.minutes.ago
-      )
-      SolidObserver::CacheEvent.create!(
-        event_type: "cache_delete",
-        key_digest: "olddigest00000000",
-        hit: false,
-        duration: 0.001,
-        metadata: "{}",
-        recorded_at: 2.hours.ago
-      )
-      SolidCache::Entry.create!(key: "cache-key", value: "cached")
+      expect(assignments[:stats][:activity_trends]).to eq(assignments[:activity_trends])
+      expect(assignments[:stats][:stability]).to eq(assignments[:stability])
+      expect(assignments[:storage_components].map { |snapshot| snapshot[:component] })
+        .to contain_exactly("cache_observer", "solid_cache")
+      expect(assignments[:recent_events].map(&:key_digest))
+        .to eq(%w[1122334455667788 fedcba0987654321 abcdef1234567890])
+    end
+  end
+
+  it "renders activity trends, stability, and sampled events for the selected range" do
+    fixed_time = Time.utc(2026, 6, 2, 12, 0, 0)
+
+    travel_to(fixed_time) do
+      seed_cache_dashboard_data(fixed_time)
 
       status, _headers, body = call_action("/solid_observer/cache?range=15m")
 
@@ -198,7 +228,9 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
       expect(body).to include("Cache overview")
       expect(body).to include("Available")
       expect(body).to include("Selected range: in last 15m · keys and values are never shown.")
-      expect(body).to include("Apply range")
+      expect(body).to include('onchange="this.form.submit()"')
+      expect(body).to include('<input type="submit" value="Apply range" hidden aria-hidden="true">')
+      expect(body).not_to include('<button type="submit"')
       expect(body).to include("Summary in selected range")
       expect(body).to include("75%")
       expect(body).to include("40")
@@ -206,7 +238,17 @@ RSpec.describe "SolidObserver cache dashboard", type: :request do
       expect(body).to include("130ms")
       expect(body).to include("SolidCache + cache observer")
       expect(body).to include("Activity trends")
-      expect(body).to include("No chart data in the selected range yet. Summary metrics still use bounded cache stats.")
+      expect(body).to include('data-so-spark="cache-hit-rate"')
+      expect(body).to include('data-so-spark="cache-operations"')
+      expect(body).to include('data-so-spark="cache-errors"')
+      expect(body).to match(/data-so-spark="cache-hit-rate".*?<polyline class="so-spark__line" points="[^"]+"/m)
+      expect(body).to match(/data-so-spark="cache-operations".*?<polyline class="so-spark__line" points="[^"]+"/m)
+      expect(body).to match(/data-so-spark="cache-errors".*?<polyline class="so-spark__line" points="[^"]+"/m)
+      expect(body).not_to include("No chart data in the selected range yet. Summary metrics still use bounded cache stats.")
+      expect(body).to include('data-so-zone="cache-stability"')
+      expect(body).to include("Stability")
+      expect(body).to include("Critical")
+      expect(body).to include("1 sampled cache error in the selected range")
       expect(body).to include("Sampled recent events")
       expect(body).to include("debug context only · no raw keys or values")
       expect(body).to include("abcdef1234…")


### PR DESCRIPTION
## Summary of changes
- Added real Activity trends (sparklines) and Stability strip to Cache overview using existing `CacheMetric`/`CacheEvent` data.
- Range selector now auto-reloads on change (simple `onchange` submit).
- Achieved visual parity with Queue Overview patterns (`so-spark`, stability badge).