### PR TITLE
[SO-089][CHORE] Add optional Cable availability guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ bin/rails solid_observer:cache:clear  # Clear all SolidCache entries (with confi
 bin/rails solid_observer:cache:prune  # Prune expired SolidCache entries
 ```
 
+### Solid Cable Observability (Coming in v0.5.0+)
+
+Cable observability is optional and will require SolidCable in the host app. Setting `config.observe_cable = true` has no effect until the v0.5.0 subscriber implementation lands, and SolidObserver does not add any SolidCable dependency or setup in this release.
+
 ### Storage
 
 The Storage page aggregates per-component health rows: Queue Observer database, Cache Observer, and SolidCache table sizes. Each row reports size, record counts, and a status indicator.

--- a/lib/generators/solid_observer/templates/initializer.rb.tt
+++ b/lib/generators/solid_observer/templates/initializer.rb.tt
@@ -34,6 +34,8 @@ SolidObserver.configure do |config|
   # config.cache_sampling_rate = 0.1  # Sample 10% of cache operations
 
   # === Cable Observability (Coming in v0.5.0+) ===
+  # Cable observability is optional and requires SolidCable in the host app.
+  # No SolidCable setup is performed by SolidObserver.
   # config.observe_cable = true
 
   # Data Retention

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -95,12 +95,20 @@ module SolidObserver
       !!defined?(::SolidCache)
     end
 
+    def solid_cable_available?
+      !!defined?(::SolidCable)
+    end
+
     def solid_queue_enabled?
       observe_queue
     end
 
     def solid_cache_enabled?
       observe_cache && solid_cache_available?
+    end
+
+    def solid_cable_enabled?
+      observe_cable && solid_cable_available?
     end
 
     def sampling_rate=(value)

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -22,6 +22,13 @@ module SolidObserver
         Rails.logger.warn "[SolidObserver] SolidCache not detected. Cache observability features will be disabled."
       end
 
+      def check_solid_cable_availability
+        return if defined?(::SolidCable)
+        return unless SolidObserver.config.observe_cable
+
+        Rails.logger.warn "[SolidObserver] SolidCable not detected. Cable observability features will be disabled."
+      end
+
       def check_ui_authentication
         Services::UiAuthCheck.call(config: SolidObserver.config)
       end
@@ -146,6 +153,7 @@ module SolidObserver
     config.before_initialize do
       Engine.check_solid_queue_availability
       Engine.check_solid_cache_availability
+      Engine.check_solid_cable_availability
     end
 
     config.after_initialize do

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -101,6 +101,23 @@ RSpec.describe SolidObserver::Configuration do
       expect(config.solid_cache_available?).to be(true)
       expect(config.solid_cache_enabled?).to be(true)
     end
+
+    it "reports cable disabled by default when SolidCable is absent" do
+      hide_const("SolidCable")
+      config = described_class.new
+
+      expect(config.solid_cable_available?).to be(false)
+      expect(config.solid_cable_enabled?).to be(false)
+    end
+
+    it "enables cable only when observe_cable and SolidCable are both present" do
+      stub_const("SolidCable", Module.new)
+      config = described_class.new
+      config.observe_cable = true
+
+      expect(config.solid_cable_available?).to be(true)
+      expect(config.solid_cable_enabled?).to be(true)
+    end
   end
 
   describe "#max_buffer_size" do

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe SolidObserver::Engine do
     it "does not define load-time availability constants" do
       expect(described_class.const_defined?(:SOLID_QUEUE_AVAILABLE, false)).to be false
       expect(described_class.const_defined?(:SOLID_CACHE_AVAILABLE, false)).to be false
+      expect(described_class.const_defined?(:SOLID_CABLE_AVAILABLE, false)).to be false
     end
   end
 
@@ -128,6 +129,37 @@ RSpec.describe SolidObserver::Engine do
       expect(logger).not_to receive(:warn).with(/SolidCache not detected/)
 
       described_class.check_solid_cache_availability
+    end
+  end
+
+  describe ".check_solid_cable_availability" do
+    after { SolidObserver.reset_configuration! }
+
+    it "warns when SolidCable is not defined and cable observation is enabled" do
+      hide_const("SolidCable")
+      SolidObserver.config.observe_cable = true
+
+      expect(logger).to receive(:warn).with(/SolidCable not detected/)
+
+      described_class.check_solid_cable_availability
+    end
+
+    it "does not warn when SolidCable is not defined and cable observation is disabled" do
+      hide_const("SolidCable")
+      SolidObserver.config.observe_cable = false
+
+      expect(logger).not_to receive(:warn).with(/SolidCable not detected/)
+
+      described_class.check_solid_cable_availability
+    end
+
+    it "does not warn when SolidCable is defined" do
+      stub_const("SolidCable", Module.new)
+      SolidObserver.config.observe_cable = true
+
+      expect(logger).not_to receive(:warn).with(/SolidCable not detected/)
+
+      described_class.check_solid_cable_availability
     end
   end
 


### PR DESCRIPTION
## Summary of Changes
Mirrored the existing SolidCache optional-availability pattern for SolidCable:

- Added `solid_cable_available?` and `solid_cable_enabled?` helpers to `Configuration`.
- Added `Engine.check_solid_cable_availability` and wired it into `config.before_initialize`.
- Added focused specs for the new configuration helpers and engine boot check.
- Updated the install generator initializer template and README to state that Cable observability is optional, requires SolidCable, and that no SolidCable dependency or setup is added in this ticket.

No telemetry, subscriber, dashboard, metrics, migration, operational control, Gemfile, Appraisal, or lockfile changes were introduced. Cable remains functionally inert until SO-090.