### PR TITLE
[SO-093][FEAT] Add Cable operational controls

### DIFF
--- a/app/controllers/solid_observer/cable_operations_controller.rb
+++ b/app/controllers/solid_observer/cable_operations_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  class CableOperationsController < ApplicationController
+    def trim
+      redirect_with_result(SolidObserver::Services::CableOperations.trim)
+    end
+
+    private
+
+    def redirect_with_result(result)
+      flash_key = result[:ok] ? :notice : :alert
+      redirect_to cable_dashboard_path, flash_key => result[:message]
+    end
+  end
+end

--- a/app/views/solid_observer/cable_dashboard/index.html.erb
+++ b/app/views/solid_observer/cable_dashboard/index.html.erb
@@ -32,6 +32,62 @@
     </form>
 
     <%= render "solid_observer/cable_dashboard/summary", stats: @stats, storage_components: @storage_components %>
+
+    <section class="so-card so-card--section" aria-labelledby="so-cable-controls-heading">
+      <header class="so-dashboard-section__header">
+        <h2 id="so-cable-controls-heading" class="so-dashboard-section__title">Operational controls</h2>
+      </header>
+
+      <% cable_controls_available = SolidObserver::Services::CableOperations.available? && @stats&.[](:backlog_available) %>
+      <% cable_backlog_count = @stats&.[](:backlog_count).to_i %>
+
+      <% if cable_controls_available %>
+        <% if cable_backlog_count > 1000 %>
+          <div class="so-cache-control-row">
+            <div class="so-cache-control-row__copy">
+              <h3 class="so-cache-control-row__title">Use the Rake task</h3>
+              <p class="so-cache-control-row__body">More than 1,000 expired/trimmable Solid Cable messages are pending. The UI will not run this trim. Run solid_observer:cable:trim from the server instead.</p>
+              <span class="so-badge so-badge--pill so-badge--warning">
+                <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+                  <circle r="3" cx="3" cy="3" />
+                </svg>
+                UI trim unavailable
+              </span>
+            </div>
+          </div>
+        <% else %>
+          <div class="so-cache-control-row">
+            <div class="so-cache-control-row__copy">
+              <h3 class="so-cache-control-row__title">Trim expired messages</h3>
+              <p class="so-cache-control-row__body">Removes expired/trimmable Solid Cable messages only. Active messages remain available to Cable.</p>
+              <span class="so-badge so-badge--pill so-badge--success">
+                <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+                  <circle r="3" cx="3" cy="3" />
+                </svg>
+                Trimmable backlog: <%= cable_backlog_count %>
+              </span>
+            </div>
+
+            <div class="so-cache-control-row__action">
+              <%= button_to "Trim expired messages",
+                    trim_cable_operations_path,
+                    method: :post,
+                    class: "so-btn",
+                    form: {class: "so-form--inline"} %>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="so-dashboard-section__meta so-dashboard-section__meta--idle">Cable controls are unavailable because Solid Cable support is disabled or not detected. No trim was attempted.</p>
+        <span class="so-badge so-badge--pill so-badge--warning">
+          <svg class="so-badge__dot" viewBox="0 0 6 6" aria-hidden="true">
+            <circle r="3" cx="3" cy="3" />
+          </svg>
+          Unavailable
+        </span>
+      <% end %>
+    </section>
+
     <%= render "solid_observer/cable_dashboard/charts" %>
 
     <% if @stats&.[](:stability)&.[](:available) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ SolidObserver::Engine.routes.draw do
   get "queue", to: "dashboard#index", defaults: {component: "queue"}, as: :queue_dashboard
   get "cache", to: "cache_dashboard#index", as: :cache_dashboard
   get "cable", to: "cable_dashboard#index", as: :cable_dashboard
+  post "cable/trim", to: "cable_operations#trim", as: :trim_cable_operations
   get "cache/controls", to: "cache_operations#index", as: :cache_operations
   post "cache/controls/prune", to: "cache_operations#prune", as: :prune_cache_operations
   post "cache/controls/clear", to: "cache_operations#clear", as: :clear_cache_operations

--- a/lib/solid_observer.rb
+++ b/lib/solid_observer.rb
@@ -44,6 +44,7 @@ ActiveSupport.on_load(:active_record) do
   require_relative "solid_observer/services/record_cable_metric"
   require_relative "solid_observer/services/flush_cable_event_buffer"
   require_relative "solid_observer/services/cable_stats"
+  require_relative "solid_observer/services/cable_operations"
 end
 
 module SolidObserver

--- a/lib/solid_observer/services/cable_operations.rb
+++ b/lib/solid_observer/services/cable_operations.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module SolidObserver
+  module Services
+    class CableOperations
+      MESSAGES = {
+        trim: {
+          success: "Expired/trimmable Solid Cable messages trimmed.",
+          failure: "Cable trim failed. No raw Cable payloads or adapter details are shown. Use solid_observer:cable:trim if the problem continues."
+        }.freeze,
+        unavailable: "Cable controls are unavailable because Solid Cable support is disabled or not detected."
+      }.freeze
+
+      class << self
+        def available?
+          new.available?
+        end
+
+        def trim
+          new.trim
+        end
+
+        def message(operation, key = nil)
+          return MESSAGES.fetch(:unavailable) if operation == :unavailable
+
+          MESSAGES.fetch(operation).fetch(key)
+        end
+
+        def unavailable_message
+          message(:unavailable)
+        end
+      end
+
+      def available?
+        SolidObserver.config.solid_cable_enabled? && !!defined?(::SolidCable::Message)
+      end
+
+      def trim
+        messages = self.class
+        return {ok: false, message: messages.unavailable_message} unless available?
+
+        perform_operation(
+          :trim,
+          success_message: messages.message(:trim, :success),
+          failure_message: messages.message(:trim, :failure)
+        ) do
+          trim_cable_messages
+        end
+      end
+
+      private
+
+      def trim_cable_messages
+        if defined?(::SolidCable::TrimJob)
+          ::SolidCable::TrimJob.perform_now
+        else
+          ::SolidCable::Message.trimmable.delete_all
+        end
+      end
+
+      def perform_operation(name, success_message:, failure_message:)
+        yield
+        {ok: true, message: success_message}
+      rescue => error
+        log_failure(name, error)
+        {ok: false, message: failure_message}
+      end
+
+      def log_failure(name, error)
+        Rails.logger&.warn("[SolidObserver] Cable #{name} failed: #{error.class}")
+      end
+    end
+  end
+end

--- a/lib/tasks/solid_observer.rake
+++ b/lib/tasks/solid_observer.rake
@@ -115,6 +115,18 @@ namespace :solid_observer do
     end
   end
 
+  namespace :cable do
+    desc "Trim expired Solid Cable messages"
+    task trim: :environment do
+      if !SolidObserver::Services::CableOperations.available?
+        puts SolidObserver::Services::CableOperations.unavailable_message
+        next
+      end
+
+      puts SolidObserver::Services::CableOperations.trim[:message]
+    end
+  end
+
   namespace :storage do
     desc "Run storage cleanup based on retention policy"
     task cleanup: :environment do

--- a/spec/requests/solid_observer/cable_dashboard_spec.rb
+++ b/spec/requests/solid_observer/cable_dashboard_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "SolidObserver cable dashboard", type: :request do
     install_path_helpers!
 
     stub_const("SolidCable", Module.new)
+    stub_const("SolidCable::Message", Class.new)
 
     SolidObserver.config.ui_enabled = true
     SolidObserver.config.observe_queue = false
@@ -74,6 +75,7 @@ RSpec.describe "SolidObserver cable dashboard", type: :request do
         :cache_dashboard_path,
         :cache_operations_path,
         :cable_dashboard_path,
+        :trim_cable_operations_path,
         :live_poll_script_path
 
       def root_path
@@ -102,6 +104,10 @@ RSpec.describe "SolidObserver cable dashboard", type: :request do
 
       def cable_dashboard_path
         "/solid_observer/cable"
+      end
+
+      def trim_cable_operations_path
+        "/solid_observer/cable/trim"
       end
 
       def live_poll_script_path
@@ -331,5 +337,57 @@ RSpec.describe "SolidObserver cable dashboard", type: :request do
     expect(body).to include("0%")
     expect(body).to include("No chart data in the selected range yet. Summary metrics still use bounded cable stats.")
     expect(body).to include("No sampled cable events in the selected range yet. Broadcasts, rejections, and errors will appear here after Cable activity is recorded.")
+  end
+
+  it "renders eligible operational controls when the trimmable backlog is within the UI limit" do
+    fixed_time = Time.utc(2026, 6, 2, 12, 0, 0)
+
+    travel_to(fixed_time) do
+      seed_cable_dashboard_data(fixed_time)
+      allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return(default_storage_snapshots)
+
+      status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+      expect(status).to eq(200)
+      expect(body).to include("Operational controls")
+      expect(body).to include("Trim expired messages")
+      expect(body).to include("Removes expired/trimmable Solid Cable messages only. Active messages remain available to Cable.")
+      expect(body).to include("Trimmable backlog: 10")
+      expect(body).to include('action="/solid_observer/cable/trim"')
+      expect(body).to match(/<(button|input)[^>]*class="so-btn"[^>]*(?:type="submit"|value="Trim expired messages")/)
+      expect(body).not_to include("Use the Rake task")
+      expect(body).not_to include("UI trim unavailable")
+    end
+  end
+
+  it "renders over-limit instruction when the trimmable backlog exceeds 1,000" do
+    snapshots = default_storage_snapshots
+    snapshots.find { |snapshot| snapshot[:component] == "solid_cable" }[:trimmable_count] = 1001
+
+    allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return(snapshots)
+
+    status, _headers, body = call_action("/solid_observer/cable?range=15m")
+
+    expect(status).to eq(200)
+    expect(body).to include("Operational controls")
+    expect(body).to include("Use the Rake task")
+    expect(body).to include("More than 1,000 expired/trimmable Solid Cable messages are pending. The UI will not run this trim. Run solid_observer:cable:trim from the server instead.")
+    expect(body).to include("UI trim unavailable")
+    expect(body).not_to include('action="/solid_observer/cable/trim"')
+    expect(body).not_to include('<button type="submit" class="so-btn">Trim expired messages</button>')
+  end
+
+  it "renders unavailable operational controls when SolidCable::Message is not detected" do
+    hide_const("SolidCable::Message")
+    allow(SolidObserver::Services::StorageInfoSnapshot).to receive(:call).and_return(default_storage_snapshots)
+
+    status, _headers, body = call_action("/solid_observer/cable")
+
+    expect(status).to eq(200)
+    expect(body).to include("Operational controls")
+    expect(body).to include("Cable controls are unavailable because Solid Cable support is disabled or not detected. No trim was attempted.")
+    expect(body).to include("Unavailable")
+    expect(body).not_to include('action="/solid_observer/cable/trim"')
+    expect(body).not_to include("Trimmable backlog:")
   end
 end

--- a/spec/requests/solid_observer/cable_operations_spec.rb
+++ b/spec/requests/solid_observer/cable_operations_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SolidObserver cable operations", type: :request do
+  around do |example|
+    previous_setting = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = false
+    example.run
+  ensure
+    ActionController::Base.allow_forgery_protection = previous_setting
+  end
+
+  before do
+    install_path_helpers!
+    stub_const("SolidCable", Module.new)
+    stub_const("SolidCable::Message", Class.new)
+    SolidObserver.config.ui_enabled = true
+    SolidObserver.config.observe_cable = true
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  def install_path_helpers!
+    controller_class = SolidObserver::CableOperationsController
+    return if controller_class.method_defined?(:cable_dashboard_path)
+
+    controller_class.class_eval do
+      helper_method :root_path,
+        :jobs_path,
+        :events_path,
+        :storage_path,
+        :cache_dashboard_path,
+        :cache_operations_path,
+        :cable_dashboard_path,
+        :trim_cable_operations_path,
+        :live_poll_script_path
+
+      def root_path
+        "/solid_observer"
+      end
+
+      def jobs_path
+        "/solid_observer/jobs"
+      end
+
+      def events_path
+        "/solid_observer/events"
+      end
+
+      def storage_path
+        "/solid_observer/storage"
+      end
+
+      def cache_dashboard_path
+        "/solid_observer/cache"
+      end
+
+      def cache_operations_path
+        "/solid_observer/cache/controls"
+      end
+
+      def cable_dashboard_path
+        "/solid_observer/cable"
+      end
+
+      def trim_cable_operations_path
+        "/solid_observer/cable/trim"
+      end
+
+      def live_poll_script_path
+        "/solid_observer/live_poll.js"
+      end
+    end
+  end
+
+  def call_action(action_name, path, method: "GET")
+    env = Rack::MockRequest.env_for(
+      path,
+      {
+        "action_dispatch.routes" => SolidObserver::Engine.routes,
+        "REQUEST_METHOD" => method
+      }
+    )
+
+    status, headers, body = SolidObserver::CableOperationsController.action(action_name).call(env)
+    response_body = +""
+    body.each { |chunk| response_body << chunk }
+    [status, headers, response_body]
+  end
+
+  it "defines the cable trim route on CableOperationsController" do
+    routes_source = File.read(File.expand_path("../../../config/routes.rb", __dir__))
+
+    expect(routes_source).to include('post "cable/trim", to: "cable_operations#trim", as: :trim_cable_operations')
+  end
+
+  it "redirects trim requests back to the cable dashboard with a notice" do
+    allow(SolidObserver::Services::CableOperations).to receive(:trim).and_return(
+      {ok: true, message: SolidObserver::Services::CableOperations.message(:trim, :success)}
+    )
+
+    status, headers, _body = call_action(:trim, "/solid_observer/cable/trim", method: "POST")
+
+    expect(status).to eq(302)
+    expect(headers["Location"]).to eq("http://example.org/solid_observer/cable")
+  end
+
+  it "redirects trim requests back to the cable dashboard with an alert on failure" do
+    allow(SolidObserver::Services::CableOperations).to receive(:trim).and_return(
+      {ok: false, message: SolidObserver::Services::CableOperations.message(:trim, :failure)}
+    )
+
+    status, headers, _body = call_action(:trim, "/solid_observer/cable/trim", method: "POST")
+
+    expect(status).to eq(302)
+    expect(headers["Location"]).to eq("http://example.org/solid_observer/cable")
+  end
+end

--- a/spec/requests/solid_observer/storages_spec.rb
+++ b/spec/requests/solid_observer/storages_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe "SolidObserver storages page", type: :request do
 
     connection.create_table :solid_observer_cable_events do |t|
       t.string :event_type, null: false, limit: 64
+      t.string :channel_class, limit: 255
+      t.string :broadcasting_digest, limit: 64
+      t.float :duration
+      t.string :error_class, limit: 255
+      t.text :error_message
+      t.text :metadata
       t.datetime :recorded_at, null: false
     end
   end

--- a/spec/solid_observer/services/cable_operations_spec.rb
+++ b/spec/solid_observer/services/cable_operations_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/solid_observer/services/cable_operations"
+
+RSpec.describe SolidObserver::Services::CableOperations do
+  let(:logger) { instance_double(Logger, warn: nil) }
+  let(:trimmable_relation) { double(delete_all: 3) }
+  let(:message_class) do
+    Class.new do
+      class << self
+        attr_accessor :trimmable_relation
+
+        def trimmable
+          trimmable_relation
+        end
+      end
+    end
+  end
+
+  before do
+    stub_const("SolidCable", Module.new)
+    stub_const("SolidCable::Message", message_class)
+    message_class.trimmable_relation = trimmable_relation
+    allow(Rails).to receive(:logger).and_return(logger)
+    SolidObserver.config.observe_cable = true
+  end
+
+  after { SolidObserver.reset_configuration! }
+
+  describe ".available?" do
+    it "returns true when cable observation is enabled and SolidCable::Message is present" do
+      expect(described_class.available?).to be(true)
+    end
+
+    it "returns false when cable observation is disabled" do
+      SolidObserver.config.observe_cable = false
+
+      expect(described_class.available?).to be(false)
+    end
+
+    it "returns false when SolidCable::Message is not defined" do
+      hide_const("SolidCable::Message")
+
+      expect(described_class.available?).to be(false)
+    end
+  end
+
+  describe ".trim" do
+    it "trims expired/trimmable messages using the fallback delete path" do
+      expect(trimmable_relation).to receive(:delete_all).and_return(3)
+
+      result = described_class.trim
+
+      expect(result).to eq(
+        ok: true,
+        message: described_class.message(:trim, :success)
+      )
+    end
+
+    it "prefers SolidCable::TrimJob.perform_now when defined" do
+      trim_job = Class.new do
+        class << self
+          attr_accessor :performed
+
+          def perform_now
+            @performed = true
+          end
+        end
+      end
+      stub_const("SolidCable::TrimJob", trim_job)
+
+      result = described_class.trim
+
+      expect(trim_job.performed).to be(true)
+      expect(result).to eq(
+        ok: true,
+        message: described_class.message(:trim, :success)
+      )
+      expect(trimmable_relation).not_to have_received(:delete_all)
+    end
+
+    it "returns the unavailable copy when controls cannot run" do
+      SolidObserver.config.observe_cable = false
+
+      result = described_class.trim
+
+      expect(result).to eq(
+        ok: false,
+        message: described_class.unavailable_message
+      )
+      expect(trimmable_relation).not_to have_received(:delete_all)
+    end
+
+    it "logs and sanitizes trim failures without exposing adapter details" do
+      allow(trimmable_relation).to receive(:delete_all).and_raise(
+        ActiveRecord::StatementInvalid.new("bad cable sql")
+      )
+
+      result = described_class.trim
+
+      expect(result).to eq(
+        ok: false,
+        message: described_class.message(:trim, :failure)
+      )
+      expect(logger).to have_received(:warn).with(
+        "[SolidObserver] Cable trim failed: ActiveRecord::StatementInvalid"
+      )
+    end
+  end
+end

--- a/spec/tasks/solid_observer_cable_tasks_spec.rb
+++ b/spec/tasks/solid_observer_cable_tasks_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rake"
+
+RSpec.describe "solid_observer cable rake tasks" do
+  before(:all) do
+    unless Rake::Task.task_defined?("solid_observer:status")
+      Rake.application = Rake::Application.new
+      Rake::Task.define_task(:environment)
+      load File.expand_path("../../lib/tasks/solid_observer.rake", __dir__)
+    end
+  end
+
+  before do
+    Rake::Task.tasks.each(&:reenable)
+  end
+
+  describe "solid_observer:cable:trim" do
+    it "trims cable messages when available" do
+      allow(SolidObserver::Services::CableOperations).to receive(:available?).and_return(true)
+      allow(SolidObserver::Services::CableOperations).to receive(:trim).and_return(
+        {message: "Expired/trimmable Solid Cable messages trimmed."}
+      )
+
+      expect {
+        Rake::Task["solid_observer:cable:trim"].invoke
+      }.to output("Expired/trimmable Solid Cable messages trimmed.\n").to_stdout
+
+      expect(SolidObserver::Services::CableOperations).to have_received(:trim)
+    end
+
+    it "prints the unavailable message when cable controls cannot run" do
+      allow(SolidObserver::Services::CableOperations).to receive(:available?).and_return(false)
+      allow(SolidObserver::Services::CableOperations).to receive(:unavailable_message).and_return(
+        "Cable controls are unavailable because Solid Cable support is disabled or not detected."
+      )
+      allow(SolidObserver::Services::CableOperations).to receive(:trim)
+
+      expect {
+        Rake::Task["solid_observer:cable:trim"].invoke
+      }.to output("Cable controls are unavailable because Solid Cable support is disabled or not detected.\n").to_stdout
+
+      expect(SolidObserver::Services::CableOperations).not_to have_received(:trim)
+    end
+  end
+end


### PR DESCRIPTION
## Summary of changes
- Add guarded Cable dashboard controls for trimming expired/trimmable Solid Cable messages.
- Add `solid_observer:cable:trim` for operator cleanup outside web request limits.
- Prevent destructive clear-all behavior and large-backlog UI trims.