### PR TITLE
[SO-090][FEAT] Add Cable telemetry foundation

### DIFF
--- a/app/models/solid_observer/cable_event.rb
+++ b/app/models/solid_observer/cable_event.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CableEvent < BaseEvent
+    self.table_name = "solid_observer_cable_events"
+
+    validates :event_type, presence: true
+    validates :recorded_at, presence: true
+
+    scope :errored, -> { where.not(error_class: nil) }
+    scope :recent, ->(limit = 10) { order(recorded_at: :desc).limit(limit) }
+  end
+end

--- a/app/models/solid_observer/cable_metric.rb
+++ b/app/models/solid_observer/cable_metric.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CableMetric < BaseRecord
+    self.table_name = "solid_observer_cable_metrics"
+
+    validates :period_start, presence: true
+    validates :broadcasts_count, :transmissions_count, :confirmations_count,
+      :rejections_count, :perform_actions_count, :errors_count,
+      numericality: {only_integer: true, greater_than_or_equal_to: 0}
+  end
+end

--- a/db/migrate/20260619000001_create_solid_observer_cable_events.rb
+++ b/db/migrate/20260619000001_create_solid_observer_cable_events.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateSolidObserverCableEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_observer_cable_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :channel_class, limit: 255
+      t.string :broadcasting_digest, limit: 64
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+
+      t.index :recorded_at
+      t.index :event_type
+      t.index :channel_class
+      t.index :broadcasting_digest
+      t.index :error_class
+    end
+  end
+end

--- a/db/migrate/20260619000002_create_solid_observer_cable_metrics.rb
+++ b/db/migrate/20260619000002_create_solid_observer_cable_metrics.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateSolidObserverCableMetrics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :solid_observer_cable_metrics do |t|
+      t.datetime :period_start, null: false
+      t.bigint :broadcasts_count, null: false, default: 0
+      t.bigint :transmissions_count, null: false, default: 0
+      t.bigint :confirmations_count, null: false, default: 0
+      t.bigint :rejections_count, null: false, default: 0
+      t.bigint :perform_actions_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+
+      t.index :period_start, unique: true, name: "idx_solid_observer_cable_metrics_unique"
+    end
+  end
+end

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -36,6 +36,13 @@ ActiveSupport.on_load(:active_record) do
   require_relative "solid_observer/services/flush_cache_event_buffer"
   require_relative "solid_observer/services/cache_stats"
   require_relative "solid_observer/services/cache_operations"
+  require_relative "solid_observer/cable_event_buffer"
+  require_relative "solid_observer/services/flush_cable_metrics"
+  require_relative "solid_observer/cable_metric_buffer"
+  require_relative "solid_observer/cable_subscriber"
+  require_relative "solid_observer/services/record_cable_event"
+  require_relative "solid_observer/services/record_cable_metric"
+  require_relative "solid_observer/services/flush_cable_event_buffer"
 end
 
 module SolidObserver

--- a/lib/solid_observer/cable_event_buffer.rb
+++ b/lib/solid_observer/cable_event_buffer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+require_relative "event_buffer_core"
+
+module SolidObserver
+  class CableEventBuffer
+    include Singleton
+    include EventBufferCore
+
+    INITIAL_METRICS = EventBufferCore::INITIAL_METRICS
+
+    def initialize
+      initialize_event_buffer
+    end
+
+    private
+
+    def flush_service
+      Services::FlushCableEventBuffer
+    end
+
+    def log_label
+      "Cable buffer"
+    end
+  end
+end

--- a/lib/solid_observer/cable_metric_buffer.rb
+++ b/lib/solid_observer/cable_metric_buffer.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "singleton"
+require "concurrent/timer_task"
+
+require_relative "services/flush_cable_metrics"
+
+module SolidObserver
+  class CableMetricBuffer
+    include Singleton
+
+    INITIAL_METRICS = {
+      flush_failures_count: 0,
+      drops_count: 0,
+      last_flush_at: nil,
+      last_flush_duration_ms: nil,
+      last_flush_error: nil
+    }.freeze
+
+    def initialize
+      @store = MetricStore.new
+      @timer_mutex = Mutex.new
+      @timer_task = nil
+    end
+
+    def increment(metric_data)
+      config = SolidObserver.config
+      return unless config.persistence_mode?
+
+      @store.add(metric_data)
+      ensure_timer_running
+      flush! if size >= config.buffer_size
+    end
+
+    def flush!
+      metrics_to_flush = @store.drain
+      return if metrics_to_flush.empty?
+
+      flush_metrics(metrics_to_flush, monotonic_ms)
+    end
+
+    def flush
+      flush!
+    end
+
+    def size
+      @store.size
+    end
+
+    def clear
+      @store.clear
+    end
+
+    def metrics
+      @store.metrics
+    end
+
+    def shutdown
+      stop_timer
+      flush!
+    end
+
+    private
+
+    def ensure_timer_running
+      timer_to_start, timer_to_stop = replace_timer_if_stopped
+      return unless timer_to_start
+
+      timer_to_stop&.shutdown
+      timer_to_start.execute
+    end
+
+    def replace_timer_if_stopped
+      @timer_mutex.synchronize do
+        current_timer_task = @timer_task
+        return [nil, nil] if current_timer_task && !current_timer_task.shuttingdown?
+
+        [build_timer_task, current_timer_task]
+      end
+    end
+
+    def stop_timer
+      timer_to_stop = @timer_mutex.synchronize do
+        current_timer = @timer_task
+        @timer_task = nil
+        current_timer
+      end
+
+      timer_to_stop&.shutdown
+    end
+
+    def build_timer_task
+      @timer_task = Concurrent::TimerTask.new(
+        execution_interval: SolidObserver.config.flush_interval,
+        run_now: false
+      ) { flush! }
+    end
+
+    def monotonic_ms
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+    end
+
+    def flush_metrics(metrics_to_flush, started_at_ms)
+      Services::FlushCableMetrics.call(metrics_to_flush)
+      @store.record_flush_success(monotonic_ms - started_at_ms)
+    rescue => error
+      handle_flush_error(error, metrics_to_flush)
+    end
+
+    def handle_flush_error(error, metrics_to_flush)
+      @store.requeue(metrics_to_flush)
+      @store.record_flush_failure(error)
+      Rails.logger&.error("[SolidObserver] Cable metric buffer flush failed: #{error.message}") if defined?(Rails)
+    end
+
+    class MetricStore
+      COUNTERS = %i[
+        broadcasts_count
+        transmissions_count
+        confirmations_count
+        rejections_count
+        perform_actions_count
+        errors_count
+      ].freeze
+
+      def initialize
+        @mutex = Mutex.new
+        @buffer = {}
+        @metrics = INITIAL_METRICS.dup
+      end
+
+      def add(metric_data)
+        @mutex.synchronize { add_metric(metric_data) }
+      end
+
+      def drain
+        @mutex.synchronize do
+          drained = @buffer.values.map(&:dup)
+          @buffer.clear
+          drained
+        end
+      end
+
+      def requeue(metrics_to_flush)
+        @mutex.synchronize { add_metrics_with_capacity(metrics_to_flush + @buffer.values) }
+      end
+
+      def clear
+        @mutex.synchronize { @buffer.clear }
+      end
+
+      def size
+        @mutex.synchronize { @buffer.size }
+      end
+
+      def metrics
+        @mutex.synchronize do
+          {
+            size: @buffer.size,
+            max_buffer_size: SolidObserver.config.max_buffer_size
+          }.merge(@metrics.dup)
+        end
+      end
+
+      def record_flush_success(duration_ms)
+        @mutex.synchronize do
+          @metrics.merge!(
+            last_flush_at: Time.current,
+            last_flush_duration_ms: duration_ms,
+            last_flush_error: nil
+          )
+        end
+      end
+
+      def record_flush_failure(error)
+        @mutex.synchronize do
+          @metrics[:flush_failures_count] += 1
+          @metrics[:last_flush_error] = error.message
+        end
+      end
+
+      private
+
+      def add_metric(metric_data)
+        config = SolidObserver.config
+        key = metric_data.fetch(:period_start)
+        if @buffer.key?(key)
+          merge_metric(@buffer.fetch(key), metric_data)
+        elsif @buffer.size < config.max_buffer_size
+          @buffer[key] = metric_hash(metric_data)
+        else
+          handle_overflow(key, metric_data)
+        end
+      end
+
+      def add_metrics_with_capacity(metrics)
+        @buffer.clear
+        metrics.each { |metric| add_metric(metric) }
+      end
+
+      def handle_overflow(key, metric_data)
+        drop_count = if SolidObserver.config.buffer_overflow_strategy == :drop_old
+          replace_old_metric(key, metric_data)
+        else
+          COUNTERS.sum { |counter| metric_data.fetch(counter, 0).to_i }
+        end
+
+        @metrics[:drops_count] += drop_count
+      end
+
+      def replace_old_metric(key, metric_data)
+        dropped = @buffer.shift&.last
+        @buffer[key] = metric_hash(metric_data)
+        dropped ? COUNTERS.sum { |counter| dropped.fetch(counter, 0).to_i } : 0
+      end
+
+      def merge_metric(target, metric_data)
+        COUNTERS.each do |counter|
+          target[counter] += metric_data.fetch(counter, 0).to_i
+        end
+      end
+
+      def metric_hash(metric_data)
+        COUNTERS.each_with_object({period_start: metric_data.fetch(:period_start)}) do |counter, hash|
+          hash[counter] = metric_data.fetch(counter, 0).to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/solid_observer/cable_subscriber.rb
+++ b/lib/solid_observer/cable_subscriber.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CableSubscriber
+    EVENTS = %w[
+      broadcast.action_cable
+      transmit.action_cable
+      transmit_subscription_confirmation.action_cable
+      transmit_subscription_rejection.action_cable
+      perform_action.action_cable
+    ].freeze
+
+    class << self
+      attr_reader :subscriptions
+
+      def subscribe
+        return unless subscription_allowed?
+
+        self.subscriptions = EVENTS.map { |event_name| subscribe_to(event_name) }
+      end
+
+      def unsubscribe
+        return unless subscriptions
+
+        subscriptions.each { |subscription| ActiveSupport::Notifications.unsubscribe(subscription) }
+        self.subscriptions = []
+      end
+
+      def subscribe!
+        subscribe
+      end
+
+      def unsubscribe!
+        unsubscribe
+      end
+
+      def subscribed?
+        !!subscriptions&.any?
+      end
+
+      private
+
+      attr_writer :subscriptions
+
+      def subscription_allowed?
+        SolidObserver.config.solid_cable_enabled? && !subscribed? && defined?(ActiveSupport::Notifications)
+      end
+
+      def subscribe_to(event_name)
+        ActiveSupport::Notifications.subscribe(event_name) do |*args|
+          event = ActiveSupport::Notifications::Event.new(*args)
+          Services::RecordCableEvent.call(event: event, buffer: CableEventBuffer.instance)
+        end
+      end
+    end
+  end
+end

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -49,7 +49,8 @@ module SolidObserver
       :flush_interval,
       :max_buffer_size,
       :buffer_overflow_strategy,
-      :filter_cache_ttl
+      :filter_cache_ttl,
+      :cable_sampling_rate
 
     # Correlation Settings
     attr_accessor :correlation_id_generator
@@ -58,13 +59,13 @@ module SolidObserver
       @ui_enabled, @ui_base_controller, @ui_username, @ui_password,
         @storage_mode, @observe_queue, @observe_cache, @observe_cable,
         @event_retention, @metrics_retention, @max_db_size, @warning_threshold,
-        @sampling_rate, @cache_sampling_rate, @cache_slow_threshold, @cache_store_errors,
+        @sampling_rate, @cache_sampling_rate, @cable_sampling_rate, @cache_slow_threshold, @cache_store_errors,
         @buffer_size, @flush_interval,
         @max_buffer_size, @buffer_overflow_strategy, @filter_cache_ttl,
         @correlation_id_generator = !production?, "::ApplicationController", nil, nil,
           :persistence, true, false, false,
           30.days, 90.days, 1.gigabyte, 0.8,
-          1.0, 0.1, 0.1, true, 1000, 10.seconds,
+          1.0, 0.1, 0.1, 0.1, true, 1000, 10.seconds,
           10_000, :drop_old, 1.minute,
           nil
     end
@@ -114,6 +115,11 @@ module SolidObserver
     def sampling_rate=(value)
       validate_rate!(:sampling_rate, value)
       @sampling_rate = value
+    end
+
+    def cable_sampling_rate=(value)
+      validate_rate!(:cable_sampling_rate, value)
+      @cable_sampling_rate = value
     end
 
     def warning_threshold=(value)

--- a/lib/solid_observer/engine.rb
+++ b/lib/solid_observer/engine.rb
@@ -46,6 +46,7 @@ module SolidObserver
         Rails.logger.info "[SolidObserver] Activating event subscribers"
         activate_queue_subscriber
         activate_cache_subscriber
+        activate_cable_subscriber
       end
 
       private
@@ -75,6 +76,7 @@ module SolidObserver
         Rails.logger.info "[SolidObserver] Starting in real-time mode (no persistence)"
         Subscriber.subscribe! if should_activate_queue_subscriber?
         CacheSubscriber.subscribe! if should_activate_cache_subscriber?
+        CableSubscriber.subscribe! if should_activate_cable_subscriber?
       end
 
       def activate_queue_subscriber
@@ -83,6 +85,10 @@ module SolidObserver
 
       def activate_cache_subscriber
         activate_subscriber_for_table("solid_observer_cache_events", CacheSubscriber) if should_activate_cache_subscriber?
+      end
+
+      def activate_cable_subscriber
+        activate_subscriber_for_table("solid_observer_cable_events", CableSubscriber) if should_activate_cable_subscriber?
       end
 
       def activate_subscriber_for_table(table_name, subscriber)
@@ -102,6 +108,10 @@ module SolidObserver
 
       def should_activate_cache_subscriber?
         SolidObserver.config.solid_cache_enabled?
+      end
+
+      def should_activate_cable_subscriber?
+        SolidObserver.config.solid_cable_enabled?
       end
 
       def log_activation_skip(message)

--- a/lib/solid_observer/services/flush_cable_event_buffer.rb
+++ b/lib/solid_observer/services/flush_cable_event_buffer.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    class FlushCableEventBuffer
+      BATCH_SIZE = 100
+
+      def self.call(events)
+        new(events).call
+      end
+
+      def initialize(events)
+        @events = events
+      end
+
+      def call
+        return 0 if @events.empty?
+
+        insert_all_events
+        @events.size
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => error
+        fallback_insert_count(error)
+      end
+
+      private
+
+      def insert_all_events
+        CableEvent.transaction { CableEvent.insert_all!(@events) }
+      end
+
+      def fallback_insert_count(error)
+        Rails.logger&.error("[SolidObserver] Cable bulk insert failed, retrying in batches: #{error.message}") if defined?(Rails)
+        @events.each_slice(BATCH_SIZE).sum { |batch| insert_batch(batch) }
+      end
+
+      def insert_batch(batch)
+        size = batch.size
+        CableEvent.insert_all(batch, returning: false)
+        size
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid => error
+        handle_batch_insert_error(size, error)
+      end
+
+      def log_batch_warning(size, error)
+        Rails.logger&.warn("[SolidObserver] Failed to insert cable batch of #{size} events: #{error.message}") if defined?(Rails)
+      end
+
+      def handle_batch_insert_error(size, error)
+        log_batch_warning(size, error)
+        0
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/flush_cable_metrics.rb
+++ b/lib/solid_observer/services/flush_cable_metrics.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    class FlushCableMetrics
+      def self.call(metrics)
+        new(metrics).call
+      end
+
+      def initialize(metrics)
+        @metrics = metrics
+      end
+
+      def call
+        return 0 if @metrics.empty?
+
+        flush_metrics
+        @metrics.size
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      private
+
+      def flush_metrics
+        SolidObserver::CableMetric.transaction do
+          @metrics.each { |metric_data| increment_metric(metric_data) }
+        end
+      end
+
+      def increment_metric(metric_data)
+        period_start = metric_data.fetch(:period_start)
+        metric = SolidObserver::CableMetric.find_or_create_by!(period_start: period_start)
+
+        SolidObserver::CableMetric.where(id: metric.id).update_counters(update_values(metric_data))
+      end
+
+      def update_values(metric_data)
+        {
+          broadcasts_count: increment_expression(:broadcasts_count, metric_data),
+          transmissions_count: increment_expression(:transmissions_count, metric_data),
+          confirmations_count: increment_expression(:confirmations_count, metric_data),
+          rejections_count: increment_expression(:rejections_count, metric_data),
+          perform_actions_count: increment_expression(:perform_actions_count, metric_data),
+          errors_count: increment_expression(:errors_count, metric_data)
+        }
+      end
+
+      def increment_expression(column, metric_data)
+        metric_data.fetch(column, 0)
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/record_cable_event.rb
+++ b/lib/solid_observer/services/record_cable_event.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module SolidObserver
+  module Services
+    class RecordCableEvent
+      def self.call(event:, buffer:)
+        new(event, buffer).call
+      end
+
+      def initialize(event, buffer)
+        @event = event
+        @buffer = buffer
+      end
+
+      def call
+        record_metric_and_event
+      rescue => error
+        raise error if error.is_a?(NameError)
+        Rails.logger&.warn("[SolidObserver] Cable event recording failed: #{error.message}") if defined?(Rails)
+      end
+
+      private
+
+      def record_metric_and_event
+        SolidObserver::Services::RecordCableMetric.call(event: @event)
+        return unless should_store_event?
+
+        @buffer.push(build_event_data)
+      end
+
+      def should_store_event?
+        case @event.name
+        when "broadcast.action_cable"
+          sampled? || errored?
+        when "transmit_subscription_rejection.action_cable"
+          true
+        else
+          false
+        end
+      end
+
+      def sampled?
+        rand <= SolidObserver.config.cable_sampling_rate
+      end
+
+      def errored?
+        !exception_data.compact.empty?
+      end
+
+      def build_event_data
+        {
+          event_type: @event.name.delete_suffix(".action_cable"),
+          channel_class: channel_class,
+          broadcasting_digest: broadcasting_digest,
+          duration: duration_in_seconds,
+          error_class: exception_data[:error_class],
+          error_message: exception_data[:error_message],
+          metadata: metadata.to_json,
+          recorded_at: Time.current
+        }
+      end
+
+      def broadcasting_digest
+        return nil unless @event.name == "broadcast.action_cable"
+
+        Digest::SHA256.hexdigest(payload[:broadcasting].to_s)
+      end
+
+      def channel_class
+        class_name = payload[:channel_class]
+        return class_name if class_name
+
+        channel = payload[:channel]
+        return nil unless channel
+
+        channel.class.name || channel.to_s
+      end
+
+      def duration_in_seconds
+        @event.duration&./(1000.0)
+      end
+
+      def metadata
+        {
+          action: payload[:action]&.to_s,
+          via: payload[:via]&.to_s,
+          data_size: payload[:data]&.to_s&.bytesize,
+          message_size: payload[:message]&.to_s&.bytesize
+        }.compact
+      end
+
+      def exception_data
+        @exception_data ||= begin
+          exception_obj = payload[:exception_object]
+          exception = payload[:exception]
+
+          if exception_obj
+            {error_class: exception_obj.class.name, error_message: exception_obj.message}
+          elsif exception.is_a?(Array)
+            {error_class: exception.first, error_message: exception.last}
+          else
+            {}
+          end
+        end
+      end
+
+      def payload
+        @event.payload || {}
+      end
+    end
+  end
+end

--- a/lib/solid_observer/services/record_cable_metric.rb
+++ b/lib/solid_observer/services/record_cable_metric.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "../cable_metric_buffer"
+
+module SolidObserver
+  module Services
+    class RecordCableMetric
+      COUNTERS = %i[
+        broadcasts_count
+        transmissions_count
+        confirmations_count
+        rejections_count
+        perform_actions_count
+        errors_count
+      ].freeze
+
+      EVENT_COUNTER_MAP = {
+        "broadcast.action_cable" => :broadcasts_count,
+        "transmit.action_cable" => :transmissions_count,
+        "transmit_subscription_confirmation.action_cable" => :confirmations_count,
+        "transmit_subscription_rejection.action_cable" => :rejections_count,
+        "perform_action.action_cable" => :perform_actions_count
+      }.freeze
+
+      def self.call(event:, buffer: SolidObserver::CableMetricBuffer.instance)
+        new(event, buffer).call
+      end
+
+      def initialize(event, buffer)
+        @event = event
+        @buffer = buffer
+      end
+
+      def call
+        @buffer.increment(metric_data)
+      rescue => error
+        Rails.logger&.warn("[SolidObserver] Cable metric recording failed: #{error.message}") if defined?(Rails)
+      end
+
+      private
+
+      def metric_data
+        COUNTERS.each_with_object({period_start: period_start}) do |counter, data|
+          data[counter] = (counter == target_counter) ? 1 : 0
+        end.merge(errors_count: error_increment)
+      end
+
+      def target_counter
+        EVENT_COUNTER_MAP.fetch(event_name, :broadcasts_count)
+      end
+
+      def period_start
+        Time.current.beginning_of_minute
+      end
+
+      def event_name
+        @event.name
+      end
+
+      def error_increment
+        exception_present? ? 1 : 0
+      end
+
+      def exception_present?
+        payload[:exception_object].present? || payload[:exception].is_a?(Array)
+      end
+
+      def payload
+        @event.payload || {}
+      end
+    end
+  end
+end

--- a/spec/models/solid_observer/cable_event_spec.rb
+++ b/spec/models/solid_observer/cable_event_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CableEvent do
+  before(:all) do
+    connection = described_class.connection
+    next if connection.table_exists?(:solid_observer_cable_events)
+
+    connection.create_table :solid_observer_cable_events do |t|
+      t.string :event_type, null: false
+      t.string :channel_class
+      t.string :broadcasting_digest
+      t.float :duration
+      t.string :error_class
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before { described_class.delete_all }
+
+  it "inherits from BaseEvent" do
+    expect(described_class.superclass).to eq(SolidObserver::BaseEvent)
+  end
+
+  it "uses solid_observer_cable_events table" do
+    expect(described_class.table_name).to eq("solid_observer_cable_events")
+  end
+
+  it "validates required fields" do
+    record = described_class.new
+
+    expect(record).not_to be_valid
+    expect(record.errors[:event_type]).to be_present
+    expect(record.errors[:recorded_at]).to be_present
+  end
+end

--- a/spec/models/solid_observer/cable_metric_spec.rb
+++ b/spec/models/solid_observer/cable_metric_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CableMetric do
+  before(:all) do
+    connection = described_class.connection
+    next if connection.table_exists?(:solid_observer_cable_metrics)
+
+    connection.create_table :solid_observer_cable_metrics do |t|
+      t.datetime :period_start, null: false
+      t.bigint :broadcasts_count, null: false, default: 0
+      t.bigint :transmissions_count, null: false, default: 0
+      t.bigint :confirmations_count, null: false, default: 0
+      t.bigint :rejections_count, null: false, default: 0
+      t.bigint :perform_actions_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+    end
+
+    connection.add_index :solid_observer_cable_metrics, :period_start, unique: true,
+      name: "idx_solid_observer_cable_metrics_unique"
+  end
+
+  before { described_class.delete_all }
+
+  it "inherits from BaseRecord" do
+    expect(described_class.superclass).to eq(SolidObserver::BaseRecord)
+  end
+
+  it "uses solid_observer_cable_metrics table" do
+    expect(described_class.table_name).to eq("solid_observer_cable_metrics")
+  end
+
+  it "validates required fields" do
+    record = described_class.new
+
+    expect(record).not_to be_valid
+    expect(record.errors[:period_start]).to be_present
+  end
+end

--- a/spec/solid_observer/cable_event_buffer_spec.rb
+++ b/spec/solid_observer/cable_event_buffer_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../support/shared_examples_for_event_buffer"
+
+RSpec.describe SolidObserver::CableEventBuffer do
+  it_behaves_like "an event buffer",
+    flush_service: SolidObserver::Services::FlushCableEventBuffer,
+    log_label: "Cable buffer",
+    event_factory: -> { {event_type: "broadcast", broadcasting_digest: "abc", recorded_at: Time.current, metadata: "{}"} }
+end

--- a/spec/solid_observer/cable_metric_buffer_spec.rb
+++ b/spec/solid_observer/cable_metric_buffer_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "time"
+
+RSpec.describe SolidObserver::CableMetricBuffer do
+  subject(:buffer) { described_class.instance }
+
+  let(:period_start) { Time.parse("2026-06-01 12:34:00 UTC") }
+  let(:metric_data) do
+    {
+      period_start: period_start,
+      broadcasts_count: 1,
+      transmissions_count: 0,
+      confirmations_count: 0,
+      rejections_count: 0,
+      perform_actions_count: 0,
+      errors_count: 0
+    }
+  end
+
+  before(:all) do
+    connection = SolidObserver::CableMetric.connection
+    next if connection.table_exists?(:solid_observer_cable_metrics)
+
+    connection.create_table :solid_observer_cable_metrics do |t|
+      t.datetime :period_start, null: false
+      t.bigint :broadcasts_count, null: false, default: 0
+      t.bigint :transmissions_count, null: false, default: 0
+      t.bigint :confirmations_count, null: false, default: 0
+      t.bigint :rejections_count, null: false, default: 0
+      t.bigint :perform_actions_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+    end
+
+    connection.add_index :solid_observer_cable_metrics, :period_start, unique: true,
+      name: "idx_solid_observer_cable_metrics_unique"
+  end
+
+  before do
+    SolidObserver.reset_configuration!
+    SolidObserver::CableMetric.delete_all
+    buffer.clear
+    buffer.shutdown
+  end
+
+  after do
+    buffer.clear
+    buffer.shutdown
+    SolidObserver.reset_configuration!
+  end
+
+  after(:all) do
+    described_class.instance.clear
+    described_class.instance.shutdown
+  end
+
+  it "aggregates metrics in memory and flushes explicitly" do
+    SolidObserver.config.buffer_size = 1000
+
+    buffer.increment(metric_data)
+    buffer.increment(metric_data.merge(transmissions_count: 1, errors_count: 1))
+    buffer.flush!
+
+    metric = SolidObserver::CableMetric.find_by!(period_start: period_start)
+    expect(metric.broadcasts_count).to eq(2)
+    expect(metric.transmissions_count).to eq(1)
+    expect(metric.confirmations_count).to eq(0)
+    expect(metric.rejections_count).to eq(0)
+    expect(metric.perform_actions_count).to eq(0)
+    expect(metric.errors_count).to eq(1)
+    expect(buffer.size).to eq(0)
+  end
+
+  it "persists metrics when the timer callback flushes" do
+    SolidObserver.config.buffer_size = 1000
+    trigger_timer = stub_timer_callback
+
+    buffer.increment(metric_data.merge(rejections_count: 1))
+    trigger_timer.call
+
+    metric = SolidObserver::CableMetric.find_by!(period_start: period_start)
+    expect(metric.broadcasts_count).to eq(1)
+    expect(metric.rejections_count).to eq(1)
+  end
+
+  it "does not buffer in realtime mode" do
+    SolidObserver.config.storage_mode = :realtime
+
+    buffer.increment(metric_data)
+
+    expect(buffer.size).to eq(0)
+  end
+
+  it "clears buffered metrics without flushing" do
+    allow(SolidObserver::Services::FlushCableMetrics).to receive(:call)
+
+    buffer.increment(metric_data)
+    buffer.clear
+
+    expect(buffer.size).to eq(0)
+    expect(SolidObserver::Services::FlushCableMetrics).not_to have_received(:call)
+  end
+
+  describe "timer lifecycle" do
+    before do
+      SolidObserver.config.buffer_size = 1000
+      SolidObserver.config.flush_interval = 60
+    end
+
+    it "starts lazily on first increment" do
+      expect(buffer.instance_variable_get(:@timer_task)).to be_nil
+
+      buffer.increment(metric_data)
+
+      expect(buffer.instance_variable_get(:@timer_task)).not_to be_nil
+    end
+  end
+
+  describe "shutdown" do
+    before do
+      SolidObserver.config.buffer_size = 1000
+      SolidObserver.config.flush_interval = 60
+    end
+
+    it "stops the timer and persists buffered metric buckets" do
+      buffer.increment(metric_data.merge(perform_actions_count: 1))
+      expect(buffer.instance_variable_get(:@timer_task)).not_to be_nil
+
+      buffer.shutdown
+
+      metric = SolidObserver::CableMetric.find_by!(period_start: period_start)
+      expect(metric.broadcasts_count).to eq(1)
+      expect(metric.perform_actions_count).to eq(1)
+      expect(buffer.size).to eq(0)
+      expect(buffer.instance_variable_get(:@timer_task)).to be_nil
+    end
+  end
+
+  describe "operational metrics" do
+    it "returns QueueEventBuffer-compatible metric keys" do
+      expect(buffer.metrics.keys).to eq(
+        %i[
+          size
+          max_buffer_size
+          flush_failures_count
+          drops_count
+          last_flush_at
+          last_flush_duration_ms
+          last_flush_error
+        ]
+      )
+    end
+
+    it "tracks successful flush metadata" do
+      buffer.increment(metric_data)
+      buffer.flush!
+
+      metrics = buffer.metrics
+      expect(metrics[:last_flush_at]).to be_a(Time)
+      expect(metrics[:last_flush_duration_ms]).to be_a(Numeric)
+      expect(metrics[:last_flush_error]).to be_nil
+    end
+
+    it "tracks flush failures, last error, and logged failures" do
+      logger = instance_double(Logger, error: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+      allow(SolidObserver::Services::FlushCableMetrics).to receive(:call).and_raise(ActiveRecord::StatementInvalid, "DB down")
+
+      initial_failures = buffer.metrics[:flush_failures_count]
+      buffer.increment(metric_data)
+      buffer.flush!
+
+      metrics = buffer.metrics
+      expect(metrics[:flush_failures_count]).to eq(initial_failures + 1)
+      expect(metrics[:last_flush_error]).to eq("DB down")
+      expect(buffer.size).to eq(1)
+      expect(logger).to have_received(:error).with("[SolidObserver] Cable metric buffer flush failed: DB down")
+    end
+  end
+
+  describe "overflow policy" do
+    before do
+      SolidObserver.config.buffer_size = 3
+      SolidObserver.config.max_buffer_size = 3
+      allow(SolidObserver.config).to receive(:buffer_size).and_return(100)
+    end
+
+    context "when strategy is :drop_old" do
+      before { SolidObserver.config.buffer_overflow_strategy = :drop_old }
+
+      it "keeps newest metric buckets and tracks dropped counters" do
+        initial_drops = buffer.metrics[:drops_count]
+        5.times { |i| buffer.increment(metric_data.merge(period_start: period_start + i.minutes)) }
+
+        buffer.flush!
+
+        expect(SolidObserver::CableMetric.pluck(:period_start)).to contain_exactly(
+          period_start + 2.minutes,
+          period_start + 3.minutes,
+          period_start + 4.minutes
+        )
+        expect(buffer.metrics[:drops_count]).to eq(initial_drops + 2)
+      end
+    end
+
+    context "when strategy is :drop_new" do
+      before { SolidObserver.config.buffer_overflow_strategy = :drop_new }
+
+      it "keeps oldest metric buckets and tracks dropped counters" do
+        initial_drops = buffer.metrics[:drops_count]
+        5.times { |i| buffer.increment(metric_data.merge(period_start: period_start + i.minutes)) }
+
+        buffer.flush!
+
+        expect(SolidObserver::CableMetric.pluck(:period_start)).to contain_exactly(
+          period_start,
+          period_start + 1.minute,
+          period_start + 2.minutes
+        )
+        expect(buffer.metrics[:drops_count]).to eq(initial_drops + 2)
+      end
+    end
+  end
+
+  def stub_timer_callback
+    timer_callback = nil
+    timer_task = instance_double(Concurrent::TimerTask, execute: nil, shutdown: nil, shuttingdown?: false)
+
+    allow(Concurrent::TimerTask).to receive(:new) do |**_options, &block|
+      timer_callback = block
+      timer_task
+    end
+
+    -> { timer_callback.call }
+  end
+end

--- a/spec/solid_observer/cable_subscriber_spec.rb
+++ b/spec/solid_observer/cable_subscriber_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::CableSubscriber do
+  before do
+    described_class.unsubscribe!
+    allow(SolidObserver::Services::RecordCableEvent).to receive(:call)
+  end
+
+  after { described_class.unsubscribe! }
+
+  it "subscribes only when solid cable is enabled" do
+    allow(SolidObserver.config).to receive(:solid_cable_enabled?).and_return(false)
+
+    described_class.subscribe!
+
+    expect(described_class.subscribed?).to be(false)
+  end
+
+  it "subscribes to configured cable events" do
+    allow(SolidObserver.config).to receive(:solid_cable_enabled?).and_return(true)
+
+    described_class.subscribe!
+    ActiveSupport::Notifications.instrument("broadcast.action_cable", {broadcasting: "chat:1"})
+
+    expect(SolidObserver::Services::RecordCableEvent).to have_received(:call).with(
+      hash_including(buffer: SolidObserver::CableEventBuffer.instance, event: be_a(ActiveSupport::Notifications::Event))
+    )
+  end
+
+  it "unsubscribes from all notifications" do
+    allow(SolidObserver.config).to receive(:solid_cable_enabled?).and_return(true)
+
+    described_class.subscribe!
+    described_class.unsubscribe!
+
+    expect(described_class.subscribed?).to be(false)
+  end
+end

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SolidObserver::Configuration do
     config = described_class.new
 
     expect(config.sampling_rate).to eq(1.0)
+    expect(config.cable_sampling_rate).to eq(0.1)
     expect(config.buffer_size).to eq(1000)
     expect(config.max_buffer_size).to eq(10_000)
     expect(config.buffer_overflow_strategy).to eq(:drop_old)
@@ -185,6 +186,39 @@ RSpec.describe SolidObserver::Configuration do
 
       expect { config.buffer_overflow_strategy = :invalid }.to raise_error(
         ArgumentError, "buffer_overflow_strategy must be :drop_old or :drop_new"
+      )
+    end
+  end
+
+  describe "#cable_sampling_rate=" do
+    it "accepts values between 0.0 and 1.0" do
+      config = described_class.new
+      config.cable_sampling_rate = 0.5
+
+      expect(config.cable_sampling_rate).to eq(0.5)
+    end
+
+    it "rejects values below 0.0" do
+      config = described_class.new
+
+      expect { config.cable_sampling_rate = -0.1 }.to raise_error(
+        ArgumentError, "cable_sampling_rate must be a number between 0.0 and 1.0"
+      )
+    end
+
+    it "rejects values above 1.0" do
+      config = described_class.new
+
+      expect { config.cable_sampling_rate = 1.1 }.to raise_error(
+        ArgumentError, "cable_sampling_rate must be a number between 0.0 and 1.0"
+      )
+    end
+
+    it "rejects non-numeric values" do
+      config = described_class.new
+
+      expect { config.cable_sampling_rate = "half" }.to raise_error(
+        ArgumentError, "cable_sampling_rate must be a number between 0.0 and 1.0"
       )
     end
   end

--- a/spec/solid_observer/engine_spec.rb
+++ b/spec/solid_observer/engine_spec.rb
@@ -291,6 +291,7 @@ RSpec.describe SolidObserver::Engine do
       allow(connection).to receive(:data_source_exists?).and_return(true)
       allow(SolidObserver::Subscriber).to receive(:subscribe!)
       allow(SolidObserver::CacheSubscriber).to receive(:subscribe!)
+      allow(SolidObserver::CableSubscriber).to receive(:subscribe!)
     end
 
     after { SolidObserver.reset_configuration! }
@@ -412,6 +413,33 @@ RSpec.describe SolidObserver::Engine do
       expect(logger).to receive(:info).with(/missing: solid_observer_queue_events/)
       expect(SolidObserver::Subscriber).not_to receive(:subscribe!)
       expect(SolidObserver::CacheSubscriber).to receive(:subscribe!)
+
+      described_class.activate_subscribers
+    end
+
+    it "keeps cable activation independent when the enabled queue/cache tables are missing" do
+      stub_const("SolidCable", Module.new)
+      SolidObserver.config.observe_cable = true
+      allow(cache).to receive(:data_source_exists?).with(pool, "solid_observer_queue_events").and_return(false)
+      allow(connection).to receive(:data_source_exists?).with("solid_observer_queue_events").and_return(false)
+      allow(cache).to receive(:data_source_exists?).with(pool, "solid_observer_cache_events").and_return(false)
+      allow(connection).to receive(:data_source_exists?).with("solid_observer_cache_events").and_return(false)
+      allow(cache).to receive(:data_source_exists?).with(pool, "solid_observer_cable_events").and_return(true)
+
+      expect(logger).to receive(:info).with(/missing: solid_observer_queue_events/)
+      expect(SolidObserver::Subscriber).not_to receive(:subscribe!)
+      expect(SolidObserver::CacheSubscriber).not_to receive(:subscribe!)
+      expect(SolidObserver::CableSubscriber).to receive(:subscribe!)
+
+      described_class.activate_subscribers
+    end
+
+    it "activates cable subscriber in realtime mode when cable is enabled" do
+      stub_const("SolidCable", Module.new)
+      SolidObserver.config.observe_cable = true
+      SolidObserver.config.storage_mode = :realtime
+
+      expect(SolidObserver::CableSubscriber).to receive(:subscribe!)
 
       described_class.activate_subscribers
     end

--- a/spec/solid_observer/services/flush_cable_event_buffer_spec.rb
+++ b/spec/solid_observer/services/flush_cable_event_buffer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Services::FlushCableEventBuffer do
+  let(:events) { [{event_type: "broadcast", broadcasting_digest: "abc", recorded_at: Time.current, metadata: "{}"}] }
+
+  it "bulk inserts cable events" do
+    allow(SolidObserver::CableEvent).to receive(:transaction).and_yield
+    allow(SolidObserver::CableEvent).to receive(:insert_all!)
+
+    described_class.call(events)
+
+    expect(SolidObserver::CableEvent).to have_received(:insert_all!).with(events)
+  end
+
+  it "falls back to smaller batches on statement failure" do
+    allow(SolidObserver::CableEvent).to receive(:transaction).and_yield
+    allow(SolidObserver::CableEvent).to receive(:insert_all!).and_raise(ActiveRecord::StatementInvalid, "boom")
+    allow(SolidObserver::CableEvent).to receive(:insert_all).and_return(true)
+    allow(Rails).to receive(:logger).and_return(instance_double(Logger, error: nil, warn: nil))
+
+    described_class.call(events)
+
+    expect(SolidObserver::CableEvent).to have_received(:insert_all).at_least(:once)
+  end
+
+  it "logs a warning and returns zero when fallback batch inserts also fail" do
+    logger = instance_double(Logger, error: nil, warn: nil)
+
+    allow(SolidObserver::CableEvent).to receive(:transaction).and_yield
+    allow(SolidObserver::CableEvent).to receive(:insert_all!).and_raise(ActiveRecord::StatementInvalid, "bulk boom")
+    allow(SolidObserver::CableEvent).to receive(:insert_all).with(events, returning: false).and_raise(
+      ActiveRecord::StatementInvalid,
+      "batch boom"
+    )
+    allow(Rails).to receive(:logger).and_return(logger)
+
+    expect(described_class.call(events)).to eq(0)
+    expect(logger).to have_received(:warn).with(
+      "[SolidObserver] Failed to insert cable batch of 1 events: batch boom"
+    )
+  end
+end

--- a/spec/solid_observer/services/flush_cable_metrics_spec.rb
+++ b/spec/solid_observer/services/flush_cable_metrics_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "time"
+
+RSpec.describe SolidObserver::Services::FlushCableMetrics do
+  let(:period_start) { Time.parse("2026-06-01 12:34:00 UTC") }
+  let(:metrics) do
+    [
+      {
+        period_start: period_start,
+        broadcasts_count: 3,
+        transmissions_count: 2,
+        confirmations_count: 1,
+        rejections_count: 1,
+        perform_actions_count: 1,
+        errors_count: 1
+      }
+    ]
+  end
+
+  before(:all) do
+    connection = SolidObserver::CableMetric.connection
+    next if connection.table_exists?(:solid_observer_cable_metrics)
+
+    connection.create_table :solid_observer_cable_metrics do |t|
+      t.datetime :period_start, null: false
+      t.bigint :broadcasts_count, null: false, default: 0
+      t.bigint :transmissions_count, null: false, default: 0
+      t.bigint :confirmations_count, null: false, default: 0
+      t.bigint :rejections_count, null: false, default: 0
+      t.bigint :perform_actions_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+    end
+
+    connection.add_index :solid_observer_cable_metrics, :period_start, unique: true,
+      name: "idx_solid_observer_cable_metrics_unique"
+  end
+
+  before { SolidObserver::CableMetric.delete_all }
+
+  it "persists aggregated cable metrics" do
+    expect(described_class.call(metrics)).to eq(1)
+
+    metric = SolidObserver::CableMetric.find_by!(period_start: period_start)
+    expect(metric.broadcasts_count).to eq(3)
+    expect(metric.transmissions_count).to eq(2)
+    expect(metric.confirmations_count).to eq(1)
+    expect(metric.rejections_count).to eq(1)
+    expect(metric.perform_actions_count).to eq(1)
+    expect(metric.errors_count).to eq(1)
+  end
+
+  it "atomically adds later flushes to existing per-minute buckets" do
+    described_class.call(metrics)
+    described_class.call([
+      {
+        period_start: period_start,
+        broadcasts_count: 2,
+        transmissions_count: 1,
+        confirmations_count: 0,
+        rejections_count: 0,
+        perform_actions_count: 0,
+        errors_count: 0
+      }
+    ])
+
+    metric = SolidObserver::CableMetric.find_by!(period_start: period_start)
+    expect(metric.broadcasts_count).to eq(5)
+    expect(metric.transmissions_count).to eq(3)
+    expect(metric.confirmations_count).to eq(1)
+    expect(metric.rejections_count).to eq(1)
+    expect(metric.perform_actions_count).to eq(1)
+    expect(metric.errors_count).to eq(1)
+  end
+
+  it "uses ActiveRecord counter arithmetic without hand-built SQL literals" do
+    source = File.read(File.expand_path("../../../lib/solid_observer/services/flush_cable_metrics.rb", __dir__))
+
+    expect(source).to include("update_counters")
+    expect(source).not_to include("Arel.sql")
+  end
+
+  it "returns zero for an empty flush" do
+    expect(described_class.call([])).to eq(0)
+  end
+end

--- a/spec/solid_observer/services/record_cable_event_spec.rb
+++ b/spec/solid_observer/services/record_cable_event_spec.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SolidObserver::Services::RecordCableEvent do
+  let(:buffer) { instance_double(SolidObserver::CableEventBuffer, push: nil) }
+  let(:broadcast_payload) { {broadcasting: "chat:1"} }
+  let(:broadcast_event) do
+    ActiveSupport::Notifications::Event.new(
+      "broadcast.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      broadcast_payload
+    )
+  end
+
+  before do
+    SolidObserver.reset_configuration!
+    SolidObserver::CableMetricBuffer.instance.clear
+    SolidObserver::CableMetricBuffer.instance.shutdown
+  end
+
+  after do
+    SolidObserver::CableMetricBuffer.instance.clear
+    SolidObserver::CableMetricBuffer.instance.shutdown
+    SolidObserver.reset_configuration!
+  end
+
+  it "stores a broadcasting digest and sanitized metadata for sampled broadcasts" do
+    allow(Kernel).to receive(:rand).and_return(0.0)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(1.0)
+
+    described_class.call(event: broadcast_event, buffer: buffer)
+
+    expect(buffer).to have_received(:push).with(hash_including(
+      event_type: "broadcast",
+      channel_class: nil,
+      broadcasting_digest: Digest::SHA256.hexdigest("chat:1"),
+      duration: be > 0,
+      error_class: nil,
+      error_message: nil,
+      metadata: satisfy { |json| JSON.parse(json).keys.none? { |key| %w[broadcasting message data identifier].include?(key) } }
+    ))
+  end
+
+  it "records metrics even when raw event is not sampled" do
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(0.0)
+    allow(SolidObserver::Services::RecordCableMetric).to receive(:call)
+
+    described_class.call(event: broadcast_event, buffer: buffer)
+
+    expect(SolidObserver::Services::RecordCableMetric).to have_received(:call).with(event: broadcast_event)
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "stores broadcast errors even when not sampled" do
+    error_event = ActiveSupport::Notifications::Event.new(
+      "broadcast.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {broadcasting: "chat:1", exception_object: StandardError.new("Broadcast failed")}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(0.0)
+
+    described_class.call(event: error_event, buffer: buffer)
+
+    expect(buffer).to have_received(:push).with(hash_including(
+      error_class: "StandardError",
+      error_message: "Broadcast failed"
+    ))
+  end
+
+  it "always stores subscription rejections" do
+    rejection_event = ActiveSupport::Notifications::Event.new(
+      "transmit_subscription_rejection.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel_class: "ChatChannel"}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(0.0)
+
+    described_class.call(event: rejection_event, buffer: buffer)
+
+    expect(buffer).to have_received(:push).with(hash_including(
+      event_type: "transmit_subscription_rejection",
+      channel_class: "ChatChannel"
+    ))
+  end
+
+  it "does not store raw rows for transmit events but records metrics" do
+    transmit_event = ActiveSupport::Notifications::Event.new(
+      "transmit.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel: Class.new { def self.name = "ChatChannel" }, message: "hello"}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.0)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(1.0)
+    allow(SolidObserver::Services::RecordCableMetric).to receive(:call)
+
+    described_class.call(event: transmit_event, buffer: buffer)
+
+    expect(SolidObserver::Services::RecordCableMetric).to have_received(:call).with(event: transmit_event)
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "does not store raw rows for confirmation events but records metrics" do
+    confirmation_event = ActiveSupport::Notifications::Event.new(
+      "transmit_subscription_confirmation.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel_class: "ChatChannel"}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.0)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(1.0)
+    allow(SolidObserver::Services::RecordCableMetric).to receive(:call)
+
+    described_class.call(event: confirmation_event, buffer: buffer)
+
+    expect(SolidObserver::Services::RecordCableMetric).to have_received(:call).with(event: confirmation_event)
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "does not store raw rows for perform_action events but records metrics" do
+    perform_event = ActiveSupport::Notifications::Event.new(
+      "perform_action.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel_class: "ChatChannel", action: "speak", data: {message: "hi"}}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.0)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(1.0)
+    allow(SolidObserver::Services::RecordCableMetric).to receive(:call)
+
+    described_class.call(event: perform_event, buffer: buffer)
+
+    expect(SolidObserver::Services::RecordCableMetric).to have_received(:call).with(event: perform_event)
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "extracts channel_class from channel object when channel_class payload key is absent" do
+    chat_channel_class = Class.new do
+      def self.name = "ChatChannel"
+    end
+    rejection_event = ActiveSupport::Notifications::Event.new(
+      "transmit_subscription_rejection.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel: chat_channel_class.new}
+    )
+
+    stub_channel_class_event(rejection_event)
+
+    expect(buffer).to have_received(:push).with(hash_including(channel_class: "ChatChannel"))
+  end
+
+  it "extracts channel_class from payload when present" do
+    rejection_event = ActiveSupport::Notifications::Event.new(
+      "transmit_subscription_rejection.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel_class: "ChatChannel"}
+    )
+
+    stub_channel_class_event(rejection_event)
+
+    expect(buffer).to have_received(:push).with(hash_including(channel_class: "ChatChannel"))
+  end
+
+  it "records exception_object details on stored events" do
+    error_event = ActiveSupport::Notifications::Event.new(
+      "transmit_subscription_rejection.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {channel_class: "ChatChannel", exception_object: StandardError.new("Rejected")}
+    )
+
+    described_class.call(event: error_event, buffer: buffer)
+
+    expect(buffer).to have_received(:push).with(hash_including(
+      error_class: "StandardError",
+      error_message: "Rejected"
+    ))
+  end
+
+  it "records explicit exception payload details on stored events" do
+    error_event = ActiveSupport::Notifications::Event.new(
+      "broadcast.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {broadcasting: "chat:1", exception: ["StandardError", "Broadcast timeout"]}
+    )
+
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(0.0)
+
+    described_class.call(event: error_event, buffer: buffer)
+
+    expect(buffer).to have_received(:push).with(hash_including(
+      error_class: "StandardError",
+      error_message: "Broadcast timeout"
+    ))
+  end
+
+  it "emits no solid_observer_cable_metrics SQL on the notification callback path" do
+    SolidObserver.config.buffer_size = 1000
+    allow(Kernel).to receive(:rand).and_return(0.9)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(0.0)
+
+    sql = capture_sql do
+      described_class.call(event: broadcast_event, buffer: buffer)
+    end
+
+    expect(sql.grep(/solid_observer_cable_metrics/i)).to be_empty
+    expect(SolidObserver::CableMetricBuffer.instance.size).to eq(1)
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "re-raises NameError wiring failures" do
+    allow(SolidObserver::Services::RecordCableMetric).to receive(:call).and_raise(
+      NameError.new("uninitialized constant SolidObserver::Services::RecordCableMetric")
+    )
+
+    expect {
+      described_class.call(event: broadcast_event, buffer: buffer)
+    }.to raise_error(NameError, /RecordCableMetric/)
+
+    expect(buffer).not_to have_received(:push)
+  end
+
+  it "logs and swallows ordinary StandardError failures" do
+    logger = instance_double(Logger, warn: nil)
+
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(SolidObserver::Services::RecordCableMetric).to receive(:call).and_raise(
+      ActiveRecord::StatementInvalid.new("missing table")
+    )
+
+    expect {
+      described_class.call(event: broadcast_event, buffer: buffer)
+    }.not_to raise_error
+
+    expect(logger).to have_received(:warn).with(
+      "[SolidObserver] Cable event recording failed: missing table"
+    )
+    expect(buffer).not_to have_received(:push)
+  end
+
+  def stub_channel_class_event(event)
+    allow(Kernel).to receive(:rand).and_return(0.0)
+    allow(SolidObserver.config).to receive(:cable_sampling_rate).and_return(1.0)
+
+    described_class.call(event: event, buffer: buffer)
+  end
+
+  def capture_sql
+    statements = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _started, _finished, _id, sql_payload|
+      statements << sql_payload[:sql]
+    end
+
+    yield
+    statements
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+end

--- a/spec/solid_observer/services/record_cable_metric_spec.rb
+++ b/spec/solid_observer/services/record_cable_metric_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "time"
+
+RSpec.describe SolidObserver::Services::RecordCableMetric do
+  let(:buffer) { instance_double(SolidObserver::CableMetricBuffer, increment: nil) }
+
+  it "buffers a metric in a 1-minute bucket without writing to the database" do
+    travel_to(Time.parse("2026-06-01 12:34:45 UTC")) do
+      described_class.call(
+        event: ActiveSupport::Notifications::Event.new("broadcast.action_cable", Time.current, Time.current + 0.01, "id", {}),
+        buffer: buffer
+      )
+    end
+
+    expect(buffer).to have_received(:increment).with(
+      hash_including(
+        period_start: Time.parse("2026-06-01 12:34:00 UTC"),
+        broadcasts_count: 1,
+        transmissions_count: 0,
+        confirmations_count: 0,
+        rejections_count: 0,
+        perform_actions_count: 0,
+        errors_count: 0
+      )
+    )
+  end
+
+  it "maps transmit events to transmissions_count" do
+    described_class.call(
+      event: ActiveSupport::Notifications::Event.new("transmit.action_cable", Time.current, Time.current + 0.01, "id", {}),
+      buffer: buffer
+    )
+
+    expect(buffer).to have_received(:increment).with(hash_including(transmissions_count: 1))
+  end
+
+  it "maps confirmation events to confirmations_count" do
+    described_class.call(
+      event: ActiveSupport::Notifications::Event.new("transmit_subscription_confirmation.action_cable", Time.current, Time.current + 0.01, "id", {}),
+      buffer: buffer
+    )
+
+    expect(buffer).to have_received(:increment).with(hash_including(confirmations_count: 1))
+  end
+
+  it "maps rejection events to rejections_count" do
+    described_class.call(
+      event: ActiveSupport::Notifications::Event.new("transmit_subscription_rejection.action_cable", Time.current, Time.current + 0.01, "id", {}),
+      buffer: buffer
+    )
+
+    expect(buffer).to have_received(:increment).with(hash_including(rejections_count: 1))
+  end
+
+  it "maps perform_action events to perform_actions_count" do
+    described_class.call(
+      event: ActiveSupport::Notifications::Event.new("perform_action.action_cable", Time.current, Time.current + 0.01, "id", {}),
+      buffer: buffer
+    )
+
+    expect(buffer).to have_received(:increment).with(hash_including(perform_actions_count: 1))
+  end
+
+  it "tracks errors using explicit exception payload" do
+    error_event = ActiveSupport::Notifications::Event.new(
+      "broadcast.action_cable",
+      Time.current,
+      Time.current + 0.01,
+      "id",
+      {exception: ["RuntimeError", "boom"]}
+    )
+
+    described_class.call(event: error_event, buffer: buffer)
+
+    expect(buffer).to have_received(:increment).with(hash_including(broadcasts_count: 1, errors_count: 1))
+  end
+end


### PR DESCRIPTION
## Summary of changes
The implementation adds optional Cable telemetry behind `solid_cable_enabled?` guard, persists one per-minute six-counter Cable metric row, stores only sampled/errored broadcasts plus all subscription rejections as raw events, and hashes broadcasting names with SHA256. 

## AC Verification
- ✓ AC 1 — Cable subscriber activation is gated by `observe_cable`, `SolidCable` availability, and `solid_observer_cable_events` table presence; Queue/Cache activation independence is covered.
- ✓ AC 2 — Cable metrics persist one row per minute with broadcasts/transmissions/confirmations/rejections/perform_actions/errors counters and a single unique `period_start` index.
- ✓ AC 3 — Raw Cable events store only sampled broadcasts, broadcast errors, and all subscription rejections; raw transmit/confirmation/perform-action rows are never stored, even on errors.
- ✓ AC 4 — Broadcasting names are SHA256 digests only; raw broadcasting/message/data/identifier values are not persisted.