### PR TITLE
[SO-092][FEAT] Add Cable dashboard and stability

### DIFF
--- a/app/controllers/solid_observer/cable_dashboard_controller.rb
+++ b/app/controllers/solid_observer/cable_dashboard_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "dashboard_controller"
+
+module SolidObserver
+  # :reek:TooManyInstanceVariables
+  class CableDashboardController < DashboardController
+    CABLE_STORAGE_COMPONENTS = %w[cable_observer solid_cable].freeze
+
+    def index
+      @component = "cable"
+      assign_cable_dashboard
+    end
+
+    private
+
+    # :reek:TooManyStatements
+    def assign_cable_dashboard
+      unless SolidObserver.config.solid_cable_enabled?
+        @cable_dashboard_available = false
+        @storage_components = []
+        @recent_events = []
+        return
+      end
+
+      range = SolidObserver::Services::CableStats.parse_range(request_range_param)
+      window = SolidObserver::Services::CableStats.range_duration(range)
+      stats = SolidObserver::Services::CableStats.call(window: window)
+
+      @cable_dashboard_available = true
+      @range = range
+      @stats = stats
+      @storage_components = cable_storage_components
+      @recent_events = recent_events(window)
+    end
+
+    def cable_storage_components
+      SolidObserver::Services::StorageInfoSnapshot.call.select do |snapshot|
+        CABLE_STORAGE_COMPONENTS.include?(snapshot[:component])
+      end
+    rescue *SolidObserver::Services::StorageInfoSnapshot::CONNECTION_ERRORS, TypeError, NoMethodError
+      []
+    end
+
+    def recent_events(window)
+      current_time = Time.current
+      SolidObserver::CableEvent.where(recorded_at: (current_time - window)..current_time).recent(10)
+    rescue ActiveRecord::StatementInvalid
+      []
+    end
+  end
+end

--- a/app/helpers/solid_observer/application_helper.rb
+++ b/app/helpers/solid_observer/application_helper.rb
@@ -156,6 +156,63 @@ module SolidObserver
       CACHE_RANGE_LABELS.fetch(range_key.to_s, "in selected range")
     end
 
+    def cable_range_label(range_key)
+      CACHE_RANGE_LABELS.fetch(range_key.to_s, "in selected range")
+    end
+
+    def cable_ratio_percent(value)
+      number_to_percentage(value.to_f * 100, precision: 1, strip_insignificant_zeros: true)
+    end
+
+    def cable_stability_badge(state)
+      stability_badge_for(state.to_sym)
+    end
+
+    def cable_stability_detail(stability)
+      state = (stability || {})[:state]&.to_sym
+      state = :stable unless STABILITY_STATES.key?(state)
+
+      case state
+      when :critical
+        critical_cable_stability_detail(stability)
+      when :degraded
+        degraded_cable_stability_detail(stability)
+      else
+        "No cable errors or subscription rejections in the selected range and backlog current snapshot is healthy"
+      end
+    end
+
+    def cable_event_digest(digest, visible_chars: 10)
+      digest = digest.to_s
+      return "—" if digest.empty?
+      return digest if digest.length <= visible_chars
+
+      "#{digest.first(visible_chars)}…"
+    end
+
+    # :reek:FeatureEnvy
+    def cable_backlog_summary(stats)
+      if stats[:backlog_available]
+        {
+          value: number_with_delimiter(stats[:backlog_count].to_i),
+          subtitle: "current Solid Cable snapshot"
+        }
+      else
+        {value: "—", subtitle: "current Solid Cable snapshot unavailable"}
+      end
+    end
+
+    def cable_storage_summary(storage_components)
+      snapshots = Array(storage_components)
+      reason = cable_storage_unavailable_reason(snapshots)
+      return {value: "—", subtitle: "— #{reason}"} if reason
+
+      {
+        value: number_to_human_size(cable_storage_total_bytes(snapshots), precision: 1, significant: false, strip_insignificant_zeros: false),
+        subtitle: "SolidObserver Cable telemetry + Solid Cable messages"
+      }
+    end
+
     def cache_stability_detail(stability)
       state = (stability || {})[:state]&.to_sym
       state = :stable unless STABILITY_STATES.key?(state)
@@ -187,6 +244,10 @@ module SolidObserver
 
     def cache_component_enabled?
       SolidObserver.config.solid_cache_enabled?
+    end
+
+    def cable_component_enabled?
+      SolidObserver.config.solid_cable_enabled?
     end
 
     def dashboard_section_active?(component)
@@ -226,6 +287,59 @@ module SolidObserver
     end
 
     def cache_storage_unavailable_reason(snapshots)
+      return "Storage snapshot unavailable" unless snapshots.size == 2
+
+      snapshots.find { |snapshot| !snapshot[:available] }&.[](:unavailable_reason)
+    end
+
+    # :reek:FeatureEnvy
+    # :reek:TooManyStatements
+    def critical_cable_stability_detail(stability)
+      parts = []
+      error_count = stability[:error_count].to_i
+      parts << pluralize(error_count, "cable error") if error_count.positive?
+
+      rejection_count = stability[:rejection_count].to_i
+      rejection_rate = stability[:rejection_rate].to_f
+      if rejection_rate > 0.0
+        parts << "#{cable_ratio_percent(rejection_rate)} rejection rate"
+      elsif rejection_count.positive?
+        parts << pluralize(rejection_count, "subscription rejection")
+      end
+
+      backlog_ratio = stability[:backlog_ratio].to_f
+      if backlog_ratio >= 0.5
+        parts << "backlog at #{number_to_percentage(backlog_ratio * 100, precision: 0)} in current snapshot"
+      end
+
+      return "Cable stability critical" if parts.empty?
+
+      "#{parts.join("; ")} in the selected range"
+    end
+
+    # :reek:FeatureEnvy
+    # :reek:TooManyStatements
+    def degraded_cable_stability_detail(stability)
+      return "Backlog current snapshot unavailable" unless stability[:backlog_available]
+
+      backlog_ratio = stability[:backlog_ratio].to_f
+      if backlog_ratio >= SolidObserver.config.cable_backlog_threshold.to_f
+        return "Backlog at #{number_to_percentage(backlog_ratio * 100, precision: 0)} in current snapshot"
+      end
+
+      rejection_count = stability[:rejection_count].to_i
+      if rejection_count.positive?
+        return "#{pluralize(rejection_count, "subscription rejection")} in the selected range"
+      end
+
+      "Cable stability degraded"
+    end
+
+    def cable_storage_total_bytes(snapshots)
+      snapshots.sum { |snapshot| snapshot[:db_size_bytes].to_i }
+    end
+
+    def cable_storage_unavailable_reason(snapshots)
       return "Storage snapshot unavailable" unless snapshots.size == 2
 
       snapshots.find { |snapshot| !snapshot[:available] }&.[](:unavailable_reason)

--- a/app/views/layouts/solid_observer/application.html.erb
+++ b/app/views/layouts/solid_observer/application.html.erb
@@ -398,7 +398,8 @@
     .so-cache-controls { max-width: 820px; }
     .so-cache-dashboard__intro,
     .so-cache-controls__intro,
-    .so-queue-overview__intro {
+    .so-queue-overview__intro,
+    .so-cable-dashboard__intro {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
@@ -407,16 +408,19 @@
     }
     .so-cache-dashboard__hint,
     .so-cache-controls__hint,
-    .so-queue-overview__hint {
+    .so-queue-overview__hint,
+    .so-cable-dashboard__hint {
       font-size: 0.875rem;
       color: var(--so-text-subtle);
       line-height: 1.5;
     }
-    .so-cache-dashboard__range-form {
+    .so-cache-dashboard__range-form,
+    .so-cable-dashboard__range-form {
       align-items: center;
       margin-bottom: 2rem;
     }
     .so-cache-dashboard__range-form select,
+    .so-cable-dashboard__range-form select,
     .so-dashboard-toolbar select {
       padding: 0.4rem 0.6rem;
       border: 1px solid var(--so-border);
@@ -425,11 +429,13 @@
       background: var(--so-card-bg);
       color: var(--so-text);
     }
-    .so-cache-dashboard__chart-empty {
+    .so-cache-dashboard__chart-empty,
+    .so-cable-dashboard__chart-empty {
       max-width: 420px;
       margin-bottom: 0;
     }
-    .so-cache-dashboard__digest {
+    .so-cache-dashboard__digest,
+    .so-cable-dashboard__digest {
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
       white-space: nowrap;
     }
@@ -564,7 +570,12 @@
           <% end %>
         <% end %>
 
-        <% if persistence_mode? && (SolidObserver.config.solid_queue_enabled? || SolidObserver.config.solid_cache_enabled?) %>
+        <% if SolidObserver.config.solid_cable_enabled? %>
+          <div class="so-sidebar__section">Cable</div>
+          <%= link_to "Overview", cable_dashboard_path, class: ("active" if controller_name == "cable_dashboard"), "aria-current": (controller_name == "cable_dashboard" ? "page" : nil) %>
+        <% end %>
+
+        <% if persistence_mode? && (SolidObserver.config.solid_queue_enabled? || SolidObserver.config.solid_cache_enabled? || SolidObserver.config.solid_cable_enabled?) %>
           <%= link_to "Storage", storage_path, class: ("active" if controller_name == "storages"), "aria-current": (controller_name == "storages" ? "page" : nil) %>
         <% end %>
       </nav>

--- a/app/views/solid_observer/cable_dashboard/_charts.html.erb
+++ b/app/views/solid_observer/cable_dashboard/_charts.html.erb
@@ -1,0 +1,31 @@
+<section class="so-dashboard-section" aria-labelledby="so-cable-charts-heading">
+  <header class="so-dashboard-section__header">
+    <h2 id="so-cable-charts-heading" class="so-dashboard-section__title">Activity trends</h2>
+  </header>
+
+  <div class="so-chart-strip">
+    <% if @stats[:activity_trends]&.[](:available) %>
+      <figure class="so-spark" data-so-spark="cable-broadcasts">
+        <figcaption class="so-spark__label">Broadcasts total <span data-so-range-copy><%= cable_range_label(@range) %></span></figcaption>
+        <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+          <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+          <polyline class="so-spark__line" points="<%= spark_points(@stats[:activity_trends][:broadcasts]) %>"/>
+        </svg>
+        <span class="so-spark__value"><%= number_with_delimiter(@stats[:broadcasts_count].to_i) %></span>
+      </figure>
+
+      <figure class="so-spark" data-so-spark="cable-rejections">
+        <figcaption class="so-spark__label">Rejections total <span data-so-range-copy><%= cable_range_label(@range) %></span></figcaption>
+        <svg class="so-spark__svg" viewBox="0 0 120 32" preserveAspectRatio="none" aria-hidden="true">
+          <line class="so-spark__baseline" x1="1" x2="119" y1="31" y2="31"/>
+          <polyline class="so-spark__line" points="<%= spark_points(@stats[:activity_trends][:rejections]) %>"/>
+        </svg>
+        <span class="so-spark__value"><%= number_with_delimiter(@stats[:rejections_count].to_i) %></span>
+      </figure>
+    <% else %>
+      <div class="so-card so-cable-dashboard__chart-empty">
+        <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-range">No chart data in the selected range yet. Summary metrics still use bounded cable stats.</p>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/solid_observer/cable_dashboard/_recent_events.html.erb
+++ b/app/views/solid_observer/cable_dashboard/_recent_events.html.erb
@@ -1,0 +1,34 @@
+<section class="so-card so-card--section" aria-labelledby="so-cable-events-heading">
+  <header class="so-dashboard-section__header">
+    <h2 id="so-cable-events-heading" class="so-dashboard-section__title">Recent Cable events</h2>
+    <span class="so-dashboard-section__meta">debug context only · broadcasting names and payloads are never shown</span>
+  </header>
+
+  <% if recent_events.present? %>
+    <table class="so-table so-table--card">
+      <caption class="sr-only">Recent Cable events without raw broadcasting names or payloads</caption>
+      <thead>
+        <tr>
+          <th>Event</th>
+          <th>Channel class</th>
+          <th>Broadcasting digest</th>
+          <th>Duration</th>
+          <th>Recorded</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% recent_events.each do |event| %>
+          <tr>
+            <td><%= event.event_type.to_s %></td>
+            <td><%= event.channel_class.presence || "—" %></td>
+            <td><span class="so-cable-dashboard__digest"><%= cable_event_digest(event.broadcasting_digest) %></span></td>
+            <td><%= event.duration ? format_duration(event.duration) : "—" %></td>
+            <td><span title="<%= event.recorded_at.utc.strftime("%Y-%m-%d %H:%M:%S UTC") %>"><%= time_ago_in_words(event.recorded_at) %> ago</span></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="so-dashboard-section__meta so-dashboard-section__meta--empty-events">No sampled cable events in the selected range yet. Broadcasts, rejections, and errors will appear here after Cable activity is recorded.</p>
+  <% end %>
+</section>

--- a/app/views/solid_observer/cable_dashboard/_summary.html.erb
+++ b/app/views/solid_observer/cable_dashboard/_summary.html.erb
@@ -1,0 +1,34 @@
+<% backlog_summary = cable_backlog_summary(stats) %>
+<% storage_summary = cable_storage_summary(storage_components) %>
+
+<section class="so-dashboard-section" aria-labelledby="so-cable-summary-heading">
+  <header class="so-dashboard-section__header">
+    <h2 id="so-cable-summary-heading" class="so-dashboard-section__title">Summary in selected range</h2>
+  </header>
+
+  <div class="so-stat-cards so-cable-dashboard__summary">
+    <article class="so-card so-metric">
+      <div class="so-card__label">Broadcasts</div>
+      <div class="so-metric__value"><%= number_with_delimiter(stats[:broadcasts_count].to_i) %></div>
+      <div class="so-card__subtitle">selected window</div>
+    </article>
+
+    <article class="so-card so-metric">
+      <div class="so-card__label">Rejection rate</div>
+      <div class="so-metric__value"><%= cable_ratio_percent(stats[:rejection_rate]) %></div>
+      <div class="so-card__subtitle">rejections / broadcasts</div>
+    </article>
+
+    <article class="so-card so-metric">
+      <div class="so-card__label">Message backlog</div>
+      <div class="so-metric__value"><%= backlog_summary[:value] %></div>
+      <div class="so-card__subtitle"><%= backlog_summary[:subtitle] %></div>
+    </article>
+
+    <article class="so-card so-metric">
+      <div class="so-card__label">Storage footprint</div>
+      <div class="so-metric__value"><%= storage_summary[:value] %></div>
+      <div class="so-card__subtitle"><%= storage_summary[:subtitle] %></div>
+    </article>
+  </div>
+</section>

--- a/app/views/solid_observer/cable_dashboard/index.html.erb
+++ b/app/views/solid_observer/cable_dashboard/index.html.erb
@@ -1,0 +1,62 @@
+<% content_for :title, "Cable overview" %>
+<% status_class = @cable_dashboard_available ? "so-badge--success" : "so-badge--warning" %>
+
+<div class="so-dashboard so-cable-dashboard">
+  <span class="sr-only">Cable Dashboard</span>
+
+  <div class="so-content__header">
+    <h1>Cable overview</h1>
+
+    <% if @cable_dashboard_available %>
+      <div class="so-cable-dashboard__intro">
+        <span class="so-badge so-badge--pill <%= status_class %>">
+          <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+            <circle r="3" cx="3" cy="3" />
+          </svg>
+          Available
+        </span>
+        <p class="so-cable-dashboard__hint">Selected range: <%= cable_range_label(@range) %> · broadcasting names and payloads are never shown.</p>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @cable_dashboard_available %>
+    <form action="<%= request.path %>" method="get" class="so-dashboard-toolbar so-cable-dashboard__range-form">
+      <label for="so-cable-range" class="so-card__label so-filters__label">Range</label>
+      <select id="so-cable-range" name="range" onchange="this.form.submit()">
+        <% SolidObserver::Services::CableStats::RANGES.each_key do |key| %>
+          <option value="<%= key %>" <%= "selected" if key == @range %>><%= cable_range_label(key) %></option>
+        <% end %>
+      </select>
+      <button type="submit" class="so-btn so-btn--refresh">Refresh data</button>
+    </form>
+
+    <%= render "solid_observer/cable_dashboard/summary", stats: @stats, storage_components: @storage_components %>
+    <%= render "solid_observer/cable_dashboard/charts" %>
+
+    <% if @stats&.[](:stability)&.[](:available) %>
+      <section class="so-stability" data-so-zone="cable-stability" aria-labelledby="so-cable-stability-heading">
+        <span class="so-stability__label" id="so-cable-stability-heading">Stability</span>
+        <%= cable_stability_badge(@stats[:stability][:state]) %>
+        <span class="so-stability__detail"><%= cable_stability_detail(@stats[:stability]) %></span>
+        <a href="#so-cable-events-heading" class="so-stability__link">View recent events →</a>
+      </section>
+    <% end %>
+
+    <%= render "solid_observer/cable_dashboard/recent_events", recent_events: @recent_events %>
+  <% else %>
+    <section class="so-card so-card--section" aria-labelledby="so-cable-unavailable-heading">
+      <header class="so-dashboard-section__header">
+        <h2 id="so-cable-unavailable-heading" class="so-dashboard-section__title">Cable dashboard unavailable</h2>
+        <span class="so-badge so-badge--pill <%= status_class %>">
+          <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+            <circle r="3" cx="3" cy="3" />
+          </svg>
+          Unavailable
+        </span>
+      </header>
+
+      <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">Cable dashboard is unavailable because Solid Cable support is disabled or not detected. Metrics are unavailable.</p>
+    </section>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ SolidObserver::Engine.routes.draw do
   root "dashboard#index"
   get "queue", to: "dashboard#index", defaults: {component: "queue"}, as: :queue_dashboard
   get "cache", to: "cache_dashboard#index", as: :cache_dashboard
+  get "cable", to: "cable_dashboard#index", as: :cable_dashboard
   get "cache/controls", to: "cache_operations#index", as: :cache_operations
   post "cache/controls/prune", to: "cache_operations#prune", as: :prune_cache_operations
   post "cache/controls/clear", to: "cache_operations#clear", as: :clear_cache_operations

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -43,6 +43,7 @@ ActiveSupport.on_load(:active_record) do
   require_relative "solid_observer/services/record_cable_event"
   require_relative "solid_observer/services/record_cable_metric"
   require_relative "solid_observer/services/flush_cable_event_buffer"
+  require_relative "solid_observer/services/cable_stats"
 end
 
 module SolidObserver

--- a/lib/solid_observer/configuration.rb
+++ b/lib/solid_observer/configuration.rb
@@ -22,12 +22,16 @@ module SolidObserver
     attr_accessor :observe_queue
 
     # Observer Settings (planned for a future release)
-    # @note Cache and Cable observers are not yet implemented
+    # @note Cable observer is not yet fully implemented
     attr_accessor :observe_cache,
       :observe_cable,
       :cache_sampling_rate,
       :cache_slow_threshold,
       :cache_store_errors
+
+    attr_reader :cable_rejection_threshold,
+      :cable_backlog_threshold,
+      :cable_error_threshold
 
     # Retention Settings
     attr_accessor :event_retention
@@ -60,12 +64,15 @@ module SolidObserver
         @storage_mode, @observe_queue, @observe_cache, @observe_cable,
         @event_retention, @metrics_retention, @max_db_size, @warning_threshold,
         @sampling_rate, @cache_sampling_rate, @cable_sampling_rate, @cache_slow_threshold, @cache_store_errors,
+        @cable_rejection_threshold, @cable_backlog_threshold, @cable_error_threshold,
         @buffer_size, @flush_interval,
         @max_buffer_size, @buffer_overflow_strategy, @filter_cache_ttl,
         @correlation_id_generator = !production?, "::ApplicationController", nil, nil,
           :persistence, true, false, false,
           30.days, 90.days, 1.gigabyte, 0.8,
-          1.0, 0.1, 0.1, 0.1, true, 1000, 10.seconds,
+          1.0, 0.1, 0.1, 0.1, true,
+          0.05, 0.10, 0.0,
+          1000, 10.seconds,
           10_000, :drop_old, 1.minute,
           nil
     end
@@ -120,6 +127,21 @@ module SolidObserver
     def cable_sampling_rate=(value)
       validate_rate!(:cable_sampling_rate, value)
       @cable_sampling_rate = value
+    end
+
+    def cable_rejection_threshold=(value)
+      validate_rate!(:cable_rejection_threshold, value)
+      @cable_rejection_threshold = value
+    end
+
+    def cable_backlog_threshold=(value)
+      validate_rate!(:cable_backlog_threshold, value)
+      @cable_backlog_threshold = value
+    end
+
+    def cable_error_threshold=(value)
+      validate_non_negative_numeric!(:cable_error_threshold, value)
+      @cable_error_threshold = value
     end
 
     def warning_threshold=(value)
@@ -181,6 +203,13 @@ module SolidObserver
     def validate_positive_numeric!(name, value)
       unless value.is_a?(Numeric) && value > 0
         raise ArgumentError, "#{name} must be a positive number"
+      end
+    end
+
+    # :reek:FeatureEnvy
+    def validate_non_negative_numeric!(name, value)
+      unless value.is_a?(Numeric) && value >= 0
+        raise ArgumentError, "#{name} must be a non-negative number"
       end
     end
 

--- a/lib/solid_observer/services/cable_stats.rb
+++ b/lib/solid_observer/services/cable_stats.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require_relative "storage_info_snapshot"
+
+module SolidObserver
+  module Services
+    # :reek:TooManyConstants
+    class CableStats
+      RANGES = {
+        "15m" => 15.minutes,
+        "30m" => 30.minutes,
+        "1h" => 1.hour,
+        "7h" => 7.hours,
+        "1d" => 1.day,
+        "7d" => 7.days,
+        "14d" => 14.days
+      }.freeze
+      DEFAULT_RANGE = "15m"
+      ACTIVITY_TREND_EMPTY = {
+        available: false,
+        broadcasts: [],
+        rejections: []
+      }.freeze
+      STABILITY_EMPTY = {
+        available: false,
+        state: :stable,
+        rejection_count: 0,
+        error_count: 0,
+        rejection_rate: 0.0,
+        backlog_ratio: nil,
+        backlog_available: false,
+        latest_recorded_at: nil
+      }.freeze
+      STABILITY_DEGRADED = {
+        available: true,
+        state: :degraded,
+        rejection_count: 0,
+        error_count: 0,
+        rejection_rate: 0.0,
+        backlog_ratio: nil,
+        backlog_available: false,
+        latest_recorded_at: nil
+      }.freeze
+      BUCKET_RULES = [
+        [2.hours.to_i, 1.minute.to_i],
+        [1.day.to_i, 15.minutes.to_i],
+        [7.days.to_i, 2.hours.to_i]
+      ].freeze
+
+      class TrendData
+        class BucketSnapshot
+          attr_reader :broadcasts_count, :rejections_count
+
+          def initialize
+            @broadcasts_count = 0
+            @rejections_count = 0
+          end
+
+          def add(row)
+            @broadcasts_count += row[1].to_i
+            @rejections_count += row[4].to_i
+          end
+
+          def value_for(key)
+            public_send(key)
+          end
+        end
+
+        def initialize(metric_rows:, window:, current_time:)
+          @metric_rows = metric_rows
+          @window = window
+          @current_time = current_time
+        end
+
+        def to_h
+          return CableStats::ACTIVITY_TREND_EMPTY.dup if metric_rows.empty?
+
+          buckets = blank_buckets
+          metric_rows.each do |row|
+            buckets[align_bucket(row[0].to_i)]&.add(row)
+          end
+
+          {
+            available: true,
+            broadcasts: count_series(buckets, :broadcasts_count),
+            rejections: count_series(buckets, :rejections_count)
+          }
+        end
+
+        private
+
+        attr_reader :metric_rows, :window, :current_time
+
+        def blank_buckets
+          start_bucket = align_bucket((current_time - window).to_i)
+          end_bucket = align_bucket(current_time.to_i)
+
+          start_bucket.step(end_bucket, bucket_seconds).each_with_object({}) do |timestamp, buckets|
+            buckets[timestamp] = BucketSnapshot.new
+          end
+        end
+
+        def count_series(buckets, key)
+          buckets.map do |timestamp, totals|
+            {t: timestamp, v: totals.value_for(key)}
+          end
+        end
+
+        def bucket_seconds
+          seconds = window.to_i
+          CableStats::BUCKET_RULES.find { |limit, _bucket| seconds <= limit }&.last || 4.hours.to_i
+        end
+
+        def align_bucket(value)
+          (value / bucket_seconds) * bucket_seconds
+        end
+      end
+
+      class BacklogSnapshot
+        def self.call
+          new.call
+        end
+
+        # :reek:TooManyStatements
+        def call
+          snapshot = fetch_snapshot
+          return unavailable unless snapshot && snapshot[:available]
+
+          count = snapshot[:trimmable_count].to_i
+          total = snapshot[:event_count].to_i
+
+          {
+            available: true,
+            count: count,
+            ratio: total.positive? ? count.to_f / total.to_f : 0.0
+          }
+        rescue *StorageInfoSnapshot::CONNECTION_ERRORS, TypeError, NoMethodError
+          unavailable
+        end
+
+        private
+
+        def fetch_snapshot
+          StorageInfoSnapshot.call.find { |component| component[:component] == "solid_cable" }
+        end
+
+        def unavailable
+          {available: false, count: nil, ratio: nil}
+        end
+      end
+
+      class StabilityData
+        def initialize(window:, current_time:, backlog_snapshot:)
+          @window = window
+          @current_time = current_time
+          @backlog_snapshot = backlog_snapshot
+        end
+
+        def to_h(metric_broadcasts_count:, metric_rejections_count:)
+          compute(
+            metric_broadcasts_count: metric_broadcasts_count,
+            metric_rejections_count: metric_rejections_count
+          ).to_h
+        rescue ActiveRecord::StatementInvalid
+          CableStats::STABILITY_DEGRADED.dup
+        end
+
+        private
+
+        attr_reader :window, :current_time, :backlog_snapshot
+
+        # :reek:TooManyStatements
+        def compute(metric_broadcasts_count:, metric_rejections_count:)
+          event_counts = query_event_counts
+          rejection_count = event_counts[:rejection_count]
+          error_count = event_counts[:error_count]
+          rejection_rate = CableStats.ratio(metric_rejections_count, metric_broadcasts_count)
+          rejection_present = rejection_count.to_i.positive? || metric_rejections_count.to_i.positive?
+          backlog_ratio = backlog_snapshot[:ratio]
+          backlog_available = backlog_snapshot[:available]
+
+          {
+            available: true,
+            state: stability_state(
+              error_count: error_count,
+              rejection_rate: rejection_rate,
+              rejection_present: rejection_present,
+              backlog_ratio: backlog_ratio,
+              backlog_available: backlog_available
+            ),
+            rejection_count: rejection_count,
+            error_count: error_count,
+            rejection_rate: rejection_rate,
+            backlog_ratio: backlog_ratio,
+            backlog_available: backlog_available,
+            latest_recorded_at: event_counts[:latest_recorded_at]
+          }
+        end
+
+        # :reek:ControlParameter
+        # :reek:LongParameterList
+        # :reek:TooManyStatements
+        def stability_state(error_count:, rejection_rate:, rejection_present:, backlog_ratio:, backlog_available:)
+          config = SolidObserver.config
+
+          return :critical if error_count.to_i > config.cable_error_threshold.to_i
+          return :critical if rejection_rate >= config.cable_rejection_threshold.to_f
+          return :critical if backlog_ratio && backlog_ratio >= 0.5
+          return :degraded if backlog_ratio && backlog_ratio >= config.cable_backlog_threshold.to_f
+          return :degraded if rejection_present
+          return :degraded unless backlog_available
+
+          :stable
+        end
+
+        def query_event_counts
+          rejection_count, error_count, latest_recorded_at = SolidObserver::CableEvent.where(recorded_at: window_range).pick(
+            Arel.sql("COUNT(CASE WHEN event_type = 'transmit_subscription_rejection' THEN 1 END)"),
+            Arel.sql("COUNT(CASE WHEN error_class IS NOT NULL AND TRIM(error_class) != '' THEN 1 END)"),
+            Arel.sql("MAX(CASE WHEN event_type = 'transmit_subscription_rejection' OR (error_class IS NOT NULL AND TRIM(error_class) != '') THEN recorded_at END)")
+          )
+
+          {
+            rejection_count: rejection_count.to_i,
+            error_count: error_count.to_i,
+            latest_recorded_at: parse_latest_recorded_at(latest_recorded_at)
+          }
+        end
+
+        def parse_latest_recorded_at(value)
+          return nil unless value.present?
+
+          value.is_a?(Time) ? value : Time.parse(value.to_s)
+        rescue ArgumentError
+          nil
+        end
+
+        def window_range
+          (current_time - window)..current_time
+        end
+      end
+
+      class << self
+        def parse_range(value, fallback: DEFAULT_RANGE)
+          range_key = value.to_s
+          RANGES.key?(range_key) ? range_key : fallback
+        end
+
+        def range_duration(value, fallback: DEFAULT_RANGE)
+          RANGES.fetch(parse_range(value, fallback: fallback))
+        end
+
+        def ratio(numerator, denominator)
+          return 0.0 if denominator.to_i.zero?
+
+          numerator.to_f / denominator.to_f
+        end
+      end
+
+      def self.call(window:)
+        new.call(window: window)
+      end
+
+      def call(window:)
+        current_time = Time.current
+        dashboard_response(window: window, current_time: current_time)
+      rescue => error
+        Rails.logger&.error("[SolidObserver] CableStats call failed: #{error.class} #{error.message}") if defined?(Rails)
+        error_response
+      end
+
+      private
+
+      def dashboard_response(window:, current_time:)
+        time_window = (current_time - window)..current_time
+        metric_rows = metric_rows(time_window: time_window)
+        totals = metric_totals(time_window: time_window)
+        backlog_snapshot = BacklogSnapshot.call
+
+        build_response(
+          totals: totals,
+          backlog_snapshot: backlog_snapshot,
+          dashboard_data: dashboard_data(
+            window: window,
+            current_time: current_time,
+            metric_rows: metric_rows,
+            totals: totals,
+            backlog_snapshot: backlog_snapshot
+          )
+        )
+      end
+
+      # :reek:FeatureEnvy
+      # :reek:LongParameterList
+      def build_response(totals:, backlog_snapshot:, dashboard_data:)
+        broadcasts_count = totals[:broadcasts_count]
+        rejections_count = totals[:rejections_count]
+
+        {
+          broadcasts_count: broadcasts_count,
+          transmissions_count: totals[:transmissions_count],
+          confirmations_count: totals[:confirmations_count],
+          rejections_count: rejections_count,
+          perform_actions_count: totals[:perform_actions_count],
+          errors_count: totals[:errors_count],
+          rejection_rate: self.class.ratio(rejections_count, broadcasts_count),
+          activity_trends: dashboard_data[:activity_trends],
+          stability: dashboard_data[:stability],
+          backlog_count: backlog_snapshot[:count],
+          backlog_available: backlog_snapshot[:available]
+        }
+      end
+
+      # :reek:LongParameterList
+      def dashboard_data(window:, current_time:, metric_rows:, totals:, backlog_snapshot:)
+        {
+          activity_trends: TrendData.new(
+            metric_rows: metric_rows,
+            window: window,
+            current_time: current_time
+          ).to_h,
+          stability: StabilityData.new(
+            window: window,
+            current_time: current_time,
+            backlog_snapshot: backlog_snapshot
+          ).to_h(
+            metric_broadcasts_count: totals[:broadcasts_count],
+            metric_rejections_count: totals[:rejections_count]
+          )
+        }
+      end
+
+      def metric_rows(time_window:)
+        SolidObserver::CableMetric.where(period_start: time_window).pluck(
+          :period_start,
+          :broadcasts_count,
+          :transmissions_count,
+          :confirmations_count,
+          :rejections_count,
+          :perform_actions_count,
+          :errors_count
+        )
+      end
+
+      def metric_totals(time_window:)
+        broadcasts_count, transmissions_count, confirmations_count, rejections_count, perform_actions_count, errors_count = SolidObserver::CableMetric.where(
+          period_start: time_window
+        ).pick(
+          Arel.sql("COALESCE(SUM(broadcasts_count), 0)"),
+          Arel.sql("COALESCE(SUM(transmissions_count), 0)"),
+          Arel.sql("COALESCE(SUM(confirmations_count), 0)"),
+          Arel.sql("COALESCE(SUM(rejections_count), 0)"),
+          Arel.sql("COALESCE(SUM(perform_actions_count), 0)"),
+          Arel.sql("COALESCE(SUM(errors_count), 0)")
+        )
+
+        {
+          broadcasts_count: broadcasts_count,
+          transmissions_count: transmissions_count,
+          confirmations_count: confirmations_count,
+          rejections_count: rejections_count,
+          perform_actions_count: perform_actions_count,
+          errors_count: errors_count
+        }
+      end
+
+      def error_response
+        {
+          broadcasts_count: 0,
+          transmissions_count: 0,
+          confirmations_count: 0,
+          rejections_count: 0,
+          perform_actions_count: 0,
+          errors_count: 0,
+          rejection_rate: 0.0,
+          activity_trends: ACTIVITY_TREND_EMPTY.dup,
+          stability: STABILITY_EMPTY.dup,
+          backlog_count: nil,
+          backlog_available: false,
+          error: "Service temporarily unavailable"
+        }
+      end
+    end
+  end
+end

--- a/spec/requests/solid_observer/cable_dashboard_spec.rb
+++ b/spec/requests/solid_observer/cable_dashboard_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidObserver cable dashboard", type: :request do
+  before(:all) do
+    connection = SolidObserver::CableMetric.connection
+
+    next if connection.table_exists?(:solid_observer_cable_metrics)
+
+    connection.create_table :solid_observer_cable_metrics do |t|
+      t.datetime :period_start, null: false
+      t.bigint :broadcasts_count, null: false, default: 0
+      t.bigint :transmissions_count, null: false, default: 0
+      t.bigint :confirmations_count, null: false, default: 0
+      t.bigint :rejections_count, null: false, default: 0
+      t.bigint :perform_actions_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+    end
+  end
+
+  before(:all) do
+    connection = SolidObserver::CableEvent.connection
+
+    next if connection.table_exists?(:solid_observer_cable_events)
+
+    connection.create_table :solid_observer_cable_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :channel_class, limit: 255
+      t.string :broadcasting_digest, limit: 64
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before do
+    ensure_engine_view_path!
+    install_path_helpers!
+
+    stub_const("SolidCable", Module.new)
+
+    SolidObserver.config.ui_enabled = true
+    SolidObserver.config.observe_queue = false
+    SolidObserver.config.observe_cache = false
+    SolidObserver.config.observe_cable = true
+    SolidObserver.config.storage_mode = :persistence
+
+    SolidObserver::CableMetric.delete_all
+    SolidObserver::CableEvent.delete_all
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  def ensure_engine_view_path!
+    engine_views = SolidObserver::Engine.root.join("app/views").to_s
+    current_paths = SolidObserver::CableDashboardController.view_paths.map(&:to_s)
+    return if current_paths.include?(engine_views)
+
+    SolidObserver::CableDashboardController.prepend_view_path(engine_views)
+  end
+
+  def install_path_helpers!
+    controller_class = SolidObserver::CableDashboardController
+    return if controller_class.method_defined?(:cable_dashboard_path)
+
+    controller_class.class_eval do
+      helper_method :root_path,
+        :jobs_path,
+        :events_path,
+        :storage_path,
+        :cache_dashboard_path,
+        :cache_operations_path,
+        :cable_dashboard_path,
+        :live_poll_script_path
+
+      def root_path
+        "/solid_observer"
+      end
+
+      def jobs_path
+        "/solid_observer/jobs"
+      end
+
+      def events_path
+        "/solid_observer/events"
+      end
+
+      def storage_path
+        "/solid_observer/storage"
+      end
+
+      def cache_dashboard_path
+        "/solid_observer/cache"
+      end
+
+      def cache_operations_path
+        "/solid_observer/cache/controls"
+      end
+
+      def cable_dashboard_path
+        "/solid_observer/cable"
+      end
+
+      def live_poll_script_path
+        "/solid_observer/live_poll.js"
+      end
+    end
+  end
+
+  def call_action(path)
+    env = Rack::MockRequest.env_for(path, {"action_dispatch.routes" => SolidObserver::Engine.routes})
+    status, headers, body = SolidObserver::CableDashboardController.action(:index).call(env)
+    response_body = +""
+    body.each { |chunk| response_body << chunk }
+    [status, headers, response_body]
+  end
+
+  def default_storage_snapshots
+    [
+      {
+        component: "cable_observer",
+        label: "SolidObserver Cable telemetry",
+        available: true,
+        db_size_bytes: 12_288,
+        event_count: 3,
+        record_label: "observer events",
+        recorded_at: Time.current,
+        unavailable_reason: nil
+      },
+      {
+        component: "solid_cable",
+        label: "Solid Cable messages",
+        available: true,
+        db_size_bytes: 24_576,
+        event_count: 100,
+        record_label: "messages",
+        recorded_at: Time.current,
+        unavailable_reason: nil,
+        trimmable_count: 10,
+        oldest_message_age_seconds: 300
+      }
+    ]
+  end
+
+  def seed_cable_dashboard_data(fixed_time)
+    SolidObserver::CableMetric.create!(
+      period_start: fixed_time.beginning_of_minute,
+      broadcasts_count: 100,
+      transmissions_count: 90,
+      confirmations_count: 80,
+      rejections_count: 5,
+      perform_actions_count: 10,
+      errors_count: 2
+    )
+    SolidObserver::CableMetric.create!(
+      period_start: 2.hours.ago.beginning_of_minute,
+      broadcasts_count: 500,
+      transmissions_count: 450,
+      confirmations_count: 400,
+      rejections_count: 50,
+      perform_actions_count: 60,
+      errors_count: 10
+    )
+
+    SolidObserver::CableEvent.create!(
+      event_type: "broadcast",
+      channel_class: "ChatChannel",
+      broadcasting_digest: "abcdef1234567890",
+      duration: 0.003,
+      metadata: "{}",
+      recorded_at: 5.minutes.ago
+    )
+    SolidObserver::CableEvent.create!(
+      event_type: "transmit_subscription_rejection",
+      channel_class: "AdminChannel",
+      broadcasting_digest: "fedcba0987654321",
+      duration: 0.001,
+      metadata: "{}",
+      recorded_at: 3.minutes.ago
+    )
+    SolidObserver::CableEvent.create!(
+      event_type: "broadcast",
+      channel_class: "ChatChannel",
+      broadcasting_digest: "1122334455667788",
+      duration: 0.02,
+      error_class: "RuntimeError",
+      error_message: "adapter internals should stay hidden",
+      metadata: "{}",
+      recorded_at: 2.minutes.ago
+    )
+    SolidObserver::CableEvent.create!(
+      event_type: "broadcast",
+      channel_class: "LegacyChannel",
+      broadcasting_digest: "olddigest00000000",
+      duration: 0.001,
+      metadata: "{}",
+      recorded_at: 2.hours.ago
+    )
+  end
+
+  it "defines the cable overview route on CableDashboardController" do
+    routes_source = File.read(File.expand_path("../../../config/routes.rb", __dir__))
+
+    expect(routes_source).to include('get "cable", to: "cable_dashboard#index", as: :cable_dashboard')
+  end
+
+  it "renders activity trends, stability, and recent events for the selected range" do
+    fixed_time = Time.utc(2026, 6, 2, 12, 0, 0)
+
+    travel_to(fixed_time) do
+      seed_cable_dashboard_data(fixed_time)
+      allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return(default_storage_snapshots)
+
+      status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+      expect(status).to eq(200)
+      expect(body).to include("Cable overview")
+      expect(body).to include("Available")
+      expect(body).to include("Selected range: in last 15m · broadcasting names and payloads are never shown.")
+      expect(body).to include('onchange="this.form.submit()"')
+      expect(body).to include('<button type="submit" class="so-btn so-btn--refresh">Refresh data</button>')
+      expect(body).to include("Summary in selected range")
+      expect(body).to include("100")
+      expect(body).to include("5%")
+      expect(body).to include("10")
+      expect(body).to include("36.0 KB")
+      expect(body).to include("SolidObserver Cable telemetry + Solid Cable messages")
+      expect(body).to include("Activity trends")
+      expect(body).to include('data-so-spark="cable-broadcasts"')
+      expect(body).to include('data-so-spark="cable-rejections"')
+      expect(body).to match(/data-so-spark="cable-broadcasts".*?\u003cpolyline class="so-spark__line" points="[^"]+"/m)
+      expect(body).to match(/data-so-spark="cable-rejections".*?\u003cpolyline class="so-spark__line" points="[^"]+"/m)
+      expect(body).not_to include("No chart data in the selected range yet. Summary metrics still use bounded cable stats.")
+      expect(body).to include('data-so-zone="cable-stability"')
+      expect(body).to include("Stability")
+      expect(body).to include("Critical")
+      expect(body).to include("Recent Cable events")
+      expect(body).to include("debug context only · broadcasting names and payloads are never shown")
+      expect(body).to include("abcdef1234…")
+      expect(body).to include("fedcba0987…")
+      expect(body).to include("1122334455…")
+      expect(body).to include("ChatChannel")
+      expect(body).to include("AdminChannel")
+      expect(body).not_to include("olddigest0000")
+      expect(body).not_to include("adapter internals should stay hidden")
+      expect(body).not_to include("{}")
+    end
+  end
+
+  it "renders a guarded unavailable state and hides cable navigation when cable support is disabled" do
+    SolidObserver.config.observe_cable = false
+
+    status, _headers, body = call_action("/solid_observer/cable")
+
+    expect(status).to eq(200)
+    expect(body).to include("Cable dashboard unavailable")
+    expect(body).to include("Unavailable")
+    expect(body).to include("Cable dashboard is unavailable because Solid Cable support is disabled or not detected. Metrics are unavailable.")
+    expect(body).not_to include("Refresh data")
+    expect(body).not_to include("Summary in selected range")
+    expect(body).not_to include("Recent Cable events")
+    expect(body).not_to include('href="/solid_observer/cable"')
+  end
+
+  it "falls back to an empty recent-events state when cable event queries fail" do
+    allow(SolidObserver::CableEvent).to receive(:where).and_raise(ActiveRecord::StatementInvalid.new("missing table"))
+
+    status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include("No sampled cable events in the selected range yet. Broadcasts, rejections, and errors will appear here after Cable activity is recorded.")
+    expect(body).not_to include("missing table")
+  end
+
+  it "keeps the cable dashboard request successful when the storage snapshot is unavailable" do
+    allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return([
+      {
+        component: "cable_observer",
+        label: "SolidObserver Cable telemetry",
+        available: false,
+        db_size_bytes: nil,
+        event_count: nil,
+        record_label: "observer events",
+        recorded_at: nil,
+        unavailable_reason: "Storage unavailable"
+      },
+      {
+        component: "solid_cable",
+        label: "Solid Cable messages",
+        available: false,
+        db_size_bytes: nil,
+        event_count: nil,
+        record_label: "messages",
+        recorded_at: nil,
+        unavailable_reason: "Storage unavailable",
+        trimmable_count: nil,
+        oldest_message_age_seconds: nil
+      }
+    ])
+
+    status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include("Cable overview")
+    expect(body).to include("Summary in selected range")
+    expect(body).to include("—")
+    expect(body).not_to include("cable db unreachable")
+  end
+
+  it "renders a degraded stability strip when the backlog subquery fails" do
+    allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_raise(
+      ActiveRecord::ConnectionNotEstablished.new("cable db unreachable")
+    )
+
+    status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include('data-so-zone="cable-stability"')
+    expect(body).to include("Degraded")
+    expect(body).not_to include("cable db unreachable")
+  end
+
+  it "renders empty states when no cable metrics or events exist" do
+    status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include("0")
+    expect(body).to include("0%")
+    expect(body).to include("No chart data in the selected range yet. Summary metrics still use bounded cable stats.")
+    expect(body).to include("No sampled cable events in the selected range yet. Broadcasts, rejections, and errors will appear here after Cable activity is recorded.")
+  end
+end

--- a/spec/solid_observer/configuration_spec.rb
+++ b/spec/solid_observer/configuration_spec.rb
@@ -190,6 +190,83 @@ RSpec.describe SolidObserver::Configuration do
     end
   end
 
+  describe "cable stability thresholds" do
+    it "sets sensible defaults" do
+      config = described_class.new
+
+      expect(config.cable_rejection_threshold).to eq(0.05)
+      expect(config.cable_backlog_threshold).to eq(0.10)
+      expect(config.cable_error_threshold).to eq(0.0)
+    end
+
+    describe "#cable_rejection_threshold=" do
+      it "accepts values between 0.0 and 1.0" do
+        config = described_class.new
+        config.cable_rejection_threshold = 0.03
+
+        expect(config.cable_rejection_threshold).to eq(0.03)
+      end
+
+      it "rejects values below 0.0" do
+        config = described_class.new
+
+        expect { config.cable_rejection_threshold = -0.1 }.to raise_error(
+          ArgumentError, "cable_rejection_threshold must be a number between 0.0 and 1.0"
+        )
+      end
+
+      it "rejects values above 1.0" do
+        config = described_class.new
+
+        expect { config.cable_rejection_threshold = 1.1 }.to raise_error(
+          ArgumentError, "cable_rejection_threshold must be a number between 0.0 and 1.0"
+        )
+      end
+    end
+
+    describe "#cable_backlog_threshold=" do
+      it "accepts values between 0.0 and 1.0" do
+        config = described_class.new
+        config.cable_backlog_threshold = 0.2
+
+        expect(config.cable_backlog_threshold).to eq(0.2)
+      end
+
+      it "rejects values above 1.0" do
+        config = described_class.new
+
+        expect { config.cable_backlog_threshold = 1.5 }.to raise_error(
+          ArgumentError, "cable_backlog_threshold must be a number between 0.0 and 1.0"
+        )
+      end
+    end
+
+    describe "#cable_error_threshold=" do
+      it "accepts non-negative numeric values" do
+        config = described_class.new
+        config.cable_error_threshold = 5
+
+        expect(config.cable_error_threshold).to eq(5)
+      end
+
+      it "rejects negative values" do
+        config = described_class.new
+
+        expect { config.cable_error_threshold = -1 }.to raise_error(
+          ArgumentError, "cable_error_threshold must be a non-negative number"
+        )
+      end
+
+      it "rejects non-numeric values" do
+        config = described_class.new
+
+        expect { config.cable_error_threshold = "none" }.to raise_error(
+          ArgumentError, "cable_error_threshold must be a non-negative number"
+        )
+      end
+    end
+  end
+
   describe "#cable_sampling_rate=" do
     it "accepts values between 0.0 and 1.0" do
       config = described_class.new

--- a/spec/solid_observer/services/cable_stats_spec.rb
+++ b/spec/solid_observer/services/cable_stats_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/solid_observer/services/cable_stats"
+
+RSpec.describe SolidObserver::Services::CableStats do
+  before(:all) do
+    connection = SolidObserver::CableMetric.connection
+    next if connection.table_exists?(:solid_observer_cable_metrics)
+
+    connection.create_table :solid_observer_cable_metrics do |t|
+      t.datetime :period_start, null: false
+      t.bigint :broadcasts_count, null: false, default: 0
+      t.bigint :transmissions_count, null: false, default: 0
+      t.bigint :confirmations_count, null: false, default: 0
+      t.bigint :rejections_count, null: false, default: 0
+      t.bigint :perform_actions_count, null: false, default: 0
+      t.bigint :errors_count, null: false, default: 0
+    end
+  end
+
+  before(:all) do
+    connection = SolidObserver::CableEvent.connection
+    next if connection.table_exists?(:solid_observer_cable_events)
+
+    connection.create_table :solid_observer_cable_events do |t|
+      t.string :event_type, null: false, limit: 64
+      t.string :channel_class, limit: 255
+      t.string :broadcasting_digest, limit: 64
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
+      t.datetime :recorded_at, null: false
+    end
+  end
+
+  before do
+    SolidObserver::CableMetric.delete_all
+    SolidObserver::CableEvent.delete_all
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  describe ".parse_range" do
+    it "returns the requested range when it is supported" do
+      expect(described_class.parse_range("1h")).to eq("1h")
+    end
+
+    it "falls back to the default range for unsupported values" do
+      expect(described_class.parse_range("bogus")).to eq("15m")
+    end
+  end
+
+  describe ".range_duration" do
+    it "returns the configured duration for a range key" do
+      expect(described_class.range_duration("1h")).to eq(1.hour)
+    end
+
+    it "uses the default duration for unsupported values" do
+      expect(described_class.range_duration("bogus")).to eq(15.minutes)
+    end
+  end
+
+  describe described_class::TrendData do
+    let(:fixed_time) { Time.utc(2026, 6, 3, 12, 0, 0) }
+
+    it "returns the empty trend payload when no metric rows exist" do
+      result = described_class.new(metric_rows: [], window: 15.minutes, current_time: fixed_time).to_h
+
+      expect(result).to eq(SolidObserver::Services::CableStats::ACTIVITY_TREND_EMPTY)
+      expect(result).not_to be(SolidObserver::Services::CableStats::ACTIVITY_TREND_EMPTY)
+    end
+
+    it "buckets metric rows and builds broadcasts and rejections series" do
+      result = described_class.new(
+        metric_rows: [
+          [fixed_time - 14.minutes + 45.seconds, 10, 0, 0, 1, 0, 0],
+          [fixed_time - 14.minutes + 10.seconds, 2, 0, 0, 1, 0, 0],
+          [fixed_time - 2.minutes + 30.seconds, 5, 0, 0, 0, 0, 0]
+        ],
+        window: 15.minutes,
+        current_time: fixed_time
+      ).to_h
+
+      broadcasts_by_time = result[:broadcasts].to_h { |point| [point[:t], point[:v]] }
+      rejections_by_time = result[:rejections].to_h { |point| [point[:t], point[:v]] }
+
+      expect(result[:available]).to be(true)
+      expect(broadcasts_by_time[(fixed_time - 14.minutes).to_i]).to eq(12)
+      expect(rejections_by_time[(fixed_time - 14.minutes).to_i]).to eq(2)
+      expect(broadcasts_by_time[(fixed_time - 2.minutes).to_i]).to eq(5)
+      expect(rejections_by_time[(fixed_time - 2.minutes).to_i]).to eq(0)
+    end
+  end
+
+  describe described_class::StabilityData do
+    let(:fixed_time) { Time.utc(2026, 6, 3, 12, 0, 0) }
+
+    def stability_data(metric_broadcasts: 0, metric_rejections: 0, backlog_ratio: 0.0, backlog_available: true)
+      described_class.new(
+        window: 15.minutes,
+        current_time: Time.current,
+        backlog_snapshot: {available: backlog_available, ratio: backlog_ratio}
+      ).to_h(
+        metric_broadcasts_count: metric_broadcasts,
+        metric_rejections_count: metric_rejections
+      )
+    end
+
+    around do |example|
+      travel_to(fixed_time) { example.run }
+    end
+
+    it "classifies the range as stable when no errors, rejections, or backlog pressure exist" do
+      expect(stability_data).to include(
+        available: true,
+        state: :stable,
+        rejection_count: 0,
+        error_count: 0,
+        backlog_available: true
+      )
+    end
+
+    it "classifies the range as degraded when backlog ratio crosses the threshold" do
+      expect(stability_data(backlog_ratio: 0.15)).to include(
+        available: true,
+        state: :degraded,
+        backlog_ratio: 0.15
+      )
+    end
+
+    it "classifies the range as degraded when rejections are present below the threshold" do
+      SolidObserver::CableMetric.create!(
+        period_start: fixed_time.beginning_of_minute,
+        broadcasts_count: 100,
+        rejections_count: 1
+      )
+
+      expect(stability_data(metric_broadcasts: 100, metric_rejections: 1)).to include(
+        available: true,
+        state: :degraded,
+        rejection_rate: 0.01
+      )
+    end
+
+    it "classifies the range as critical when the rejection rate crosses the threshold" do
+      expect(stability_data(metric_broadcasts: 100, metric_rejections: 10)).to include(
+        available: true,
+        state: :critical,
+        rejection_rate: 0.1
+      )
+    end
+
+    it "classifies the range as critical when error events are present" do
+      SolidObserver::CableEvent.create!(
+        event_type: "broadcast",
+        channel_class: "ChatChannel",
+        broadcasting_digest: "digest",
+        duration: 0.01,
+        error_class: "RuntimeError",
+        error_message: "hidden from UI",
+        metadata: "{}",
+        recorded_at: 5.minutes.ago
+      )
+
+      expect(stability_data).to include(
+        available: true,
+        state: :critical,
+        error_count: 1,
+        rejection_count: 0
+      )
+    end
+
+    it "classifies the range as critical when backlog reaches the 50% ceiling" do
+      expect(stability_data(backlog_ratio: 0.5)).to include(
+        available: true,
+        state: :critical,
+        backlog_ratio: 0.5
+      )
+    end
+
+    it "classifies the range as degraded when the backlog snapshot is unavailable" do
+      expect(stability_data(backlog_available: false)).to include(
+        available: true,
+        state: :degraded,
+        backlog_available: false
+      )
+    end
+
+    it "tracks the latest recorded at timestamp for rejection and error events" do
+      recorded_at = fixed_time - 4.minutes
+      SolidObserver::CableEvent.create!(
+        event_type: "transmit_subscription_rejection",
+        channel_class: "ChatChannel",
+        broadcasting_digest: "digest",
+        duration: 0.01,
+        metadata: "{}",
+        recorded_at: recorded_at
+      )
+      event = SolidObserver::CableEvent.last
+      result = stability_data(metric_broadcasts: 100, metric_rejections: 1)
+
+      expect(result).to include(
+        available: true,
+        state: :degraded,
+        rejection_count: 1
+      )
+      expect(result[:latest_recorded_at].strftime("%Y-%m-%d %H:%M:%S")).to eq(event.recorded_at.strftime("%Y-%m-%d %H:%M:%S"))
+    end
+  end
+
+  it "returns dashboard-ready aggregated cable stats for window" do
+    now = Time.current
+    SolidObserver::CableMetric.create!(
+      period_start: now.beginning_of_minute,
+      broadcasts_count: 100,
+      transmissions_count: 90,
+      confirmations_count: 80,
+      rejections_count: 5,
+      perform_actions_count: 10,
+      errors_count: 2
+    )
+
+    allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return([
+      {
+        component: "solid_cable",
+        available: true,
+        event_count: 100,
+        trimmable_count: 10
+      }
+    ])
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats[:broadcasts_count]).to eq(100)
+    expect(stats[:rejections_count]).to eq(5)
+    expect(stats[:errors_count]).to eq(2)
+    expect(stats[:rejection_rate]).to eq(0.05)
+    expect(stats[:backlog_count]).to eq(10)
+    expect(stats[:backlog_available]).to be(true)
+    expect(stats[:stability]).to include(available: true, state: :critical)
+  end
+
+  it "returns safe fallback when metric table query fails" do
+    allow(SolidObserver::CableMetric).to receive(:where).and_raise(ActiveRecord::StatementInvalid.new("missing table"))
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats).to include(
+      broadcasts_count: 0,
+      rejections_count: 0,
+      errors_count: 0,
+      rejection_rate: 0.0,
+      backlog_available: false
+    )
+    expect(stats[:error]).to eq("Service temporarily unavailable")
+  end
+
+  it "degrades stability on ActiveRecord::StatementInvalid from cable events query, preserving other data" do
+    now = Time.current
+    SolidObserver::CableMetric.create!(
+      period_start: now.beginning_of_minute,
+      broadcasts_count: 100,
+      rejections_count: 5
+    )
+
+    allow(SolidObserver::CableEvent).to receive(:where).and_raise(
+      ActiveRecord::StatementInvalid.new("no such table: solid_observer_cable_events")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats).not_to have_key(:error)
+    expect(stats[:broadcasts_count]).to eq(100)
+    expect(stats[:stability]).to include(available: true, state: :degraded)
+  end
+
+  it "preserves metric totals and trends when only the cable events (stability) query fails" do
+    now = Time.current
+    SolidObserver::CableMetric.create!(
+      period_start: now.beginning_of_minute,
+      broadcasts_count: 100,
+      rejections_count: 5
+    )
+
+    allow(SolidObserver::CableEvent).to receive(:where).and_raise(
+      ActiveRecord::StatementInvalid.new("no such table: solid_observer_cable_events")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats).not_to have_key(:error)
+    expect(stats[:broadcasts_count]).to eq(100)
+    expect(stats[:activity_trends][:available]).to be(true)
+    expect(stats[:stability]).to include(available: true, state: :degraded)
+  end
+
+  it "sanitizes non-ActiveRecord errors in fallback" do
+    allow(SolidObserver::CableMetric).to receive(:where).and_raise(
+      TypeError.new("no implicit conversion of nil into String")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats[:error]).to eq("Service temporarily unavailable")
+  end
+
+  it "sanitizes generic RuntimeError in fallback without leaking message" do
+    allow(SolidObserver::CableMetric).to receive(:where).and_raise(
+      RuntimeError.new("PG::DuplicateTable: relation already exists")
+    )
+
+    stats = described_class.call(window: 5.minutes)
+
+    expect(stats[:error]).to eq("Service temporarily unavailable")
+  end
+end


### PR DESCRIPTION
## Summary of changes
Delivered the Cable dashboard, `CableStats`, configurable thresholds, views, helpers, route/nav, and request/service/config specs. Round 2 fixed the isolated request load-order require and exact event identifier copy flagged by Designer QA. Challenger and Designer reviews are clean with zero Critical and zero Strong findings.

## AC Verification
- ✓ AC 1 — Cable dashboard exposes broadcasts, rejection rate, broadcast/rejection trends for the selected range, plus message backlog, storage footprint, and stability.
- ✓ AC 2 — Stability uses configurable defaults and distinguishes selected-range rejections/errors from current-snapshot backlog.
- ✓ AC 3 — Recent events render only safe identifiers/digests/classes; raw broadcasting names, payloads, metadata, adapter error text, and `error_message` are not rendered.
- ✓ AC 4 — Disabled, empty, and partial-failure states render understandable UI following existing SolidObserver navigation, styling, and accessibility conventions.