### PR TITLE
[SO-080][FEAT] Unify dashboard headers, select heights, and Storage nav

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -34,6 +34,7 @@ detectors:
       - SolidObserver::DashboardController#assign_range_and_stats
       - SolidObserver::Queries::EventsQuery#call
       - SolidObserver::CacheEventBuffer#flush!
+      - SolidObserver::ApplicationHelper#mode_badge
 
   LongParameterList:
     exclude:

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -397,7 +397,8 @@
 
     .so-cache-controls { max-width: 820px; }
     .so-cache-dashboard__intro,
-    .so-cache-controls__intro {
+    .so-cache-controls__intro,
+    .so-queue-overview__intro {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
@@ -405,7 +406,8 @@
       margin-top: 0.5rem;
     }
     .so-cache-dashboard__hint,
-    .so-cache-controls__hint {
+    .so-cache-controls__hint,
+    .so-queue-overview__hint {
       font-size: 0.875rem;
       color: var(--so-text-subtle);
       line-height: 1.5;
@@ -414,7 +416,8 @@
       align-items: center;
       margin-bottom: 2rem;
     }
-    .so-cache-dashboard__range-form select {
+    .so-cache-dashboard__range-form select,
+    .so-dashboard-toolbar select {
       padding: 0.4rem 0.6rem;
       border: 1px solid var(--so-border);
       border-radius: var(--so-radius);
@@ -550,7 +553,6 @@
           <%= link_to "Jobs", jobs_path, class: ("active" if controller_name == "jobs"), "aria-current": (controller_name == "jobs" ? "page" : nil) %>
           <% if persistence_mode? %>
             <%= link_to "Events", events_path, class: ("active" if controller_name == "events"), "aria-current": (controller_name == "events" ? "page" : nil) %>
-            <%= link_to "Storage", storage_path, class: ("active" if controller_name == "storages"), "aria-current": (controller_name == "storages" ? "page" : nil) %>
           <% end %>
         <% end %>
 
@@ -560,6 +562,10 @@
           <% if SolidObserver::Services::CacheOperations.available? %>
             <%= link_to "Controls", cache_operations_path, class: ("active" if controller_name == "cache_operations"), "aria-current": (controller_name == "cache_operations" ? "page" : nil) %>
           <% end %>
+        <% end %>
+
+        <% if persistence_mode? && (SolidObserver.config.solid_queue_enabled? || SolidObserver.config.solid_cache_enabled?) %>
+          <%= link_to "Storage", storage_path, class: ("active" if controller_name == "storages"), "aria-current": (controller_name == "storages" ? "page" : nil) %>
         <% end %>
       </nav>
       <div class="so-sidebar__mode">

--- a/app/views/solid_observer/dashboard/index.html.erb
+++ b/app/views/solid_observer/dashboard/index.html.erb
@@ -4,7 +4,25 @@
   <%= render template: "solid_observer/cache_dashboard/index" %>
 <% else %>
 <div class="so-dashboard">
-  <% if !SolidObserver.config.solid_queue_enabled? %>
+  <% queue_enabled = SolidObserver.config.solid_queue_enabled? %>
+  <% queue_status_class = queue_enabled ? "so-badge--success" : "so-badge--warning" %>
+
+  <div class="so-content__header">
+    <h1>Queue overview</h1>
+    <div class="so-queue-overview__intro">
+      <span class="so-badge so-badge--pill <%= queue_status_class %>">
+        <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+          <circle r="3" cx="3" cy="3" />
+        </svg>
+        <%= queue_enabled ? "Available" : "Unavailable" %>
+      </span>
+      <% if queue_enabled %>
+        <p class="so-queue-overview__hint">Selected range: <%= range_label(@range) %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <% if !queue_enabled %>
     <section class="so-card so-card--section" aria-labelledby="so-queue-unavailable-heading">
       <h2 id="so-queue-unavailable-heading">Queue Unavailable</h2>
       <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">Queue component is disabled or not installed. Enable SolidQueue to access dashboard controls.</p>

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -237,6 +237,13 @@ RSpec.describe "Dashboard", type: :feature do
       visit "/solid_observer"
       expect(page).to have_css("[data-so-freshness]")
     end
+
+    it "renders Queue overview header with h1, status badge, and range caption" do
+      visit "/solid_observer"
+      expect(page).to have_css(".so-content__header h1", text: "Queue overview")
+      expect(page).to have_css(".so-badge.so-badge--pill", text: /Available/)
+      expect(page).to have_css(".so-queue-overview__intro")
+    end
   end
 
   context "in realtime mode" do


### PR DESCRIPTION
 ## Summary of changes
- Adds a Cache-style overview header (h1 + Available/Unavailable pill + `Selected range:` caption) to the Queue dashboard, so Queue and Cache present matching surfaces.
- Brings the Queue Range select to the Events `.so-filters` 35px reference height via a new `.so-dashboard-toolbar select` rule new partials, no asset-pipeline changes.