### PR TITLE
[SO-079][FIX] Read failed-job error payload as Hash

### DIFF
--- a/app/views/solid_observer/jobs/show.html.erb
+++ b/app/views/solid_observer/jobs/show.html.erb
@@ -52,16 +52,16 @@
       <tbody>
         <tr>
           <td>Error Class</td>
-          <td><code><%= @execution.error.exception_class %></code></td>
+          <td><code><%= @execution.error["exception_class"] %></code></td>
         </tr>
         <tr>
           <td>Message</td>
-          <td><%= @execution.error.message %></td>
+          <td><%= @execution.error["message"] %></td>
         </tr>
       </tbody>
     </table>
     <div class="so-card__label">Backtrace</div>
-    <pre class="so-pre so-pre--error"><code><%= @execution.error.backtrace&.first(20)&.join("\n") || "No backtrace available" %></code></pre>
+    <pre class="so-pre so-pre--error"><code><%= @execution.error["backtrace"]&.first(20)&.join("\n") || "No backtrace available" %></code></pre>
   </div>
 
   <div class="so-actions">

--- a/spec/features/jobs_spec.rb
+++ b/spec/features/jobs_spec.rb
@@ -256,4 +256,54 @@ RSpec.describe "Jobs", type: :feature do
       end
     end
   end
+
+  context "when showing a failed execution with a serialized error payload" do
+    before do
+      ensure_solid_queue_tables!
+      stub_solid_queue_models!
+      SolidQueue::FailedExecution.serialize :error, coder: JSON
+      SolidObserver.config.storage_mode = :persistence
+
+      SolidQueue::ReadyExecution.delete_all
+      SolidQueue::ScheduledExecution.delete_all
+      SolidQueue::ClaimedExecution.delete_all
+      SolidQueue::FailedExecution.delete_all
+      SolidQueue::Job.delete_all
+
+      now = Time.current
+      failed_job = SolidQueue::Job.create!(
+        queue_name: "default",
+        class_name: "FailedHashErrorJob",
+        priority: 0,
+        created_at: now - 1.minute,
+        updated_at: now - 1.minute
+      )
+      @failed_execution = SolidQueue::FailedExecution.create!(
+        job: failed_job,
+        error: {
+          "exception_class" => "SolidQueue::Processes::ProcessExitError",
+          "message" => "Process pid=8471 exited unexpectedly. Received unhandled signal 6.",
+          "backtrace" => nil
+        },
+        created_at: now - 1.minute
+      )
+    end
+
+    after do
+      SolidQueue::ReadyExecution.delete_all if defined?(SolidQueue::ReadyExecution)
+      SolidQueue::ScheduledExecution.delete_all if defined?(SolidQueue::ScheduledExecution)
+      SolidQueue::ClaimedExecution.delete_all if defined?(SolidQueue::ClaimedExecution)
+      SolidQueue::FailedExecution.delete_all if defined?(SolidQueue::FailedExecution)
+      SolidQueue::Job.delete_all if defined?(SolidQueue::Job)
+    end
+
+    it "renders the error details from the Hash payload" do
+      visit "/solid_observer/jobs/#{@failed_execution.id}?status=failed"
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_content("SolidQueue::Processes::ProcessExitError")
+      expect(page).to have_content("Process pid=8471 exited unexpectedly")
+      expect(page).to have_content("No backtrace available")
+    end
+  end
 end


### PR DESCRIPTION
  ## Summary
  - Fix `ActionView::Template::Error: undefined method 'exception_class' for Hash` when viewing a failed job whose
  `error` column is populated.
  - `SolidQueue::FailedExecution#error` is a JSON-serialized Hash with string keys, not an object — switch `show.html.erb` to bracket access for `exception_class`, `message`, and `backtrace`.
  - Add a feature-spec context that constructs the Hash payload shape from the reported production stack trace (`SolidQueue::Processes::ProcessExitError`, nil backtrace) and asserts HTTP 200 + value rendering.