### PR TITLE
[SO-091][FEAT] Add Cable storage health

### DIFF
--- a/app/models/solid_observer/storage_info.rb
+++ b/app/models/solid_observer/storage_info.rb
@@ -6,7 +6,7 @@ module SolidObserver
 
     MB_TO_BYTES = 1_048_576
     GB_TO_BYTES = 1_073_741_824
-    COMPONENTS = %w[queue_observer cache_observer solid_cache].freeze
+    COMPONENTS = %w[queue_observer cache_observer solid_cache cable_observer solid_cable].freeze
 
     validates :db_size_bytes, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
     validates :event_count, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}

--- a/app/views/solid_observer/storages/show.html.erb
+++ b/app/views/solid_observer/storages/show.html.erb
@@ -28,7 +28,24 @@
             <div class="so-card__value"><%= size_value %></div>
             <div class="so-card__subtitle">
               <% if component[:available] %>
-                <%= records_value %> <%= component[:record_label] %>
+                <% if component[:component] == "solid_cable" %>
+                  <% parts = ["#{records_value} #{component[:record_label]}"] %>
+                  <% parts << "#{number_with_delimiter(component[:trimmable_count])} trimmable" unless component[:trimmable_count].nil? %>
+                  <% unless component[:oldest_message_age_seconds].nil? %>
+                    <% age = component[:oldest_message_age_seconds] %>
+                    <% if age < 3600 %>
+                      <% value = [age / 60, 1].max; unit = "m" %>
+                    <% elsif age < 86_400 %>
+                      <% value = age / 3600; unit = "h" %>
+                    <% else %>
+                      <% value = age / 86_400; unit = "d" %>
+                    <% end %>
+                    <% parts << "oldest #{value}#{unit}" %>
+                  <% end %>
+                  <%= parts.join(" · ") %>
+                <% else %>
+                  <%= records_value %> <%= component[:record_label] %>
+                <% end %>
               <% else %>
                 <%= component[:unavailable_reason] %>
               <% end %>
@@ -53,10 +70,19 @@
           </thead>
           <tbody>
             <% @storage_history.each do |snapshot| %>
-              <% record_label = snapshot.component == "solid_cache" ? "cache rows" : "observer events" %>
+              <% record_label = case snapshot.component
+                when "solid_cache" then "cache rows"
+                when "solid_cable" then "messages"
+                else "observer events"
+                end %>
+              <% component_label = case snapshot.component
+                when "solid_cable" then "Solid Cable messages"
+                when "cable_observer" then "SolidObserver Cable telemetry"
+                else snapshot.component.humanize
+                end %>
               <tr>
                 <td><%= snapshot.recorded_at.strftime("%Y-%m-%d %H:%M") %></td>
-                <td><%= snapshot.component.humanize %></td>
+                <td><%= component_label %></td>
                 <td><%= number_to_human_size(snapshot.db_size_bytes, precision: 1, significant: false, strip_insignificant_zeros: false) %></td>
                 <td><%= number_with_delimiter(snapshot.event_count) %> <%= record_label %></td>
               </tr>

--- a/lib/solid_observer/services/storage_info_snapshot.rb
+++ b/lib/solid_observer/services/storage_info_snapshot.rb
@@ -65,6 +65,10 @@ module SolidObserver
           key == "solid_cache"
         end
 
+        def solid_cable?
+          key == "solid_cable"
+        end
+
         def storage_model
           model.call
         end
@@ -72,13 +76,14 @@ module SolidObserver
         def snapshot
           return unless enabled?
           return unavailable_snapshot(reason: "SolidCache is unavailable") if unavailable_solid_cache?
+          return unavailable_snapshot(reason: "SolidCable is unavailable") if solid_cable? && !defined?(::SolidCable::Message)
 
           existing_data_source_snapshot
         rescue *StorageInfoSnapshot::CONNECTION_ERRORS, TypeError
           unavailable_snapshot(reason: "Storage unavailable")
         end
 
-        def available_snapshot(db_size_bytes:, event_count:)
+        def available_snapshot(db_size_bytes:, event_count:, **extras)
           {
             component: key,
             label: label,
@@ -88,7 +93,7 @@ module SolidObserver
             record_label: record_label,
             recorded_at: Time.current,
             unavailable_reason: nil
-          }
+          }.merge(extras)
         end
 
         def unavailable_snapshot(reason:)
@@ -116,22 +121,39 @@ module SolidObserver
           table_name = record_model.table_name.to_s
           return unavailable_snapshot(reason: "Table unavailable") unless data_source_available?(connection, table_name)
 
+          build_available_snapshot(record_model, connection, table_name)
+        end
+
+        def build_available_snapshot(record_model, connection, table_name)
+          count = -> { record_model.count }
+          event_count = solid_cache? ? RecordCount.new(connection, table_name).solid_cache_count(&count) : count.call
+
           available_snapshot(
             db_size_bytes: DatabaseSize.call(connection: connection, table_name: table_name),
-            event_count: snapshot_event_count(record_model, connection, table_name)
+            event_count: event_count,
+            **extras_for(record_model)
           )
+        end
+
+        def extras_for(record_model)
+          solid_cable? ? solid_cable_extras(record_model) : {}
         end
 
         def data_source_available?(connection, table_name)
           !table_name.empty? && connection.data_source_exists?(table_name)
         end
 
-        def snapshot_event_count(record_model, connection, table_name)
-          record_count = RecordCount.new(connection, table_name)
-          exact_count = -> { record_model.count }
-          return exact_count.call unless solid_cache?
+        def solid_cable_extras(record_model)
+          {
+            trimmable_count: safe_query { record_model.trimmable.count },
+            oldest_message_age_seconds: safe_query { (Time.current - record_model.minimum(:created_at).to_time).to_i }
+          }
+        end
 
-          record_count.solid_cache_count(&exact_count)
+        def safe_query
+          yield
+        rescue *StorageInfoSnapshot::CONNECTION_ERRORS, TypeError, NoMethodError
+          nil
         end
       end
 
@@ -156,6 +178,20 @@ module SolidObserver
           record_label: "cache rows",
           model: -> { ::SolidCache::Entry },
           enabled: -> { SolidObserver.config.solid_cache_enabled? }
+        ),
+        Component.new(
+          key: "cable_observer",
+          label: "SolidObserver Cable telemetry",
+          record_label: "observer events",
+          model: -> { SolidObserver::CableEvent },
+          enabled: -> { SolidObserver.config.solid_cable_enabled? }
+        ),
+        Component.new(
+          key: "solid_cable",
+          label: "Solid Cable messages",
+          record_label: "messages",
+          model: -> { ::SolidCable::Message },
+          enabled: -> { SolidObserver.config.solid_cable_enabled? }
         )
       ].freeze
 

--- a/spec/models/solid_observer/storage_info_spec.rb
+++ b/spec/models/solid_observer/storage_info_spec.rb
@@ -84,6 +84,26 @@ RSpec.describe SolidObserver::StorageInfo do
       )
     end
 
+    it "persists a solid_cable component" do
+      snapshot = described_class.record_snapshot(db_size: 1024, event_count: 5, component: "solid_cable")
+
+      expect(snapshot).to have_attributes(
+        component: "solid_cable",
+        db_size_bytes: 1024,
+        event_count: 5
+      )
+    end
+
+    it "persists a cable_observer component" do
+      snapshot = described_class.record_snapshot(db_size: 2048, event_count: 10, component: "cable_observer")
+
+      expect(snapshot).to have_attributes(
+        component: "cable_observer",
+        db_size_bytes: 2048,
+        event_count: 10
+      )
+    end
+
     it "logs and re-raises validation failures" do
       logger = instance_double(Logger, error: nil)
       allow(Rails).to receive(:logger).and_return(logger)

--- a/spec/requests/solid_observer/storages_spec.rb
+++ b/spec/requests/solid_observer/storages_spec.rb
@@ -31,6 +31,29 @@ RSpec.describe "SolidObserver storages page", type: :request do
     end
   end
 
+  before(:all) do
+    connection = SolidObserver::CableEvent.connection
+
+    next if connection.table_exists?(:solid_observer_cable_events)
+
+    connection.create_table :solid_observer_cable_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before(:all) do
+    connection = ActiveRecord::Base.connection
+
+    next if connection.table_exists?(:solid_cable_messages)
+
+    connection.create_table :solid_cable_messages do |t|
+      t.string :channel
+      t.text :payload
+      t.datetime :created_at
+    end
+  end
+
   around do |example|
     previous_layout = SolidObserver::StoragesController.send(:_layout)
     SolidObserver::StoragesController.layout false
@@ -47,15 +70,22 @@ RSpec.describe "SolidObserver storages page", type: :request do
       self.table_name = "solid_cache_entries"
     end)
 
+    stub_const("SolidCable", Module.new)
+    stub_const("SolidCable::Message", Class.new(ActiveRecord::Base) do
+      self.table_name = "solid_cable_messages"
+    end)
+
     SolidObserver.config.ui_enabled = true
     SolidObserver.config.observe_queue = false
     SolidObserver.config.observe_cache = true
+    SolidObserver.config.observe_cable = true
     SolidObserver.config.storage_mode = :persistence
 
     allow(SolidObserver::StorageInfo).to receive(:recent).with(20).and_return([])
 
     SolidObserver::CacheEvent.delete_all
-    SolidCache::Entry.delete_all
+    SolidObserver::CableEvent.delete_all
+    SolidCable::Message.delete_all
   end
 
   after { SolidObserver.reset_configuration! }
@@ -79,5 +109,57 @@ RSpec.describe "SolidObserver storages page", type: :request do
     expect(body).to include("SolidCache")
     expect(body).to include("Storage unavailable")
     expect(body).not_to include("TypeError")
+  end
+
+  it "renders Solid Cable and Cable observer cards when cable observation is enabled" do
+    status, _headers, body = call_action
+
+    expect(status).to eq(200)
+    expect(body).to include("Solid Cable messages")
+    expect(body).to include("SolidObserver Cable telemetry")
+    expect(body).to include("Available")
+  end
+
+  it "keeps the storages page request successful when SolidCable metrics raise PostgreSQL-style TypeError" do
+    allow(SolidCable::Message).to receive(:count).and_raise(TypeError, "no implicit conversion of nil into String")
+
+    status, _headers, body = call_action
+
+    expect(status).to eq(200)
+    expect(body).to include("Solid Cable messages")
+    expect(body).to include("Storage unavailable")
+    expect(body).not_to include("TypeError")
+  end
+
+  it "labels solid_cable history rows as messages in the Recent Snapshots table" do
+    snapshot = double(
+      "SolidObserver::StorageInfo",
+      component: "solid_cable",
+      db_size_bytes: 1024,
+      event_count: 5,
+      recorded_at: Time.current
+    )
+    allow(SolidObserver::StorageInfo).to receive(:recent).with(20).and_return([snapshot])
+
+    _status, _headers, body = call_action
+
+    expect(body).to include("Solid Cable messages")
+    expect(body).to include("5 messages")
+  end
+
+  it "labels cable_observer history rows as SolidObserver Cable telemetry in the Recent Snapshots table" do
+    snapshot = double(
+      "SolidObserver::StorageInfo",
+      component: "cable_observer",
+      db_size_bytes: 2048,
+      event_count: 10,
+      recorded_at: Time.current
+    )
+    allow(SolidObserver::StorageInfo).to receive(:recent).with(20).and_return([snapshot])
+
+    _status, _headers, body = call_action
+
+    expect(body).to include("SolidObserver Cable telemetry")
+    expect(body).to include("10 observer events")
   end
 end

--- a/spec/solid_observer/services/storage_info_snapshot_spec.rb
+++ b/spec/solid_observer/services/storage_info_snapshot_spec.rb
@@ -6,7 +6,9 @@ require "spec_helper"
 RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
   let(:queue_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
   let(:cache_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:cable_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
   let(:solid_cache_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
+  let(:solid_cable_connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
   let(:solid_cache_entry_class) do
     Class.new do
       class << self
@@ -33,9 +35,27 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
     end
   end
 
+  let(:solid_cable_message_class) do
+    Class.new do
+      class << self
+        attr_accessor :connection, :table_name
+
+        def count
+        end
+
+        def minimum(_column)
+        end
+
+        def trimmable
+        end
+      end
+    end
+  end
+
   before do
     allow(SolidObserver.config).to receive(:solid_queue_enabled?).and_return(true)
     allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(true)
+    allow(SolidObserver.config).to receive(:solid_cable_enabled?).and_return(true)
 
     allow(SolidObserver::QueueEvent).to receive(:connection).and_return(queue_connection)
     allow(SolidObserver::QueueEvent).to receive(:count).and_return(10)
@@ -45,14 +65,19 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
     allow(SolidObserver::CacheEvent).to receive(:count).and_return(20)
     allow(cache_connection).to receive(:data_source_exists?).with("solid_observer_cache_events").and_return(true)
 
+    allow(SolidObserver::CableEvent).to receive(:connection).and_return(cable_connection)
+    allow(SolidObserver::CableEvent).to receive(:count).and_return(30)
+    allow(cable_connection).to receive(:data_source_exists?).with("solid_observer_cable_events").and_return(true)
+
     allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: queue_connection, table_name: "solid_observer_queue_events").and_return(100)
     allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: cache_connection, table_name: "solid_observer_cache_events").and_return(200)
+    allow(SolidObserver::Services::DatabaseSize).to receive(:call).with(connection: cable_connection, table_name: "solid_observer_cable_events").and_return(400)
   end
 
-  it "returns queue and cache component snapshots" do
+  it "returns queue, cache, cable, and solid cache component snapshots" do
     snapshots = described_class.call
 
-    expect(snapshots.map { |item| item[:component] }).to include("queue_observer", "cache_observer")
+    expect(snapshots.map { |item| item[:component] }).to include("queue_observer", "cache_observer", "cable_observer", "solid_cable")
   end
 
   it "omits solid cache when disabled" do
@@ -61,6 +86,44 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
     snapshots = described_class.call
 
     expect(snapshots.map { |item| item[:component] }).not_to include("solid_cache")
+  end
+
+  it "omits cable components when cable observation is disabled" do
+    allow(SolidObserver.config).to receive(:solid_cable_enabled?).and_return(false)
+
+    snapshots = described_class.call
+
+    expect(snapshots.map { |item| item[:component] }).not_to include("solid_cable", "cable_observer")
+  end
+
+  it "reports solid cable as unavailable when SolidCable::Message is not defined" do
+    snapshots = described_class.call
+    solid_cable = snapshots.find { |item| item[:component] == "solid_cable" }
+
+    expect(solid_cable).to include(
+      label: "Solid Cable messages",
+      available: false,
+      db_size_bytes: nil,
+      event_count: nil,
+      record_label: "messages",
+      recorded_at: nil,
+      unavailable_reason: "SolidCable is unavailable"
+    )
+  end
+
+  it "reports cable observer as unavailable when table is missing" do
+    allow(cable_connection).to receive(:data_source_exists?).with("solid_observer_cable_events").and_return(false)
+
+    snapshots = described_class.call
+    cable_snapshot = snapshots.find { |item| item[:component] == "cable_observer" }
+
+    expect(cable_snapshot).to include(
+      label: "SolidObserver Cable telemetry",
+      available: false,
+      db_size_bytes: nil,
+      event_count: nil,
+      unavailable_reason: "Table unavailable"
+    )
   end
 
   it "omits queue observer when queue component is disabled" do
@@ -205,6 +268,66 @@ RSpec.describe SolidObserver::Services::StorageInfoSnapshot do
         db_size_bytes: nil,
         event_count: nil,
         record_label: "cache rows",
+        recorded_at: nil,
+        unavailable_reason: "Storage unavailable"
+      )
+    end
+  end
+
+  context "when SolidCable::Message is available" do
+    before do
+      allow(SolidObserver.config).to receive(:solid_queue_enabled?).and_return(false)
+      allow(SolidObserver.config).to receive(:solid_cache_enabled?).and_return(false)
+      allow(SolidObserver.config).to receive(:solid_cable_enabled?).and_return(true)
+
+      stub_const("SolidCable", Module.new)
+      stub_const("SolidCable::Message", solid_cable_message_class)
+
+      allow(SolidCable::Message).to receive(:connection).and_return(solid_cable_connection)
+      allow(SolidCable::Message).to receive(:table_name).and_return("solid_cable_messages")
+      allow(solid_cable_connection).to receive(:adapter_name).and_return("SQLite")
+      allow(SolidCable::Message).to receive(:count).and_return(42)
+      allow(solid_cable_connection).to receive(:data_source_exists?).with("solid_cable_messages").and_return(true)
+      allow(SolidObserver::Services::DatabaseSize).to receive(:call)
+        .with(connection: solid_cable_connection, table_name: "solid_cable_messages")
+        .and_return(500)
+
+      trimmable_relation = double(count: 7)
+      allow(SolidCable::Message).to receive(:trimmable).and_return(trimmable_relation)
+      allow(SolidCable::Message).to receive(:minimum).with(:created_at).and_return(1.hour.ago)
+    end
+
+    it "uses SolidCable::Message with its dynamic table name for storage metrics" do
+      snapshots = described_class.call
+      solid_cable = snapshots.find { |snapshot| snapshot[:component] == "solid_cable" }
+
+      expect(solid_cable).to include(
+        label: "Solid Cable messages",
+        available: true,
+        db_size_bytes: 500,
+        event_count: 42,
+        record_label: "messages",
+        trimmable_count: 7,
+        unavailable_reason: nil
+      )
+      expect(solid_cable[:oldest_message_age_seconds]).to be_within(2).of(3600)
+      expect(solid_cable_connection).to have_received(:data_source_exists?).with("solid_cable_messages")
+      expect(SolidObserver::Services::DatabaseSize).to have_received(:call)
+        .with(connection: solid_cable_connection, table_name: "solid_cable_messages")
+    end
+
+    it "returns an unavailable solid cable snapshot when the concrete model raises PostgreSQL-style TypeError" do
+      allow(SolidCable::Message).to receive(:count).and_raise(TypeError, "no implicit conversion of nil into String")
+
+      snapshots = described_class.call
+      solid_cable = snapshots.find { |snapshot| snapshot[:component] == "solid_cable" }
+
+      expect(solid_cable).to include(
+        label: "Solid Cable messages",
+        available: false,
+        db_size_bytes: nil,
+        event_count: nil,
+        record_label: "messages",
         recorded_at: nil,
         unavailable_reason: "Storage unavailable"
       )


### PR DESCRIPTION
## Summary
Added the Cable storage components, persistence keys, UI rendering, and regression coverage. 

## AC Verification
- ✓ AC 1 — Storages shows Solid Cable message storage when Cable observation is enabled, including message count, trimmable backlog, oldest message age, and footprint when safely available.
- ✓ AC 2 — Storages shows SolidObserver Cable telemetry separately from Solid Cable message storage using existing card/table patterns.
- ✓ AC 3 — Missing Solid Cable constants/tables, unsupported queries, and PostgreSQL-style `TypeError` failures render safe unavailable/N/A states without leaking errors or failing the request.
- ✓ AC 4 — Snapshot persistence and Recent Snapshots labels accept and distinguish `solid_cable` and `cable_observer`.