### PR TITLE
[SO-084][REFACTOR] Clean up Rails engine load-order and Zeitwerk conflicts

### DIFF
--- a/lib/generators/solid_observer/templates/initializer.rb.tt
+++ b/lib/generators/solid_observer/templates/initializer.rb.tt
@@ -13,7 +13,7 @@ SolidObserver.configure do |config|
   # config.ui_username = "admin"
   # config.ui_password = "secret"
 
-  # Base controller for UI (customize authorization)
+  # Base controller used only to detect API-only rendering compatibility
   # config.ui_base_controller = "ApplicationController"
 
   # === Queue Observability (v0.1.0) ===

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -1,30 +1,45 @@
 # frozen_string_literal: true
 
+require "active_support/lazy_load_hooks"
+
 require_relative "solid_observer/version"
 require_relative "solid_observer/configuration"
 require_relative "solid_observer/correlation_id_resolver"
-require_relative "solid_observer/base_event" if defined?(ActiveRecord)
-require_relative "solid_observer/base_metric" if defined?(ActiveRecord)
 require_relative "solid_observer/params/jobs_filter"
 require_relative "solid_observer/params/events_filter"
-require_relative "solid_observer/queries/job_executions_query" if defined?(ActiveRecord)
-require_relative "solid_observer/queries/events_query" if defined?(ActiveRecord)
-require_relative "solid_observer/queries/execution_finder" if defined?(ActiveRecord)
-require_relative "solid_observer/services/record_event" if defined?(ActiveRecord)
-require_relative "solid_observer/services/flush_event_buffer" if defined?(ActiveRecord)
-require_relative "solid_observer/services/cleanup_storage" if defined?(ActiveRecord)
 require_relative "solid_observer/services/ui_auth_check"
-require_relative "solid_observer/queue_event_buffer" if defined?(ActiveRecord)
-require_relative "solid_observer/subscriber" if defined?(ActiveSupport)
+require_relative "solid_observer/subscriber"
 require_relative "solid_observer/cli/base"
 require_relative "solid_observer/cli/status"
 require_relative "solid_observer/cli/storage"
 require_relative "solid_observer/cli/jobs"
 require_relative "solid_observer/queue_stats"
-require_relative "../app/presenters/solid_observer/execution_presenter"
 require_relative "solid_observer/engine" if defined?(Rails::Engine)
 
+ActiveSupport.on_load(:active_record) do
+  require_relative "solid_observer/base_event"
+  require_relative "solid_observer/base_metric"
+  require_relative "solid_observer/queries/job_executions_query"
+  require_relative "solid_observer/queries/events_query"
+  require_relative "solid_observer/queries/execution_finder"
+  require_relative "solid_observer/services/record_event"
+  require_relative "solid_observer/services/flush_event_buffer"
+  require_relative "solid_observer/services/cleanup_storage"
+  require_relative "solid_observer/queue_event_buffer"
+  require_relative "solid_observer/cache_event_buffer"
+  require_relative "solid_observer/services/flush_cache_metrics"
+  require_relative "solid_observer/cache_metric_buffer"
+  require_relative "solid_observer/cache_subscriber"
+  require_relative "solid_observer/services/record_cache_event"
+  require_relative "solid_observer/services/record_cache_metric"
+  require_relative "solid_observer/services/flush_cache_event_buffer"
+  require_relative "solid_observer/services/cache_stats"
+  require_relative "solid_observer/services/cache_operations"
+end
+
 module SolidObserver
+  autoload :ExecutionPresenter, File.expand_path("../app/presenters/solid_observer/execution_presenter", __dir__)
+
   class Error < StandardError; end
 
   class << self

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "cache_event_buffer"
-require_relative "services/flush_cache_metrics"
-require_relative "cache_metric_buffer"
-require_relative "cache_subscriber"
-require_relative "services/record_cache_event"
-require_relative "services/record_cache_metric"
-require_relative "services/flush_cache_event_buffer"
-require_relative "services/cache_stats"
-require_relative "services/cache_operations"
-
 module SolidObserver
   class Engine < ::Rails::Engine
     isolate_namespace SolidObserver
-
-    SOLID_QUEUE_AVAILABLE = defined?(::SolidQueue)
-    SOLID_CACHE_AVAILABLE = defined?(::SolidCache)
 
     middleware.use ActionDispatch::Cookies
     middleware.use ActionDispatch::Session::CookieStore, key: "_solid_observer_session"
@@ -48,16 +35,17 @@ module SolidObserver
 
       def activate_subscribers
         return activate_subscribers_in_realtime if SolidObserver.config.realtime_mode?
-        return if activation_skipped_for_table_status_for_enabled_components?
 
         Rails.logger.info "[SolidObserver] Activating event subscribers"
-        Subscriber.subscribe! if should_activate_queue_subscriber?
-        CacheSubscriber.subscribe! if should_activate_cache_subscriber?
+        activate_queue_subscriber
+        activate_cache_subscriber
       end
 
       private
 
       def queue_db_config
+        return unless active_record_available?
+
         ActiveRecord::Base.configurations.configs_for(
           env_name: Rails.env,
           name: "solid_observer_queue"
@@ -73,30 +61,32 @@ module SolidObserver
         SolidObserver::BaseMetric.connects_to(**connection_config)
       end
 
+      def active_record_available?
+        defined?(::ActiveRecord::Base)
+      end
+
       def activate_subscribers_in_realtime
         Rails.logger.info "[SolidObserver] Starting in real-time mode (no persistence)"
         Subscriber.subscribe! if should_activate_queue_subscriber?
         CacheSubscriber.subscribe! if should_activate_cache_subscriber?
       end
 
-      def activation_skipped_for_table_status_for_enabled_components?
-        enabled_tables = []
-        enabled_tables << "solid_observer_queue_events" if should_activate_queue_subscriber?
-        enabled_tables << "solid_observer_cache_events" if should_activate_cache_subscriber?
-
-        enabled_tables.any? { |table_name| skip_activation_for_missing_table?(table_name) }
+      def activate_queue_subscriber
+        activate_subscriber_for_table("solid_observer_queue_events", Subscriber) if should_activate_queue_subscriber?
       end
 
-      def skip_activation_for_missing_table?(table_name)
+      def activate_cache_subscriber
+        activate_subscriber_for_table("solid_observer_cache_events", CacheSubscriber) if should_activate_cache_subscriber?
+      end
+
+      def activate_subscriber_for_table(table_name, subscriber)
         case table_status(table_name)
         when :absent
           log_activation_skip("Tables not found (missing: #{table_name}). Run: rails solid_observer:install:migrations && rails db:migrate")
-          true
         when :unknown
           log_activation_skip("Database not reachable at boot. Skipping subscriber activation.")
-          true
         else
-          false
+          subscriber.subscribe!
         end
       end
 
@@ -113,13 +103,19 @@ module SolidObserver
       end
 
       def table_status(table_name)
+        return :unknown unless active_record_available?
+
+        data_source_status(table_name)
+      rescue *boot_connection_errors
+        :unknown
+      end
+
+      def data_source_status(table_name)
         pool = SolidObserver::BaseEvent.connection_pool
 
         return :present if cached_data_source_exists?(pool, table_name)
 
         data_source_exists_in_db?(pool, table_name) ? :present : :absent
-      rescue *boot_connection_errors
-        :unknown
       end
 
       def cached_data_source_exists?(pool, table_name)
@@ -134,6 +130,8 @@ module SolidObserver
       end
 
       def boot_connection_errors
+        return [] unless active_record_available?
+
         [
           ActiveRecord::NoDatabaseError,
           ActiveRecord::ConnectionNotEstablished,

--- a/spec/solid_observer/application_controller_spec.rb
+++ b/spec/solid_observer/application_controller_spec.rb
@@ -178,6 +178,13 @@ RSpec.describe SolidObserver::ApplicationController, type: :controller do
   end
 
   describe "API-only app compatibility" do
+    it "does not inherit from configured ui_base_controller" do
+      stub_const("FakeApiController", Class.new(ActionController::API))
+      SolidObserver.config.ui_base_controller = "FakeApiController"
+
+      expect(described_class.superclass).to eq(ActionController::Base)
+    end
+
     it "detects an API-only base controller correctly" do
       stub_const("FakeApiController", Class.new(ActionController::API))
       expect(FakeApiController.ancestors).to include(ActionController::API)
@@ -186,6 +193,13 @@ RSpec.describe SolidObserver::ApplicationController, type: :controller do
     it "does not detect a standard base controller as API-only" do
       stub_const("FakeStandardController", Class.new(ActionController::Base))
       expect(FakeStandardController.ancestors).not_to include(ActionController::API)
+    end
+
+    it "documents ui_base_controller as API-only rendering compatibility" do
+      template = File.read(File.expand_path("../../lib/generators/solid_observer/templates/initializer.rb.tt", __dir__))
+
+      expect(template).to include("Base controller used only to detect API-only rendering compatibility")
+      expect(template).not_to include("customize authorization")
     end
   end
 
@@ -234,7 +248,11 @@ RSpec.describe SolidObserver::ApplicationController, type: :controller do
       Class.new(SolidObserver::ApplicationController) do
         append_view_path File.expand_path("../../app/views", __dir__)
 
-        helper_method :root_path, :jobs_path, :events_path, :storage_path
+        helper_method :root_path,
+          :jobs_path,
+          :events_path,
+          :storage_path,
+          :live_poll_script_path
 
         class << self
           attr_accessor :error_to_raise
@@ -258,6 +276,10 @@ RSpec.describe SolidObserver::ApplicationController, type: :controller do
 
         def storage_path
           "/solid_observer/storage"
+        end
+
+        def live_poll_script_path
+          "/solid_observer/live_poll.js"
         end
       end
     end

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "spec_helper"
 
 RSpec.describe SolidObserver::Engine do
@@ -15,6 +16,35 @@ RSpec.describe SolidObserver::Engine do
 
   it "isolates namespace to SolidObserver" do
     expect(described_class.isolated?).to be true
+  end
+
+  describe "load order" do
+    it "defers ActiveRecord-backed constants until ActiveRecord::Base loads" do
+      script = <<~RUBY
+        require "rails"
+        require "active_record/railtie"
+        require "solid_observer"
+
+        abort "BaseEvent loaded too early" if SolidObserver.const_defined?(:BaseEvent, false)
+
+        ActiveRecord::Base
+
+        abort "BaseEvent missing" unless SolidObserver.const_defined?(:BaseEvent, false)
+        abort "BaseEvent superclass mismatch" unless SolidObserver::BaseEvent < ActiveRecord::Base
+      RUBY
+
+      project_root = File.expand_path("../..", __dir__)
+      _stdout, stderr, status = Open3.capture3(
+        Gem.ruby, "-Ilib", "-e", script, chdir: project_root
+      )
+
+      expect(status).to be_success, stderr
+    end
+
+    it "does not define load-time availability constants" do
+      expect(described_class.const_defined?(:SOLID_QUEUE_AVAILABLE, false)).to be false
+      expect(described_class.const_defined?(:SOLID_CACHE_AVAILABLE, false)).to be false
+    end
   end
 
   describe "engine-scoped middleware stack" do
@@ -176,6 +206,49 @@ RSpec.describe SolidObserver::Engine do
     end
   end
 
+  describe ".configure_database_connection" do
+    after { SolidObserver.reset_configuration! }
+
+    it "does not raise or connect models when ActiveRecord is absent" do
+      hide_const("ActiveRecord")
+
+      expect(SolidObserver::BaseEvent).not_to receive(:connects_to)
+      expect(SolidObserver::BaseMetric).not_to receive(:connects_to)
+
+      expect { described_class.configure_database_connection }.not_to raise_error
+    end
+
+    it "does not connect observer models when the observer queue database is not configured" do
+      configurations = instance_double(ActiveRecord::DatabaseConfigurations)
+      allow(ActiveRecord::Base).to receive(:configurations).and_return(configurations)
+      allow(configurations).to receive(:configs_for)
+        .with(env_name: Rails.env, name: "solid_observer_queue")
+        .and_return(nil)
+
+      expect(SolidObserver::BaseEvent).not_to receive(:connects_to)
+      expect(SolidObserver::BaseMetric).not_to receive(:connects_to)
+
+      described_class.configure_database_connection
+    end
+
+    it "connects observer models when the observer queue database is configured" do
+      configurations = instance_double(ActiveRecord::DatabaseConfigurations)
+      connection_config = {
+        database: {writing: :solid_observer_queue, reading: :solid_observer_queue}
+      }
+
+      allow(ActiveRecord::Base).to receive(:configurations).and_return(configurations)
+      allow(configurations).to receive(:configs_for)
+        .with(env_name: Rails.env, name: "solid_observer_queue")
+        .and_return(Object.new)
+
+      expect(SolidObserver::BaseEvent).to receive(:connects_to).with(**connection_config)
+      expect(SolidObserver::BaseMetric).to receive(:connects_to).with(**connection_config)
+
+      described_class.configure_database_connection
+    end
+  end
+
   describe ".activate_subscribers" do
     let(:pool) { instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool) }
     let(:cache) { instance_double(ActiveRecord::ConnectionAdapters::SchemaCache) }
@@ -188,6 +261,7 @@ RSpec.describe SolidObserver::Engine do
       allow(cache).to receive(:data_source_exists?).and_return(false)
       allow(connection).to receive(:data_source_exists?).and_return(true)
       allow(SolidObserver::Subscriber).to receive(:subscribe!)
+      allow(SolidObserver::CacheSubscriber).to receive(:subscribe!)
     end
 
     after { SolidObserver.reset_configuration! }
@@ -285,6 +359,20 @@ RSpec.describe SolidObserver::Engine do
 
       expect(logger).to receive(:info).with(/not reachable/)
       expect(SolidObserver::Subscriber).not_to receive(:subscribe!)
+
+      described_class.activate_subscribers
+    end
+
+    it "keeps cache activation independent when the enabled queue table is missing" do
+      stub_const("SolidCache", Module.new)
+      SolidObserver.config.observe_cache = true
+      allow(cache).to receive(:data_source_exists?).with(pool, "solid_observer_queue_events").and_return(false)
+      allow(connection).to receive(:data_source_exists?).with("solid_observer_queue_events").and_return(false)
+      allow(cache).to receive(:data_source_exists?).with(pool, "solid_observer_cache_events").and_return(true)
+
+      expect(logger).to receive(:info).with(/missing: solid_observer_queue_events/)
+      expect(SolidObserver::Subscriber).not_to receive(:subscribe!)
+      expect(SolidObserver::CacheSubscriber).to receive(:subscribe!)
 
       described_class.activate_subscribers
     end


### PR DESCRIPTION
## Summary of changes
- Defer AR-backed SolidObserver constants into `ActiveSupport.on_load(:active_record)` to prevent permanent skip when `solid_observer` loads before ActiveRecord.
- Remove frozen load-time `SOLID_QUEUE_AVAILABLE`/`SOLID_CACHE_AVAILABLE` constants.
- Make subscriber activation per-component: a missing Queue table no longer blocks Cache subscriber activation.
- Guard ActiveRecord/config absence paths against `NameError`.
- Re-scope and document `ui_base_controller` as API-only rendering compatibility detection, not controller inheritance.
- Remove `app/` `require_relative` from `lib/solid_observer.rb` (replace with native `autoload` for `ExecutionPresenter` overridden cleanly by Zeitwerk).