### PR TITLE
[SO-082][FIX] Security posture, auth policy, and adapter hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ The install generator mounts it for you. To mount manually:
 mount SolidObserver::Engine, at: "/solid_observer"
 ```
 
+Production dashboard exposure is the host application's responsibility. If you
+enable and mount the dashboard in production, wrap the mount in your existing
+admin authentication/authorization constraint (example shown for apps that
+already provide an `authenticate` route helper):
+
+```ruby
+# config/routes.rb
+authenticate :user, ->(user) { user.admin? } do
+  mount SolidObserver::Engine, at: "/solid_observer"
+end
+```
+
 ### Auth Configuration
 
 ```ruby
@@ -207,6 +219,7 @@ For production hardening (fail-loud on missing env var vs. fail-open), see [Conf
 - **API-only apps** — the Web UI works without manual configuration. The engine ships its own Cookies/Session/Flash middleware stack scoped to `/solid_observer/*`.
 - **Host-app callbacks are not inherited.** Use `ui_username` / `ui_password` for built-in HTTP Basic Auth.
 - **Auth misconfiguration is fail-open, but loud.** If `ui_username` is set but `ui_password` resolves to `nil`, the UI ships unauthenticated and logs a boot `WARNING`.
+- **HTTP Basic Auth requires both credentials.** Setting only `ui_username` or only `ui_password` disables built-in auth; protect production mounts at the host-app route boundary.
 
 See the full component breakdown in [Components](#components) below.
 
@@ -279,6 +292,13 @@ The Storage page aggregates per-component health rows: Queue Observer database, 
 </p>
 
 For adapter notes and multi-adapter setup, see [Database Setup](#database-setup-persistence-mode) below.
+
+### Storage unavailable diagnostics
+
+The dashboard is admin/developer-facing. When SolidObserver storage is not
+reachable, the current default 503 error page includes the raw exception class
+and message so maintainers can diagnose adapter, credential, migration, or
+database availability problems. Do not expose the dashboard to untrusted users.
 
 ## Configuration
 

--- a/app/controllers/solid_observer/application_controller.rb
+++ b/app/controllers/solid_observer/application_controller.rb
@@ -6,6 +6,7 @@ module SolidObserver
       [
         *([PG::ConnectionBad] if defined?(PG::ConnectionBad)),
         *([Mysql2::Error::ConnectionError] if defined?(Mysql2::Error::ConnectionError)),
+        *([Trilogy::Error] if defined?(Trilogy::Error)),
         *([SQLite3::CantOpenException] if defined?(SQLite3::CantOpenException))
       ]
     end

--- a/lib/generators/solid_observer/templates/initializer.rb.tt
+++ b/lib/generators/solid_observer/templates/initializer.rb.tt
@@ -9,7 +9,16 @@ SolidObserver.configure do |config|
   # Recommended: false in production, true in development/staging
   config.ui_enabled = !Rails.env.production?
 
-  # Authentication for web UI — set a username to enable HTTP Basic Auth
+  # Production dashboard exposure is the host app's responsibility. If you mount
+  # the dashboard in production, wrap the mount in your existing admin auth
+  # constraint, for example in config/routes.rb:
+  #
+  #   authenticate :user, ->(user) { user.admin? } do
+  #     mount SolidObserver::Engine, at: "/solid_observer"
+  #   end
+  #
+  # Built-in HTTP Basic Auth is enabled only when BOTH credentials are present.
+  # Setting only one credential disables Basic Auth and logs a boot warning.
   # config.ui_username = "admin"
   # config.ui_password = "secret"
 

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -137,6 +137,7 @@ module SolidObserver
           ActiveRecord::StatementInvalid,
           *([PG::ConnectionBad] if defined?(PG::ConnectionBad)),
           *([Mysql2::Error::ConnectionError] if defined?(Mysql2::Error::ConnectionError)),
+          *([Trilogy::Error] if defined?(Trilogy::Error)),
           *([SQLite3::CantOpenException] if defined?(SQLite3::CantOpenException))
         ]
       end

--- a/lib/solid_observer/services/flush_cache_metrics.rb
+++ b/lib/solid_observer/services/flush_cache_metrics.rb
@@ -35,7 +35,7 @@ module SolidObserver
           period_start: period_start
         )
 
-        SolidObserver::CacheMetric.where(id: metric.id).update_all(update_values(metric_data))
+        SolidObserver::CacheMetric.where(id: metric.id).update_counters(update_values(metric_data))
       end
 
       def update_values(metric_data)
@@ -49,12 +49,7 @@ module SolidObserver
       end
 
       def increment_expression(column, metric_data)
-        value = quoted_value(metric_data.fetch(column, 0))
-        Arel.sql("#{column} + #{value}")
-      end
-
-      def quoted_value(value)
-        SolidObserver::CacheMetric.connection.quote(value)
+        metric_data.fetch(column, 0)
       end
     end
   end

--- a/lib/solid_observer/services/storage_info_snapshot.rb
+++ b/lib/solid_observer/services/storage_info_snapshot.rb
@@ -164,6 +164,7 @@ module SolidObserver
         ActiveRecord::StatementInvalid,
         *([PG::ConnectionBad] if defined?(PG::ConnectionBad)),
         *([Mysql2::Error::ConnectionError] if defined?(Mysql2::Error::ConnectionError)),
+        *([Trilogy::Error] if defined?(Trilogy::Error)),
         *([SQLite3::CantOpenException] if defined?(SQLite3::CantOpenException))
       ].freeze
 

--- a/spec/lib/solid_observer/services/flush_cache_metrics_spec.rb
+++ b/spec/lib/solid_observer/services/flush_cache_metrics_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe SolidObserver::Services::FlushCacheMetrics do
     expect(metric.duration_total).to be_within(0.0001).of(0.5)
   end
 
+  it "uses ActiveRecord counter arithmetic without hand-built SQL literals" do
+    source = File.read(File.expand_path("../../../../lib/solid_observer/services/flush_cache_metrics.rb", __dir__))
+
+    expect(source).to include("update_counters")
+    expect(source).not_to include("Arel.sql")
+  end
+
   it "returns zero for an empty flush" do
     expect(described_class.call([])).to eq(0)
   end

--- a/spec/solid_observer/application_controller_spec.rb
+++ b/spec/solid_observer/application_controller_spec.rb
@@ -227,6 +227,11 @@ RSpec.describe SolidObserver::ApplicationController, type: :controller do
       expect(rescue_classes(temp_controller_class)).to include("Mysql2::Error::ConnectionError")
     end
 
+    it "registers Trilogy::Error when defined at class load" do
+      stub_const("Trilogy::Error", Class.new(StandardError))
+      expect(rescue_classes(temp_controller_class)).to include("Trilogy::Error")
+    end
+
     it "registers SQLite3::CantOpenException when defined at class load" do
       stub_const("SQLite3::CantOpenException", Class.new(StandardError))
       expect(rescue_classes(temp_controller_class)).to include("SQLite3::CantOpenException")
@@ -235,11 +240,13 @@ RSpec.describe SolidObserver::ApplicationController, type: :controller do
     it "skips adapter classes that are not defined at class load" do
       hide_const("PG::ConnectionBad")
       hide_const("Mysql2::Error::ConnectionError")
+      hide_const("Trilogy::Error")
       hide_const("SQLite3::CantOpenException")
 
       classes = rescue_classes(temp_controller_class)
       expect(classes).not_to include("PG::ConnectionBad")
       expect(classes).not_to include("Mysql2::Error::ConnectionError")
+      expect(classes).not_to include("Trilogy::Error")
     end
   end
 

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -350,6 +350,16 @@ RSpec.describe SolidObserver::Engine do
       described_class.activate_subscribers
     end
 
+    it "handles Trilogy::Error by skipping activation" do
+      stub_const("Trilogy::Error", Class.new(StandardError))
+      allow(pool).to receive(:with_connection).and_raise(Trilogy::Error)
+
+      expect(logger).to receive(:info).with(/not reachable/)
+      expect(SolidObserver::Subscriber).not_to receive(:subscribe!)
+
+      described_class.activate_subscribers
+    end
+
     it "handles SQLite3::CantOpenException by skipping activation" do
       stub_const("SQLite3::CantOpenException", Class.new(StandardError))
       allow(pool).to receive(:with_connection).and_raise(SQLite3::CantOpenException)

--- a/spec/solid_observer/services/storage_info_snapshot_spec.rb
+++ b/spec/solid_observer/services/storage_info_snapshot_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "open3"
 require "spec_helper"
 
 RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
@@ -112,6 +113,24 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
       event_count: nil,
       unavailable_reason: "Storage unavailable"
     )
+  end
+
+  it "includes Trilogy::Error in connection rescues when Trilogy is loaded before the service" do
+    script = <<~RUBY
+      require "active_record"
+      module Trilogy
+        Error = Class.new(StandardError)
+      end
+      require "solid_observer/services/storage_info_snapshot"
+
+      errors = SolidObserver::Services::StorageInfoSnapshot::CONNECTION_ERRORS
+      abort "Trilogy::Error missing" unless errors.include?(Trilogy::Error)
+    RUBY
+
+    project_root = File.expand_path("../../..", __dir__)
+    _stdout, stderr, status = Open3.capture3(Gem.ruby, "-Ilib", "-e", script, chdir: project_root)
+
+    expect(status).to be_success, stderr
   end
 
   context "when SolidCache::Entry is available" do


### PR DESCRIPTION
## Summary of changes
- Add host-owned protected-mount guidance and clarify SolidObserver UI auth requirements.
- Add guarded Trilogy DB-unavailable handling across controller, engine boot, and storage snapshots.
- Document storage-unavailable error disclosure as admin/developer-facing diagnostics.
- Replace cache metric SQL literal arithmetic with safer counter updates.
