### PR TITLE
[SO-085][FIX] Optimize production dashboard paths

### DIFF
--- a/db/migrate/20260612000001_add_event_type_recorded_at_index_to_cache_events.rb
+++ b/db/migrate/20260612000001_add_event_type_recorded_at_index_to_cache_events.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddEventTypeRecordedAtIndexToCacheEvents < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    options = concurrent_supported? ? {algorithm: :concurrently} : {}
+
+    add_index :solid_observer_cache_events,
+      %i[event_type recorded_at],
+      order: {recorded_at: :desc},
+      if_not_exists: true,
+      **options
+  end
+
+  private
+
+  def concurrent_supported?
+    connection.adapter_name.match?(/postgres/i)
+  end
+end

--- a/lib/solid_observer/chart_buffer.rb
+++ b/lib/solid_observer/chart_buffer.rb
@@ -2,7 +2,40 @@
 
 module SolidObserver
   class ChartBuffer
+    CACHE_KEY = "solid_observer/chart_buffer/ready_samples"
     INSTANCE_MUTEX = Mutex.new
+    SAMPLE_CAP = 720
+    STORAGE_MUTEX = Mutex.new
+
+    class SampleWindow
+      def initialize(samples)
+        @samples = samples
+      end
+
+      def upsert(sample, cap:)
+        return replace_latest_sample(sample) if latest_sample_timestamp == sample[:t]
+
+        append_new_sample(sample, cap: cap)
+      end
+
+      private
+
+      def latest_sample_timestamp
+        @samples.last&.[](:t)
+      end
+
+      def replace_latest_sample(sample)
+        @samples[-1] = sample
+        @samples
+      end
+
+      def append_new_sample(sample, cap:)
+        @samples << sample
+        overflow = @samples.length - cap
+        @samples.shift(overflow) if overflow.positive?
+        @samples
+      end
+    end
 
     class << self
       def append(value, at: Time.now)
@@ -24,16 +57,12 @@ module SolidObserver
       end
     end
 
-    def initialize
-      @mutex = Mutex.new
-      @samples = []
-      @cap = nil
-    end
+    @fallback_samples = []
 
     def append(value, at: Time.now)
       sample = {t: at.to_i, v: value.to_i}
 
-      @mutex.synchronize { store_sample(sample) }
+      STORAGE_MUTEX.synchronize { persist_sample(sample) }
 
       sample
     end
@@ -41,43 +70,71 @@ module SolidObserver
     def recent(window_seconds)
       cutoff = Time.now.to_i - window_seconds.to_i
 
-      @mutex.synchronize do
-        @samples.select { |sample| sample[:t] >= cutoff }.map(&:dup)
+      STORAGE_MUTEX.synchronize do
+        load_samples.select { |sample| sample[:t] >= cutoff }.map(&:dup)
       end
     end
 
     def clear
-      @mutex.synchronize do
-        @samples.clear
-        @cap = nil
+      STORAGE_MUTEX.synchronize do
+        empty_samples = []
+        replace_fallback_samples(empty_samples)
+        cache_store&.delete(CACHE_KEY)
+      rescue
+        nil
       end
     end
 
     private
 
-    def store_sample(sample)
-      @cap ||= compute_cap
-      replace_or_append(sample)
-      trim_to_cap
+    def persist_sample(sample)
+      samples = SampleWindow.new(load_samples).upsert(sample, cap: SAMPLE_CAP)
+      write_samples(samples)
     end
 
-    def replace_or_append(sample)
-      latest_sample = @samples.last
-
-      if latest_sample && latest_sample[:t] == sample[:t]
-        @samples[-1] = sample
-      else
-        @samples << sample
-      end
+    def load_samples
+      normalize_samples(cache_store&.read(CACHE_KEY) || stored_fallback_samples)
+    rescue
+      stored_fallback_samples
     end
 
-    def trim_to_cap
-      overflow = @samples.length - @cap
-      @samples.shift(overflow) if overflow.positive?
+    def write_samples(samples)
+      normalized = normalize_samples(samples)
+
+      replace_fallback_samples(normalized.map(&:dup))
+      cache_store&.write(CACHE_KEY, normalized)
+    rescue
+      replace_fallback_samples(normalized)
     end
 
-    def compute_cap
-      (3600 / 5).to_i # 720 samples — 1h at the 5s cadence
+    def cache_store
+      return unless defined?(Rails)
+
+      Rails.cache
+    end
+
+    def stored_fallback_samples
+      normalize_samples(self.class.instance_variable_get(:@fallback_samples))
+    end
+
+    def replace_fallback_samples(samples)
+      self.class.instance_variable_set(:@fallback_samples, samples)
+    end
+
+    def normalize_samples(samples)
+      Array(samples).filter_map do |sample|
+        normalize_sample(sample)
+      end.last(SAMPLE_CAP)
+    end
+
+    def normalize_sample(sample)
+      return unless sample.is_a?(Hash)
+
+      timestamp = sample[:t] || sample["t"]
+      value = sample[:v] || sample["v"]
+      return unless timestamp && value
+
+      {t: timestamp.to_i, v: value.to_i}
     end
   end
 end

--- a/lib/solid_observer/services/cache_stats.rb
+++ b/lib/solid_observer/services/cache_stats.rb
@@ -123,10 +123,10 @@ module SolidObserver
         class EventCounts
           attr_reader :error_count, :slow_count, :latest_recorded_at
 
-          def initialize
-            @error_count = 0
-            @slow_count = 0
-            @latest_recorded_at = nil
+          def initialize(error_count: 0, slow_count: 0, latest_recorded_at: nil)
+            @error_count = error_count.to_i
+            @slow_count = slow_count.to_i
+            @latest_recorded_at = latest_recorded_at
           end
 
           def record(recorded_at:, error_class:, duration:)
@@ -181,21 +181,37 @@ module SolidObserver
         attr_reader :window, :current_time
 
         def event_counts
-          counts = EventCounts.new
+          error_count, slow_count, latest_recorded_at = SolidObserver::CacheEvent.where(recorded_at: window_range).pick(
+            Arel.sql("COUNT(CASE WHEN #{error_condition_sql} THEN 1 END)"),
+            Arel.sql("COUNT(CASE WHEN #{slow_condition_sql} THEN 1 END)"),
+            Arel.sql("MAX(CASE WHEN #{tracked_condition_sql} THEN recorded_at END)")
+          )
 
-          SolidObserver::CacheEvent.where(recorded_at: window_range).pluck(
-            :recorded_at,
-            :duration,
-            :error_class
-          ).each do |recorded_at, duration, error_class|
-            counts.record(recorded_at: recorded_at, error_class: error_class, duration: duration)
-          end
-
-          counts
+          EventCounts.new(
+            error_count: error_count,
+            slow_count: slow_count,
+            latest_recorded_at: latest_recorded_at
+          )
         end
 
         def window_range
           (current_time - window)..current_time
+        end
+
+        def tracked_condition_sql
+          "(#{error_condition_sql}) OR (#{slow_condition_sql})"
+        end
+
+        def error_condition_sql
+          "error_class IS NOT NULL AND TRIM(error_class) != ''"
+        end
+
+        def slow_condition_sql
+          "(error_class IS NULL OR TRIM(error_class) = '') AND duration >= #{slow_threshold}"
+        end
+
+        def slow_threshold
+          SolidObserver.config.cache_slow_threshold.to_f
         end
       end
 
@@ -218,7 +234,8 @@ module SolidObserver
         current_time = Time.current
         dashboard_response(window: window, current_time: current_time)
       rescue => error
-        error_response(error.message)
+        Rails.logger&.error("[SolidObserver] CacheStats call failed: #{error.class} #{error.message}") if defined?(Rails)
+        error_response
       end
 
       private
@@ -308,7 +325,7 @@ module SolidObserver
         numerator.to_f / denominator
       end
 
-      def error_response(message)
+      def error_response
         {
           hit_rate: 0.0,
           throughput: 0.0,
@@ -321,7 +338,7 @@ module SolidObserver
           duration_total: 0.0,
           activity_trends: ACTIVITY_TREND_EMPTY.dup,
           stability: STABILITY_EMPTY.dup,
-          error: message
+          error: "Service temporarily unavailable"
         }
       end
     end

--- a/lib/solid_observer/services/cleanup_storage.rb
+++ b/lib/solid_observer/services/cleanup_storage.rb
@@ -6,6 +6,13 @@ require_relative "storage_info_snapshot"
 module SolidObserver
   module Services
     class CleanupStorage
+      MAINTENANCE_STATEMENT_BUILDERS = {
+        "sqlite" => ->(_tables) { ["VACUUM"] },
+        "postgresql" => ->(tables) { tables.map { |table_name| "VACUUM ANALYZE #{table_name}" } },
+        "mysql2" => ->(tables) { ["OPTIMIZE TABLE #{tables.join(", ")}"] },
+        "trilogy" => ->(tables) { ["OPTIMIZE TABLE #{tables.join(", ")}"] }
+      }.freeze
+
       def self.call
         new.call
       end
@@ -13,37 +20,54 @@ module SolidObserver
       def call
         return 0 if SolidObserver.config.realtime_mode?
 
-        deleted_count = perform_cleanup_transaction
-        post_cleanup(deleted_count)
-      rescue => e
-        handle_cleanup_failure(e)
+        post_cleanup(cleanup_counts)
+      rescue => error
+        handle_cleanup_failure(error)
       end
 
       private
+
+      def cleanup_counts
+        perform_cleanup.tap { record_snapshot_after_cleanup }
+      end
 
       def handle_cleanup_failure(error)
         Rails.logger.error "[SolidObserver] Cleanup failed: #{error.message}"
         raise
       end
 
-      def perform_cleanup_transaction
-        QueueEvent.transaction do
-          deleted_count = delete_old_events
-          record_snapshot_after_cleanup
-          deleted_count
-        end
+      def perform_cleanup
+        config = SolidObserver.config
+        event_cutoff = config.event_retention.ago
+
+        {
+          queue_events: QueueEvent.transaction do
+            QueueEvent.where("recorded_at < ?", event_cutoff).delete_all
+          end,
+          cache_events: delete_telemetry_records(
+            SolidObserver::CacheEvent,
+            column: :recorded_at,
+            cutoff: event_cutoff
+          ),
+          cache_metrics: delete_telemetry_records(
+            SolidObserver::CacheMetric,
+            column: :period_start,
+            cutoff: config.metrics_retention.ago
+          )
+        }
       end
 
-      def post_cleanup(deleted_count)
+      def post_cleanup(cleanup_counts)
         vacuum_database
         check_storage_warnings
-        log_results(deleted_count)
-        deleted_count
+        log_results(cleanup_counts)
+        cleanup_counts.values.sum
       end
 
-      def delete_old_events
-        cutoff = SolidObserver.config.event_retention.ago
-        QueueEvent.where("recorded_at < ?", cutoff).delete_all
+      def delete_telemetry_records(model, column:, cutoff:)
+        return 0 unless data_source_available?(model)
+
+        model.where("#{column} < ?", cutoff).delete_all
       end
 
       def record_snapshot_after_cleanup
@@ -70,40 +94,37 @@ module SolidObserver
       end
 
       def vacuum_database
-        statement = maintenance_statement
-        return unless statement
-
-        QueueEvent.connection.execute(statement)
-      rescue => e
-        Rails.logger.warn "[SolidObserver] Database maintenance failed: #{e.message}"
+        maintenance_statements.each do |statement|
+          QueueEvent.connection.execute(statement)
+        end
+      rescue => error
+        Rails.logger.warn "[SolidObserver] Database maintenance failed: #{error.message}"
       end
 
       def check_storage_warnings
         current_size = current_database_size
-        return unless warning_needed?(current_size)
+        return unless current_size
+        return unless current_size > (SolidObserver.config.max_db_size * SolidObserver.config.warning_threshold)
 
         Rails.logger.warn(storage_warning_message(current_size))
-      end
-
-      def warning_needed?(current_size)
-        return false unless current_size
-
-        config = SolidObserver.config
-        max_size = config.max_db_size
-        threshold = config.warning_threshold
-        current_size > (max_size * threshold)
       end
 
       def storage_warning_message(current_size)
         max_size = SolidObserver.config.max_db_size
         percentage = ((current_size.to_f / max_size) * 100).round(1)
-        current_size_human = human_size(current_size)
-        max_size_human = human_size(max_size)
+        current_size_human = ActiveSupport::NumberHelper.number_to_human_size(
+          current_size,
+          precision: 1,
+          significant: false,
+          strip_insignificant_zeros: false
+        )
+        max_size_human = ActiveSupport::NumberHelper.number_to_human_size(
+          max_size,
+          precision: 1,
+          significant: false,
+          strip_insignificant_zeros: false
+        )
         "[SolidObserver] Queue DB approaching limit: #{current_size_human} / #{max_size_human} (#{percentage}%)"
-      end
-
-      def human_size(bytes)
-        ActiveSupport::NumberHelper.number_to_human_size(bytes, precision: 1, significant: false, strip_insignificant_zeros: false)
       end
 
       def current_database_size
@@ -112,16 +133,30 @@ module SolidObserver
         @current_database_size = DatabaseSize.call(connection: QueueEvent.connection)
       end
 
-      def log_results(deleted_count)
-        Rails.logger.info "[SolidObserver] Cleaned #{deleted_count} queue events"
+      def log_results(cleanup_counts)
+        Rails.logger.info(
+          "[SolidObserver] Cleaned #{cleanup_counts[:queue_events]} queue events, " \
+          "#{cleanup_counts[:cache_events]} cache events, " \
+          "#{cleanup_counts[:cache_metrics]} cache metrics"
+        )
       end
 
-      def maintenance_statement
-        case QueueEvent.connection.adapter_name.downcase
-        when "sqlite" then "VACUUM"
-        when "postgresql" then "VACUUM ANALYZE solid_observer_queue_events"
-        when "mysql2", "trilogy" then "OPTIMIZE TABLE solid_observer_queue_events"
+      def maintenance_statements
+        tables = [QueueEvent, SolidObserver::CacheEvent, SolidObserver::CacheMetric].filter_map do |model|
+          model.table_name if data_source_available?(model)
         end
+        return [] if tables.empty?
+
+        MAINTENANCE_STATEMENT_BUILDERS.fetch(QueueEvent.connection.adapter_name.downcase, ->(_known_tables) { [] }).call(tables)
+      end
+
+      def data_source_available?(model)
+        table_name = model.table_name.to_s
+        return false if table_name.empty?
+
+        model.connection.data_source_exists?(table_name)
+      rescue *StorageInfoSnapshot::CONNECTION_ERRORS, TypeError
+        false
       end
     end
   end

--- a/lib/solid_observer/services/record_cache_event.rb
+++ b/lib/solid_observer/services/record_cache_event.rb
@@ -5,6 +5,8 @@ require "digest"
 module SolidObserver
   module Services
     class RecordCacheEvent
+      INTERNAL_CACHE_KEY_PREFIX = "solid_observer/"
+
       def self.call(event:, buffer:)
         new(event, buffer).call
       end
@@ -15,6 +17,8 @@ module SolidObserver
       end
 
       def call
+        return if internal_cache_event?
+
         record_metric_and_event
       rescue => error
         raise error if error.is_a?(NameError)
@@ -136,6 +140,25 @@ module SolidObserver
 
       def payload
         @event.payload || {}
+      end
+
+      def internal_cache_event?
+        internal_cache_key?(payload[:key])
+      end
+
+      def internal_cache_key?(key)
+        case key
+        when Array
+          nested_internal_cache_key?(key)
+        when Hash
+          nested_internal_cache_key?(key.flatten(1))
+        else
+          key.to_s.start_with?(INTERNAL_CACHE_KEY_PREFIX)
+        end
+      end
+
+      def nested_internal_cache_key?(entries)
+        entries.any? { |entry| internal_cache_key?(entry) }
       end
     end
   end

--- a/lib/solid_observer/services/storage_info_snapshot.rb
+++ b/lib/solid_observer/services/storage_info_snapshot.rb
@@ -5,6 +5,57 @@ require_relative "database_size"
 module SolidObserver
   module Services
     class StorageInfoSnapshot
+      class RecordCount
+        def initialize(connection, table_name)
+          @connection = connection
+          @table_name = table_name
+        end
+
+        def solid_cache_count
+          case adapter_key
+          when :postgresql then postgresql_approximate_count
+          when :mysql then mysql_approximate_count
+          else
+            yield
+          end
+        end
+
+        private
+
+        attr_reader :connection, :table_name
+
+        def adapter_key
+          case connection.adapter_name.to_s.downcase
+          when /postgres|postgis/ then :postgresql
+          when "mysql2", "trilogy", "mysql" then :mysql
+          else
+            :other
+          end
+        end
+
+        def postgresql_approximate_count
+          quoted_table = connection.quote(table_name)
+
+          connection.query_value(<<~SQL.squish)&.to_i || 0
+            SELECT COALESCE(
+              (SELECT reltuples::bigint FROM pg_class WHERE oid = to_regclass(#{quoted_table})),
+              0
+            )
+          SQL
+        end
+
+        def mysql_approximate_count
+          quoted_table = connection.quote(table_name)
+
+          connection.query_value(<<~SQL)&.to_i || 0
+            SELECT COALESCE(table_rows, 0)
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = #{quoted_table}
+          SQL
+        end
+      end
+
       Component = Struct.new(:key, :label, :record_label, :model, :enabled, keyword_init: true) do
         def enabled?
           enabled.call
@@ -16,14 +67,6 @@ module SolidObserver
 
         def storage_model
           model.call
-        end
-
-        def data_source_exists?(connection, table_name)
-          connection.data_source_exists?(table_name)
-        end
-
-        def database_size(connection, table_name)
-          DatabaseSize.call(connection: connection, table_name: table_name)
         end
 
         def snapshot
@@ -71,16 +114,24 @@ module SolidObserver
           record_model = storage_model
           connection = record_model.connection
           table_name = record_model.table_name.to_s
-          return table_unavailable_snapshot if table_name.empty? || !data_source_exists?(connection, table_name)
+          return unavailable_snapshot(reason: "Table unavailable") unless data_source_available?(connection, table_name)
 
           available_snapshot(
-            db_size_bytes: database_size(connection, table_name),
-            event_count: record_model.count
+            db_size_bytes: DatabaseSize.call(connection: connection, table_name: table_name),
+            event_count: snapshot_event_count(record_model, connection, table_name)
           )
         end
 
-        def table_unavailable_snapshot
-          unavailable_snapshot(reason: "Table unavailable")
+        def data_source_available?(connection, table_name)
+          !table_name.empty? && connection.data_source_exists?(table_name)
+        end
+
+        def snapshot_event_count(record_model, connection, table_name)
+          record_count = RecordCount.new(connection, table_name)
+          exact_count = -> { record_model.count }
+          return exact_count.call unless solid_cache?
+
+          record_count.solid_cache_count(&exact_count)
         end
       end
 

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -122,7 +122,7 @@ namespace :solid_observer do
       puts "Running storage cleanup (retention: #{retention.inspect})..."
 
       deleted_count = SolidObserver::Services::CleanupStorage.call
-      puts "✓ Cleanup complete: #{deleted_count} old events deleted"
+      puts "✓ Cleanup complete: #{deleted_count} old telemetry rows deleted"
     end
 
     desc "Purge ALL SolidObserver storage data (use with caution!)"
@@ -132,10 +132,30 @@ namespace :solid_observer do
 
       confirmation = $stdin.gets&.strip&.downcase
       if confirmation == "y"
-        event_count = SolidObserver::QueueEvent.count
+        data_source_exists = lambda do |model|
+          table_name = model.table_name.to_s
+          !table_name.empty? && model.connection.data_source_exists?(table_name)
+        rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid, TypeError
+          false
+        end
+
+        telemetry_models = [
+          {label: :queue_events, model: SolidObserver::QueueEvent},
+          {label: :cache_events, model: SolidObserver::CacheEvent},
+          {label: :cache_metrics, model: SolidObserver::CacheMetric}
+        ]
+
+        telemetry_counts = telemetry_models.to_h do |entry|
+          count = data_source_exists.call(entry[:model]) ? entry[:model].count : 0
+          [entry[:label], count]
+        end
         snapshot_count = SolidObserver::StorageInfo.count
 
-        SolidObserver::QueueEvent.delete_all
+        telemetry_models.each do |entry|
+          next unless data_source_exists.call(entry[:model])
+
+          entry[:model].delete_all
+        end
         SolidObserver::StorageInfo.delete_all
 
         connection = SolidObserver::QueueEvent.connection
@@ -144,12 +164,23 @@ namespace :solid_observer do
           connection.execute("VACUUM")
           puts "✓ Database vacuumed to reclaim disk space"
         when "postgresql"
-          connection.execute("ANALYZE solid_observer_queue_events")
-          connection.execute("ANALYZE solid_observer_storage_info")
+          [
+            SolidObserver::QueueEvent.table_name,
+            SolidObserver::StorageInfo.table_name,
+            (SolidObserver::CacheEvent.table_name if data_source_exists.call(SolidObserver::CacheEvent)),
+            (SolidObserver::CacheMetric.table_name if data_source_exists.call(SolidObserver::CacheMetric))
+          ].compact.each do |table_name|
+            connection.execute("ANALYZE #{table_name}")
+          end
           puts "✓ Database tables analyzed"
         end
 
-        puts "✓ Purged #{event_count} events and #{snapshot_count} storage snapshots"
+        puts(
+          "✓ Purged #{telemetry_counts.fetch(:queue_events)} queue events, " \
+          "#{telemetry_counts.fetch(:cache_events)} cache events, " \
+          "#{telemetry_counts.fetch(:cache_metrics)} cache metrics, " \
+          "and #{snapshot_count} storage snapshots"
+        )
       else
         puts "Aborted"
       end

--- a/spec/lib/solid_observer/services/cache_stats_spec.rb
+++ b/spec/lib/solid_observer/services/cache_stats_spec.rb
@@ -155,6 +155,32 @@ RSpec.describe SolidObserver::Services::CacheStats do
       )
     end
 
+    it "keeps latest_recorded_at scoped to slow or errored events" do
+      slow_recorded_at = 4.minutes.ago
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_write",
+        key_digest: "slow-event",
+        duration: 0.25,
+        metadata: "{}",
+        recorded_at: slow_recorded_at
+      )
+      SolidObserver::CacheEvent.create!(
+        event_type: "cache_write",
+        key_digest: "fast-event",
+        duration: 0.01,
+        metadata: "{}",
+        recorded_at: 1.minute.ago
+      )
+
+      expect(stability_data).to include(
+        available: true,
+        state: :degraded,
+        error_count: 0,
+        slow_count: 1,
+        latest_recorded_at: slow_recorded_at
+      )
+    end
+
     it "classifies the range as critical when error events are present" do
       SolidObserver::CacheEvent.create!(
         event_type: "cache_write",
@@ -254,6 +280,63 @@ RSpec.describe SolidObserver::Services::CacheStats do
       errors_count: 0,
       duration_total: 0.0
     )
-    expect(stats[:error]).to eq("missing table")
+    expect(stats[:error]).to eq("Service temporarily unavailable")
+  end
+
+  it "degrades stability on ActiveRecord::StatementInvalid from cache events query, preserving other data" do
+    allow(SolidObserver::CacheEvent).to receive(:where).and_raise(
+      ActiveRecord::StatementInvalid.new("no such table: solid_observer_cache_events")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats).not_to have_key(:error)
+    expect(stats[:stability]).to include(available: false, state: :stable)
+  end
+
+  it "preserves metric totals and trends when only the cache events (stability) query fails" do
+    now = Time.current
+    SolidObserver::CacheMetric.create!(
+      event_type: "cache_read",
+      period_start: now.beginning_of_minute,
+      operations_count: 100,
+      hits_count: 70,
+      misses_count: 30,
+      errors_count: 5,
+      duration_total: 12.5
+    )
+
+    allow(SolidObserver::CacheEvent).to receive(:where).and_raise(
+      ActiveRecord::StatementInvalid.new("no such table: solid_observer_cache_events")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats).not_to have_key(:error)
+    expect(stats[:operations_count]).to eq(100)
+    expect(stats[:hits_count]).to eq(70)
+    expect(stats[:hit_rate]).to be > 0.0
+    expect(stats[:throughput]).to be > 0.0
+    expect(stats[:stability]).to include(available: false, state: :stable)
+  end
+
+  it "sanitizes non-ActiveRecord errors in fallback" do
+    allow(SolidObserver::CacheMetric).to receive(:where).and_raise(
+      TypeError.new("no implicit conversion of nil into String")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats[:error]).to eq("Service temporarily unavailable")
+  end
+
+  it "sanitizes generic RuntimeError in fallback without leaking message" do
+    allow(SolidObserver::CacheMetric).to receive(:where).and_raise(
+      RuntimeError.new("PG::DuplicateTable: relation \"cache_entries\" already exists")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats[:error]).to eq("Service temporarily unavailable")
   end
 end

--- a/spec/lib/solid_observer/services/record_cache_event_spec.rb
+++ b/spec/lib/solid_observer/services/record_cache_event_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe SolidObserver::Services::RecordCacheEvent do
     expect(buffer).not_to have_received(:push)
   end
 
+  it "skips SolidObserver-internal cache keys for both metrics and event storage" do
+    internal_event = ActiveSupport::Notifications::Event.new(
+      "cache_write.active_support",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {key: "solid_observer/chart_buffer/ready_samples", hit: true, super_operation: :fetch}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.0)
+    allow(SolidObserver.config).to receive_messages(cache_sampling_rate: 1.0, cache_slow_threshold: 0.0, cache_store_errors: true)
+    allow(SolidObserver::Services::RecordCacheMetric).to receive(:call)
+
+    described_class.call(event: internal_event, buffer: buffer)
+
+    expect(SolidObserver::Services::RecordCacheMetric).not_to have_received(:call)
+    expect(buffer).not_to have_received(:push)
+  end
+
   it "emits no solid_observer_cache_metrics SQL on the notification callback path" do
     SolidObserver.config.buffer_size = 1000
     allow(Kernel).to receive(:rand).and_return(0.9)

--- a/spec/solid_observer/chart_buffer_spec.rb
+++ b/spec/solid_observer/chart_buffer_spec.rb
@@ -3,6 +3,13 @@
 require "spec_helper"
 
 RSpec.describe SolidObserver::ChartBuffer do
+  let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(cache_store)
+    described_class.clear
+  end
+
   after do
     described_class.clear
     SolidObserver.reset_configuration!
@@ -19,6 +26,20 @@ RSpec.describe SolidObserver::ChartBuffer do
             {t: Time.utc(2026, 5, 10, 12, 0, 0).to_i, v: 4},
             {t: Time.utc(2026, 5, 10, 12, 0, 20).to_i, v: 7}
           ]
+        )
+      end
+    end
+
+    it "shares samples across distinct instances via shared cache storage" do
+      first_instance = described_class.new
+      second_instance = described_class.new
+      sample_time = Time.utc(2026, 5, 10, 12, 0, 0)
+
+      travel_to(sample_time) do
+        first_instance.append(11, at: sample_time)
+
+        expect(second_instance.recent(60)).to eq(
+          [{t: sample_time.to_i, v: 11}]
         )
       end
     end
@@ -67,6 +88,30 @@ RSpec.describe SolidObserver::ChartBuffer do
       samples = described_class.recent(10.years.to_i)
       expect(samples.size).to eq(400)
       expect(samples).to all(include(:t, :v))
+    end
+
+    it "falls back to shared process-local storage when cache access fails" do
+      broken_cache_store = instance_double(ActiveSupport::Cache::Store)
+      first_instance = described_class.new
+      second_instance = described_class.new
+      sample_time = Time.utc(2026, 5, 10, 12, 0, 0)
+
+      allow(Rails).to receive(:cache).and_return(broken_cache_store)
+      allow(broken_cache_store).to receive(:read).and_raise(StandardError, "cache unavailable")
+      allow(broken_cache_store).to receive(:write).and_raise(StandardError, "cache unavailable")
+      allow(broken_cache_store).to receive(:delete).and_raise(StandardError, "cache unavailable")
+
+      travel_to(sample_time) do
+        first_instance.append(12, at: sample_time)
+
+        expect(second_instance.recent(60)).to eq(
+          [{t: sample_time.to_i, v: 12}]
+        )
+
+        second_instance.clear
+
+        expect(first_instance.recent(60)).to eq([])
+      end
     end
   end
 

--- a/spec/solid_observer/services/cleanup_storage_spec.rb
+++ b/spec/solid_observer/services/cleanup_storage_spec.rb
@@ -4,21 +4,37 @@ require "spec_helper"
 
 RSpec.describe SolidObserver::Services::CleanupStorage do
   let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil) }
-  let(:relation) { instance_double(ActiveRecord::Relation) }
+  let(:queue_relation) { instance_double(ActiveRecord::Relation) }
+  let(:cache_event_relation) { instance_double(ActiveRecord::Relation) }
+  let(:cache_metric_relation) { instance_double(ActiveRecord::Relation) }
   let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:cache_event_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:cache_metric_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
     allow(SolidObserver.config).to receive(:event_retention).and_return(30.days)
+    allow(SolidObserver.config).to receive(:metrics_retention).and_return(90.days)
     allow(SolidObserver.config).to receive(:max_db_size).and_return(1.megabyte)
     allow(SolidObserver.config).to receive(:warning_threshold).and_return(0.8)
 
     allow(SolidObserver::QueueEvent).to receive(:transaction).and_yield
-    allow(SolidObserver::QueueEvent).to receive(:where).and_return(relation)
+    allow(SolidObserver::QueueEvent).to receive(:where).and_return(queue_relation)
     allow(SolidObserver::QueueEvent).to receive(:count).and_return(500)
     allow(SolidObserver::QueueEvent).to receive(:connection).and_return(connection)
+    allow(connection).to receive(:data_source_exists?).with("solid_observer_queue_events").and_return(true)
 
-    allow(relation).to receive(:delete_all).and_return(10)
+    allow(SolidObserver::CacheEvent).to receive(:where).and_return(cache_event_relation)
+    allow(SolidObserver::CacheEvent).to receive(:connection).and_return(cache_event_connection)
+    allow(cache_event_connection).to receive(:data_source_exists?).with("solid_observer_cache_events").and_return(true)
+
+    allow(SolidObserver::CacheMetric).to receive(:where).and_return(cache_metric_relation)
+    allow(SolidObserver::CacheMetric).to receive(:connection).and_return(cache_metric_connection)
+    allow(cache_metric_connection).to receive(:data_source_exists?).with("solid_observer_cache_metrics").and_return(true)
+
+    allow(queue_relation).to receive(:delete_all).and_return(10)
+    allow(cache_event_relation).to receive(:delete_all).and_return(4)
+    allow(cache_metric_relation).to receive(:delete_all).and_return(3)
     allow(connection).to receive(:execute)
     allow(connection).to receive(:adapter_name).and_return("SQLite")
 
@@ -44,17 +60,26 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
     end
 
     it "deletes events older than retention period" do
-      expect(relation).to receive(:delete_all)
+      expect(queue_relation).to receive(:delete_all)
 
       described_class.call
     end
 
-    it "returns count of deleted events" do
-      allow(relation).to receive(:delete_all).and_return(15)
+    it "deletes cache events and cache metrics older than retention periods" do
+      expect(cache_event_relation).to receive(:delete_all)
+      expect(cache_metric_relation).to receive(:delete_all)
+
+      described_class.call
+    end
+
+    it "returns total count of deleted telemetry rows" do
+      allow(queue_relation).to receive(:delete_all).and_return(15)
+      allow(cache_event_relation).to receive(:delete_all).and_return(6)
+      allow(cache_metric_relation).to receive(:delete_all).and_return(2)
 
       result = described_class.call
 
-      expect(result).to eq(15)
+      expect(result).to eq(23)
     end
 
     it "records snapshot within transaction" do
@@ -95,11 +120,51 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
     end
 
     it "logs successful cleanup" do
-      allow(relation).to receive(:delete_all).and_return(10)
+      allow(queue_relation).to receive(:delete_all).and_return(10)
+      allow(cache_event_relation).to receive(:delete_all).and_return(4)
+      allow(cache_metric_relation).to receive(:delete_all).and_return(3)
 
-      expect(logger).to receive(:info).with("[SolidObserver] Cleaned 10 queue events")
+      expect(logger).to receive(:info).with(
+        "[SolidObserver] Cleaned 10 queue events, 4 cache events, 3 cache metrics"
+      )
 
       described_class.call
+    end
+
+    it "runs cache cleanup outside the queue transaction" do
+      in_transaction = false
+
+      allow(SolidObserver::QueueEvent).to receive(:transaction) do |&block|
+        in_transaction = true
+        block.call
+      ensure
+        in_transaction = false
+      end
+
+      allow(queue_relation).to receive(:delete_all) do
+        expect(in_transaction).to be(true)
+        10
+      end
+      allow(cache_event_relation).to receive(:delete_all) do
+        expect(in_transaction).to be(false)
+        4
+      end
+      allow(cache_metric_relation).to receive(:delete_all) do
+        expect(in_transaction).to be(false)
+        3
+      end
+
+      described_class.call
+    end
+
+    it "skips cache telemetry cleanup when cache tables are unavailable" do
+      allow(cache_event_connection).to receive(:data_source_exists?).with("solid_observer_cache_events").and_return(false)
+      allow(cache_metric_connection).to receive(:data_source_exists?).with("solid_observer_cache_metrics").and_return(false)
+
+      described_class.call
+
+      expect(cache_event_relation).not_to have_received(:delete_all)
+      expect(cache_metric_relation).not_to have_received(:delete_all)
     end
 
     context "when VACUUM fails" do
@@ -156,7 +221,7 @@ RSpec.describe SolidObserver::Services::CleanupStorage do
 
     context "when cleanup fails" do
       before do
-        allow(relation).to receive(:delete_all).and_raise(StandardError, "DB error")
+        allow(queue_relation).to receive(:delete_all).and_raise(StandardError, "DB error")
       end
 
       it "logs error and re-raises" do

--- a/spec/solid_observer/services/storage_info_snapshot_spec.rb
+++ b/spec/solid_observer/services/storage_info_snapshot_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
 
       allow(SolidCache::Entry).to receive(:connection).and_return(solid_cache_connection)
       allow(SolidCache::Entry).to receive(:table_name).and_return("host_app_cache_entries")
+      allow(solid_cache_connection).to receive(:adapter_name).and_return("SQLite")
       allow(SolidCache::Entry).to receive(:count).and_return(7)
       allow(solid_cache_connection).to receive(:data_source_exists?).with("host_app_cache_entries").and_return(true)
       allow(SolidObserver::Services::DatabaseSize).to receive(:call)
@@ -151,6 +152,26 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
         .with(connection: solid_cache_connection, table_name: "host_app_cache_entries")
       expect(SolidCache::Record).not_to have_received(:connection)
       expect(SolidCache::Record).not_to have_received(:count)
+    end
+
+    it "uses adapter-aware approximate PostgreSQL counts for SolidCache entries" do
+      allow(solid_cache_connection).to receive(:adapter_name).and_return("PostgreSQL")
+      allow(solid_cache_connection).to receive(:quote).with("host_app_cache_entries").and_return("'host_app_cache_entries'")
+      allow(solid_cache_connection).to receive(:query_value).and_return("1234")
+
+      snapshots = described_class.call
+      solid_cache = snapshots.find { |snapshot| snapshot[:component] == "solid_cache" }
+
+      expect(solid_cache).to include(
+        label: "SolidCache",
+        available: true,
+        db_size_bytes: 300,
+        event_count: 1234,
+        record_label: "cache rows",
+        unavailable_reason: nil
+      )
+      expect(solid_cache_connection).to have_received(:query_value).with(/pg_class/)
+      expect(SolidCache::Entry).not_to have_received(:count)
     end
 
     it "returns an unavailable solid cache snapshot when the concrete model raises PostgreSQL-style TypeError" do

--- a/spec/tasks/solid_observer_rake_spec.rb
+++ b/spec/tasks/solid_observer_rake_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe "solid_observer rake tasks" do
 
         expect {
           Rake::Task["solid_observer:storage:cleanup"].invoke
-        }.to output(/Running storage cleanup.*Cleanup complete: 42 old events deleted/m).to_stdout
+        }.to output(/Running storage cleanup.*Cleanup complete: 42 old telemetry rows deleted/m).to_stdout
 
         expect(SolidObserver::Services::CleanupStorage).to have_received(:call)
       end
@@ -341,13 +341,22 @@ RSpec.describe "solid_observer rake tasks" do
       before do
         allow(SolidObserver::QueueEvent).to receive(:count).and_return(100)
         allow(SolidObserver::QueueEvent).to receive(:delete_all)
+        allow(SolidObserver::CacheEvent).to receive(:count).and_return(40)
+        allow(SolidObserver::CacheEvent).to receive(:delete_all)
+        allow(SolidObserver::CacheMetric).to receive(:count).and_return(25)
+        allow(SolidObserver::CacheMetric).to receive(:delete_all)
         allow(SolidObserver::StorageInfo).to receive(:count).and_return(10)
         allow(SolidObserver::StorageInfo).to receive(:delete_all)
 
         connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter)
         allow(SolidObserver::QueueEvent).to receive(:connection).and_return(connection)
+        allow(SolidObserver::CacheEvent).to receive(:connection).and_return(connection)
+        allow(SolidObserver::CacheMetric).to receive(:connection).and_return(connection)
         allow(connection).to receive(:execute)
         allow(connection).to receive(:adapter_name).and_return("SQLite")
+        allow(connection).to receive(:data_source_exists?).with("solid_observer_queue_events").and_return(true)
+        allow(connection).to receive(:data_source_exists?).with("solid_observer_cache_events").and_return(true)
+        allow(connection).to receive(:data_source_exists?).with("solid_observer_cache_metrics").and_return(true)
       end
 
       it "purges data when user confirms with y" do
@@ -355,9 +364,11 @@ RSpec.describe "solid_observer rake tasks" do
 
         expect {
           Rake::Task["solid_observer:storage:purge"].invoke
-        }.to output(/Purged 100 events and 10 storage snapshots/m).to_stdout
+        }.to output(/Purged 100 queue events, 40 cache events, 25 cache metrics, and 10 storage snapshots/m).to_stdout
 
         expect(SolidObserver::QueueEvent).to have_received(:delete_all)
+        expect(SolidObserver::CacheEvent).to have_received(:delete_all)
+        expect(SolidObserver::CacheMetric).to have_received(:delete_all)
         expect(SolidObserver::StorageInfo).to have_received(:delete_all)
       end
 


### PR DESCRIPTION
## Summary of changes
- Replace cache stability full-window Ruby loading with database aggregation and preserve partial fallback behavior.
- Avoid exact PostgreSQL SolidCache row counts in storage snapshots.
- Add cache telemetry retention/purge coverage plus cache-event composite indexing.
- Share bounded ChartBuffer samples across processes and filter SolidObserver internal cache keys from cache telemetry.
- Sanitize cache-stats fallback responses so SQL/table/exception details stay server-side.
